### PR TITLE
Fix the way to enable frame-multiplexer

### DIFF
--- a/lib/core/frame-multiplexer.lisp
+++ b/lib/core/frame-multiplexer.lisp
@@ -276,7 +276,8 @@
       (switch-current-frame vf frame))
     (lem::change-display-size-hook)))
 
-(add-hook *after-init-hook* 'frame-multiplexer-on)
+(add-hook *after-init-hook*
+          (lambda () (setf (variable-value 'frame-multiplexer :global) t)))
 
 (define-command frame-multiplexer-test () ()
   (labels ((vf ()

--- a/lib/core/frame-multiplexer.lisp
+++ b/lib/core/frame-multiplexer.lisp
@@ -276,8 +276,10 @@
       (switch-current-frame vf frame))
     (lem::change-display-size-hook)))
 
-(add-hook *after-init-hook*
-          (lambda () (setf (variable-value 'frame-multiplexer :global) t)))
+(defun enable-frame-multiplexer ()
+  (setf (variable-value 'frame-multiplexer :global) t))
+
+(add-hook *after-init-hook* 'enable-frame-multiplexer)
 
 (define-command frame-multiplexer-test () ()
   (labels ((vf ()


### PR DESCRIPTION
Sorry. In this case, the correct way is enabling via editor-variable.