### PR TITLE
Executing command signal

### DIFF
--- a/lib/core/command.lisp
+++ b/lib/core/command.lisp
@@ -2,10 +2,29 @@
 
 (export '(*pre-command-hook*
           *post-command-hook*
+          before-executing-command
+          after-executing-command
           this-command
           execute
           primary-command
           call-command))
+
+(defgeneric handle-signal (condition)
+  (:method (condition)
+    nil))
+
+(define-condition <executing-command> ()
+  ((command :initarg :command
+            :initform (alexandria:required-argument :command)
+            :reader executing-command-command)))
+
+(define-condition before-executing-command (<executing-command>) ()
+  (:report (lambda (c s)
+             (format s "before executing the ~S command" (executing-command-command c)))))
+
+(define-condition after-executing-command (<executing-command>) ()
+  (:report (lambda (c s)
+             (format s "after executing the ~S command" (executing-command-command c)))))
 
 (defconstant +primary-command-class-name+ 'primary-command)
 
@@ -26,9 +45,15 @@
     (make-instance class)))
 
 (defun call-command (this-command universal-argument)
+  (signal-subconditions 'before-executing-command :command this-command)
   (run-hooks *pre-command-hook*)
   (prog1 (alexandria:if-let (*this-command* (get-command this-command))
            (execute *this-command* universal-argument)
            (editor-error "~A: command not found" this-command))
     (buffer-undo-boundary)
-    (run-hooks *post-command-hook*)))
+    (run-hooks *post-command-hook*)
+    (signal-subconditions 'after-executing-command :command this-command)))
+
+(defun signal-subconditions (condition &rest initargs)
+  (dolist (c (collect-subclasses (ensure-class condition) :include-itself t))
+    (apply #'signal c initargs)))

--- a/lib/core/command.lisp
+++ b/lib/core/command.lisp
@@ -12,16 +12,16 @@
   (:method (condition)
     nil))
 
-(define-condition <executing-command> ()
+(define-condition executing-command ()
   ((command :initarg :command
             :initform (alexandria:required-argument :command)
             :reader executing-command-command)))
 
-(define-condition before-executing-command (<executing-command>) ()
+(define-condition before-executing-command (executing-command) ()
   (:report (lambda (c s)
              (format s "before executing the ~S command" (executing-command-command c)))))
 
-(define-condition after-executing-command (<executing-command>) ()
+(define-condition after-executing-command (executing-command) ()
   (:report (lambda (c s)
              (format s "after executing the ~S command" (executing-command-command c)))))
 

--- a/lib/core/command.lisp
+++ b/lib/core/command.lisp
@@ -1,8 +1,6 @@
 (in-package :lem)
 
-(export '(*pre-command-hook*
-          *post-command-hook*
-          handle-signal
+(export '(handle-signal
           before-executing-command
           after-executing-command
           this-command
@@ -29,9 +27,6 @@
 
 (defconstant +primary-command-class-name+ 'primary-command)
 
-(defvar *pre-command-hook* '())
-(defvar *post-command-hook* '())
-
 (defvar *this-command*)
 
 (defun this-command ()
@@ -47,12 +42,10 @@
 
 (defun call-command (this-command universal-argument)
   (signal-subconditions 'before-executing-command :command this-command)
-  (run-hooks *pre-command-hook*)
   (prog1 (alexandria:if-let (*this-command* (get-command this-command))
            (execute *this-command* universal-argument)
            (editor-error "~A: command not found" this-command))
     (buffer-undo-boundary)
-    (run-hooks *post-command-hook*)
     (signal-subconditions 'after-executing-command :command this-command)))
 
 (defun signal-subconditions (condition &rest initargs)

--- a/lib/core/command.lisp
+++ b/lib/core/command.lisp
@@ -56,5 +56,5 @@
     (signal-subconditions 'after-executing-command :command this-command)))
 
 (defun signal-subconditions (condition &rest initargs)
-  (dolist (c (collect-subclasses (ensure-class condition) :include-itself t))
+  (dolist (c (collect-subclasses (ensure-class condition) :include-itself nil))
     (apply #'signal c initargs)))

--- a/lib/core/command.lisp
+++ b/lib/core/command.lisp
@@ -2,6 +2,7 @@
 
 (export '(*pre-command-hook*
           *post-command-hook*
+          handle-signal
           before-executing-command
           after-executing-command
           this-command

--- a/lib/core/directory-mode.lisp
+++ b/lib/core/directory-mode.lisp
@@ -382,8 +382,8 @@
 
 (setf *find-directory-function* 'directory-buffer)
 
-(defun post-command-hook ()
+
+(define-condition update-line (after-executing-command) ())
+(defmethod handle-signal ((condition after-executing-command))
   (when (eq 'directory-mode (buffer-major-mode (current-buffer)))
     (update-line (current-point))))
-
-(add-hook *post-command-hook* 'post-command-hook)

--- a/lib/core/directory-mode.lisp
+++ b/lib/core/directory-mode.lisp
@@ -385,5 +385,5 @@
 
 (define-condition update-line (after-executing-command) ())
 (defmethod handle-signal ((condition after-executing-command))
-  (when (eq 'directory-mode (buffer-major-mode (current-buffer)))
+  (when (mode-active-p (current-buffer) 'directory-mode)
     (update-line (current-point))))

--- a/lib/core/file-command.lisp
+++ b/lib/core/file-command.lisp
@@ -168,6 +168,7 @@
 
 (define-condition ask-revert-buffer (before-executing-command)
   ((last-time :initform nil
+              :allocation :class
               :accessor ask-revert-buffer-last-time)))
 (defmethod handle-signal ((condition ask-revert-buffer))
   (when (or (null (ask-revert-buffer-last-time condition))

--- a/lib/core/interp.lisp
+++ b/lib/core/interp.lisp
@@ -133,9 +133,7 @@
 
 (defun command-loop ()
   (do-command-loop (:interactive t)
-    (handler-bind ((<executing-command>
-                     (lambda (condition)
-                       (handle-signal condition))))
+    (handler-bind ((<executing-command> #'handle-signal))
       (if (toplevel-command-loop-p)
           (with-error-handler ()
             (let ((*toplevel-command-loop-p* nil))

--- a/lib/core/interp.lisp
+++ b/lib/core/interp.lisp
@@ -133,17 +133,17 @@
 
 (defun command-loop ()
   (do-command-loop (:interactive t)
-    (handler-bind ((<executing-command> #'handle-signal))
-      (if (toplevel-command-loop-p)
+    (if (toplevel-command-loop-p)
+        (handler-bind ((<executing-command> #'handle-signal))
           (with-error-handler ()
             (let ((*toplevel-command-loop-p* nil))
               (handler-bind ((editor-condition
                                (lambda (c)
                                  (declare (ignore c))
                                  (invoke-restart 'lem-restart:message))))
-                (command-loop-body))))
-          (command-loop-body))
-      (fix-current-buffer-if-broken))))
+                (command-loop-body)))))
+        (command-loop-body))
+    (fix-current-buffer-if-broken)))
 
 (defun toplevel-command-loop (initialize-function)
   (with-catch-bailout

--- a/lib/core/interp.lisp
+++ b/lib/core/interp.lisp
@@ -134,7 +134,7 @@
 (defun command-loop ()
   (do-command-loop (:interactive t)
     (if (toplevel-command-loop-p)
-        (handler-bind ((<executing-command> #'handle-signal))
+        (handler-bind ((executing-command #'handle-signal))
           (with-error-handler ()
             (let ((*toplevel-command-loop-p* nil))
               (handler-bind ((editor-condition

--- a/lib/core/lem.lisp
+++ b/lib/core/lem.lisp
@@ -34,23 +34,6 @@
    (buffer-start-point buffer)
    (buffer-end-point buffer)))
 
-(let ((last-time nil))
-  (defun ask-revert-buffer ()
-    (when (or (null last-time)
-              (< (* 2 (/ internal-time-units-per-second 10))
-                 (- (get-internal-real-time) last-time)))
-      (setf last-time (get-internal-real-time))
-      (when (changed-disk-p (current-buffer))
-        (revert-buffer t)
-        #+(or)
-        (cond ((eql (buffer-value (current-buffer) 'no-revert-buffer)
-                    (file-write-date (buffer-filename))))
-              ((prompt-for-y-or-n-p (format nil "Revert buffer from file ~A" (buffer-filename)))
-               (revert-buffer t))
-              (t
-               (setf (buffer-value (current-buffer) 'no-revert-buffer)
-                     (file-write-date (buffer-filename)))))))))
-
 (defun setup-first-frame ()
   (let ((frame (make-frame nil)))
     (map-frame (implementation) frame)
@@ -86,9 +69,7 @@
                 5000)
       (add-hook (variable-value 'before-save-hook :global)
                 (lambda (buffer)
-                  (scan-file-property-list buffer)))
-      (add-hook *pre-command-hook*
-                'ask-revert-buffer))))
+                  (scan-file-property-list buffer))))))
 
 (defun teardown ()
   (teardown-frames)

--- a/lib/core/line-numbers.lisp
+++ b/lib/core/line-numbers.lisp
@@ -19,6 +19,10 @@
         (line-numbers-on)
         (line-numbers-off))))
 
+(define-condition update (after-executing-command) ())
+(defmethod handle-signal ((condition update))
+  (update))
+
 (defun update (&optional (window (current-window)))
   (let ((buffer (window-buffer window)))
     (mapc #'delete-overlay (buffer-value buffer 'line-number-overlays))
@@ -46,7 +50,6 @@
 (defun line-numbers-init ()
   (unless *initialized*
     (setf *initialized* t)
-    (add-hook *post-command-hook* 'update)
     (add-hook *window-scroll-functions* 'update)))
 
 (defun line-numbers-on ()
@@ -56,7 +59,6 @@
 (defun line-numbers-off ()
   (when (variable-value 'line-numbers)
     (setf *initialized* nil)
-    (remove-hook *post-command-hook* 'update)
     (remove-hook *window-scroll-functions* 'update)
     (dolist (buffer (buffer-list))
       (mapc #'delete-overlay (buffer-value buffer 'line-number-overlays)))))

--- a/lib/core/mode.lisp
+++ b/lib/core/mode.lisp
@@ -56,7 +56,8 @@
 (defun mode-active-p (buffer mode)
   (or (eq mode (buffer-major-mode buffer))
       (find mode (buffer-minor-modes buffer))
-      (find mode *global-minor-mode-list*)))
+      (find mode *global-minor-mode-list*)
+      (eq mode (mode-name (current-global-mode)))))
 
 (defun enable-minor-mode (minor-mode)
   (if (global-minor-mode-p minor-mode)

--- a/lib/core/package.lisp
+++ b/lib/core/package.lisp
@@ -1,5 +1,5 @@
 (defpackage :lem
-  (:use :cl :lem-base)
+  (:use :cl :lem-base :lem-utils/class)
   (:export . #.(loop :for sym :being :the :external-symbols :of (find-package :lem-base)
                      :collect (make-symbol (string sym))))
   #+sbcl

--- a/lib/core/typeout.lisp
+++ b/lib/core/typeout.lisp
@@ -155,9 +155,8 @@
     (unless (line-offset (current-point) (window-height (current-window)))
       (dismiss-typeout-window))))
 
-(defun typeout-window-post-command-hook ()
+(define-condition dismiss-typeout-window-if-getout (after-executing-command) ())
+(defmethod handle-signal ((condition dismiss-typeout-window-if-getout))
   (when (and (not (mode-active-p (window-buffer (current-window)) 'typeout-mode))
              *typeout-window*)
     (dismiss-typeout-window)))
-
-(add-hook *post-command-hook* 'typeout-window-post-command-hook)

--- a/lib/utils/class.lisp
+++ b/lib/utils/class.lisp
@@ -1,0 +1,22 @@
+(defpackage :lem-utils/class
+  (:use :cl)
+  (:export :ensure-class
+           :self-and-direct-subclasses
+           :collect-subclasses))
+(in-package :lem-utils/class)
+
+(defun ensure-class (class)
+  (etypecase class
+    (class class)
+    (symbol (find-class class))))
+
+(defun collect-subclasses (class &key (include-itself
+                                       (alexandria:required-argument :include-itself)))
+  (labels ((rec (class include-itself)
+             (let ((subclasses
+                     (loop :for subclass :in (c2mop:class-direct-subclasses class)
+                           :append (rec subclass t))))
+               (if include-itself
+                   (cons class subclasses)
+                   subclasses))))
+    (rec (ensure-class class) include-itself)))

--- a/lib/utils/class.lisp
+++ b/lib/utils/class.lisp
@@ -1,7 +1,6 @@
 (defpackage :lem-utils/class
   (:use :cl)
   (:export :ensure-class
-           :self-and-direct-subclasses
            :collect-subclasses))
 (in-package :lem-utils/class)
 

--- a/lib/utils/lem-utils.asd
+++ b/lib/utils/lem-utils.asd
@@ -1,3 +1,4 @@
 (defsystem "lem-utils"
   :class :package-inferred-system
-  :depends-on ("lem-utils/main"))
+  :depends-on ("lem-utils/main"
+               "lem-utils/class"))

--- a/modes/lsp-mode/lsp-mode.lisp
+++ b/modes/lsp-mode/lsp-mode.lisp
@@ -1162,8 +1162,13 @@
 (defun enable-document-highlight-idle-timer ()
   (unless *document-highlight-idle-timer*
     (setf *document-highlight-idle-timer*
-          (start-idle-timer 500 t #'document-highlight-calls-timer nil "lsp-document-highlight"))
-    (add-hook *post-command-hook* 'clear-document-highlight-overlays)))
+          (start-idle-timer 500 t #'document-highlight-calls-timer nil
+                            "lsp-document-highlight"))))
+
+(define-condition lsp-after-executing-command (after-executing-command) ())
+(defmethod handle-signal ((condition lsp-after-executing-command))
+  (when (mode-active-p (current-buffer) 'lsp-mode)
+    (clear-document-highlight-overlays)))
 
 ;;; document symbols
 

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -128,17 +128,20 @@
                              (ensure-state (current-state)))))
     (funcall it)))
 
+(define-condition post-command-hook (after-executing-command) ())
+(defmethod handle-signal ((condition post-command-hook))
+  (when (mode-active-p (current-buffer) 'vi-mode)
+    (vi-post-command-hook)))
+
 (add-hook *enable-hook*
           (lambda ()
             (initialize-vi-modeline)
             (change-state 'command)
             (add-hook *prompt-activate-hook* 'prompt-activate-hook)
-            (add-hook *prompt-deactivate-hook* 'prompt-deactivate-hook)
-            (add-hook *post-command-hook* 'vi-post-command-hook)))
+            (add-hook *prompt-deactivate-hook* 'prompt-deactivate-hook)))
 
 (add-hook *disable-hook*
           (lambda ()
             (finalize-vi-modeline)
             (remove-hook *prompt-activate-hook* 'prompt-activate-hook)
-            (remove-hook *prompt-deactivate-hook* 'prompt-deactivate-hook)
-            (remove-hook *post-command-hook* 'vi-post-command-hook)))
+            (remove-hook *prompt-deactivate-hook* 'prompt-deactivate-hook)))


### PR DESCRIPTION
conditionとsignalを用いてコマンド実行前後の処理を外から追加する仕組みを提供する
`*pre-command-hook*` と `*post-command-hook*` は廃止する

主に以下のシンボルを追加
after-executing-command (condition)
before-executing-command (condition)
handle-signal (generic-function)

コマンドの前後にbefore-executing-command, after-executing-commandのサブクラスにsignalを送る
コマンドループの外側でhandler-bindを用いてデフォルトのlem:handle-signalを呼び出すようになっている

拡張の例1
静的に挙動を追加する
```common-lisp
(define-condition foo (after-executing-command) ())
(define-condition bar (before-executing-command) ())

(defmethod handle-signal ((condition foo))
  ;; コマンド実行前に呼び出される
  )

(defmethod handle-signal ((condition bar))
  ;; コマンド実行後に呼び出される
  )
```

拡張の例2
動的にコマンドループに作用させる

```common-lisp
(define-condition hoge (after-executing-command) ())

(handler-bind ((hoge (lambda (c)
                       (declare (ignorable c))
                       ;; コマンド実行後にここに到達する
                       ;; hogeに関する対話的な処理をする
                       )))
  (prompt-for-string "> "))
```