### PR TITLE
v1.9.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([lem],[1.9])
+AC_INIT([lem],[1.9.2])
 AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_FILES([Makefile contrib/Makefile scripts/gen-contrib/Makefile])
 

--- a/lem.asd
+++ b/lem.asd
@@ -1,5 +1,5 @@
 (defsystem "lem"
-  :version "1.9"
+  :version "1.9.2"
   :depends-on ("lem-core"
                "lem-vi-mode"
                "lem-lisp-mode"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lem",
-  "version": "1.9.0",
+  "version": "1.9.2",
   "description": "lem frontend",
   "main": "frontends/electron/index.js",
   "scripts": {


### PR DESCRIPTION
- When trying to open files that could not be recognized as text files, abort and show message.
- define-command changed
  - Users have to change their own lem configuration to fit for this version. ``define-command`` arg-descriptor doesn’t have compatibility with old versions.
  - Generate class when defining commands. advice-classes can be added because of it.
  - When you redefine the same name command with a different form, an error will occur.
- syntax-highlight for lisp-mode changed. Now you can get proper highlighting for `define-xxxx` . Before this version, it was only highlighted until `define-`.
- `slime` command becomes non-blocking. While connecting swank-server animation on mode-line would be shown.
- Fix if a key is already bound; attempting to override that binding produces an error. (by Gordon Brown )
- Add C-M-y (kill-around-form)
- Rename editor variable truncate-lines to line-wrap.
- Transparency can be dealt with by overlay. When you mark region, you can see the foreground attribute still be seen. You can see the difference when you use directory-mode’s underlined line.
- Optimize for less redrawing.
- Refactoring and adding tests and a lot of fix bugs.

---

- バイナリファイルを開こうとしたときに失敗した場合メッセージを出してabortするようにした。
- define-commandの変更
  - arg-descriptorの変更によって過去との互換性が無くなった。
  - classを定義するようになった。結果としてadvice-classesを追加できるようになった(selection-mode/selection-mode.lisp参照)
  - 同名のコマンドを再定義するときに内容が違っているとリスタートエラーを出すようになった。
- lisp-modeのシンタックスハイライトで`define-xxxx`の`define-`までしか色がつかなかかったのを修正。
- slimeコマンド中にブロックしないようになった。ロード中にモードラインにアニメーションが表示されるようになった。
- define-keyで単一のキーの定義の後に単一キーで始まる複数キー定義をした際にエラーが出ていたのを修正し上書きする挙動に直した。
- C-M-y (kill-around-form) を追加
- エディタ変数truncate-linesをline-wrapに変更
- オーバーレイを透過させるようになった。(範囲選択をした際や、directory-modeの下線のバックグラウンドカラーが維持されるようになった。)
- 再描画の最適化
- 沢山のリファクタリングとテストの追加そしてバグの修正。

