### PR TITLE
Allow a multi-key sequence to override a single-key definition

### DIFF
--- a/lib/core/keymap.lisp
+++ b/lib/core/keymap.lisp
@@ -55,7 +55,7 @@
                    (setf (gethash k table) symbol))
                   (t
                    (let ((next (gethash k table)))
-                     (if next
+                     (if (and next (hash-table-p next))
                          (setf table next)
                          (let ((new-table (make-hash-table :test 'eq)))
                            (setf (gethash k table) new-table)


### PR DESCRIPTION
Currently, if a key is already bound, attempting to override that
binding produces an error, specifically, if the following config code
is used:

```lisp
(define-key lem-lisp-mode:*lisp-mode-keymap* "," 'my-function)
(define-key lem-lisp-mode:*lisp-mode-keymap* ", ," 'my-other-function)
```
The given error is:
```
The value
  MY_FUNCTION
is not of type
  HASH-TABLE
when binding HASH-TABLE
```

Which is not particularly helpful.

This commit adjusts the behavior of `define-key` in the above
situation: change the definition of the key to the given definition,
regardless of whether it's already been defined.

---

The alternate solution that occurred to me would be to signal a condition here and ask the user whether they want to override the definition or leave the existing one in place. I can write up a version of that if you'd prefer that behavior instead.