### PR TITLE
Add LSP spec for Rust's `rls`

### DIFF
--- a/modes/lsp-mode/lsp-mode.lisp
+++ b/modes/lsp-mode/lsp-mode.lisp
@@ -1643,6 +1643,12 @@
   :command '("typescript-language-server" "--stdio")
   :mode :stdio)
 
+(define-language-spec (rust-spec lem-rust-mode:rust-mode)
+  :language-id "rust"
+  :root-uri-patterns '("Cargo.toml")
+  :command '("rls")
+  :mode :stdio)
+
 (defun find-dart-bin-path ()
   (multiple-value-bind (output error-output status)
       (uiop:run-program '("which" "dart")


### PR DESCRIPTION
This PR defines lsp-mode's language spec for Rust's [rls](https://github.com/rust-lang/rls).