### PR TITLE
Add var and defun for removing trailing whitespace on save

### DIFF
--- a/src/file-command.lisp
+++ b/src/file-command.lisp
@@ -5,13 +5,13 @@
 
 (defun maybe-create-directory (directory)
   (when (prompt-for-y-or-n-p
-         (format nil "Directory does not exist: ~A. Create" directory))
+	 (format nil "Directory does not exist: ~A. Create" directory))
     (ensure-directories-exist directory)))
 
 (defun directory-for-file-or-lose (filename)
   (let ((directory (directory-namestring filename)))
     (unless (or (uiop:directory-exists-p directory)
-                (maybe-create-directory directory))
+		(maybe-create-directory directory))
       (error 'editor-abort))
     directory))
 
@@ -20,27 +20,27 @@
 (define-command find-file (arg) ("p")
   (let ((*default-external-format* *default-external-format*))
     (let ((filename
-            (cond ((and (numberp arg) (= 1 arg))
-                   (prompt-for-file
-                    "Find File: "
-                    :directory (buffer-directory)
-                    :default nil
-                    :existing nil))
-                  ((numberp arg)
-                   (setf *default-external-format*
-                         (prompt-for-encodings
-                          "Encodings: "
-                          :history-symbol 'mh-read-file-encodings))
-                   (prompt-for-file
-                    "Find File: "
-                    :directory (buffer-directory)
-                    :default nil
-                    :existing nil))
-                  ((pathnamep arg)
-                   (namestring arg)))))
+	    (cond ((and (numberp arg) (= 1 arg))
+		   (prompt-for-file
+		    "Find File: "
+		    :directory (buffer-directory)
+		    :default nil
+		    :existing nil))
+		  ((numberp arg)
+		   (setf *default-external-format*
+			 (prompt-for-encodings
+			  "Encodings: "
+			  :history-symbol 'mh-read-file-encodings))
+		   (prompt-for-file
+		    "Find File: "
+		    :directory (buffer-directory)
+		    :default nil
+		    :existing nil))
+		  ((pathnamep arg)
+		   (namestring arg)))))
       (dolist (pathname (expand-files* filename))
-        (execute-find-file (get-file-mode pathname)
-                           pathname)))))
+	(execute-find-file (get-file-mode pathname)
+			   pathname)))))
 
 (defmethod execute-find-file (mode pathname)
   (directory-for-file-or-lose pathname)
@@ -64,19 +64,19 @@
   (when (variable-value 'Add-Newline-at-EOF-on-Writing-File :default buffer)
     (unless (start-line-p (buffer-end-point buffer))
       (with-point ((p (buffer-point buffer) :left-inserting))
-        (save-excursion
-          (insert-character p #\newline))))))
+	(save-excursion
+	  (insert-character p #\newline))))))
 
 (define-editor-variable delete-trailing-whitespace-on-writing-file nil)
 
 (defun clear-trailing-whitespace-on-write (&optional buffer)
-  (when (equal t delete-trailing-whitespace-on-writing-file)
+  (when (variable-value 'delete-trailing-whitespace-on-writing-file :default buffer)
     (delete-trailing-whitespace buffer)))
 
 (defun save-buffer (buffer &optional force-p)
   (cond
     ((and (or force-p (buffer-modified-p buffer))
-          (buffer-filename buffer))
+	  (buffer-filename buffer))
      (add-newline-at-eof buffer)
      (clear-trailing-whitespace-on-write buffer)
      (write-to-file buffer (buffer-filename buffer))
@@ -93,20 +93,20 @@
 
 (define-command write-file (filename) ("FWrite File: ")
   (let* ((old (buffer-name))
-         (new (file-namestring filename))
-         (expand-file-name (expand-file-name filename)))
+	 (new (file-namestring filename))
+	 (expand-file-name (expand-file-name filename)))
     (unless (and (find expand-file-name (mapcar #'buffer-filename
-                                                (buffer-list))
-                       :test #'equal)
-                 (not (prompt-for-y-or-n-p (format nil
-                                                   "~a is opend, overwrite it?"
-                                                   expand-file-name))))
+						(buffer-list))
+		       :test #'equal)
+		 (not (prompt-for-y-or-n-p (format nil
+						   "~a is opend, overwrite it?"
+						   expand-file-name))))
       (directory-for-file-or-lose filename)
       (unless (string= old new)
-        (buffer-rename (current-buffer)
-                       (if (get-buffer new)
-                           (unique-buffer-name new)
-                           new)))
+	(buffer-rename (current-buffer)
+		       (if (get-buffer new)
+			   (unique-buffer-name new)
+			   new)))
       (setf (buffer-filename) expand-file-name)
       (add-newline-at-eof (current-buffer))
       (save-current-buffer t))))
@@ -120,18 +120,18 @@
 
 (define-command insert-file (filename) ("fInsert file: ")
   (insert-file-contents (current-point)
-                        (expand-file-name filename))
+			(expand-file-name filename))
   t)
 
 (define-command save-some-buffers (&optional save-silently-p) ("P")
   (let ((prev-buffer (current-buffer)))
     (dolist (buffer (buffer-list))
       (when (and (buffer-modified-p buffer)
-                 (buffer-filename buffer))
-        (switch-to-buffer buffer nil)
-        (when (or save-silently-p
-                  (prompt-for-y-or-n-p (format nil "Save file ~A" (buffer-filename buffer))))
-          (save-current-buffer))))
+		 (buffer-filename buffer))
+	(switch-to-buffer buffer nil)
+	(when (or save-silently-p
+		  (prompt-for-y-or-n-p (format nil "Save file ~A" (buffer-filename buffer))))
+	  (save-current-buffer))))
     (switch-to-buffer prev-buffer nil)))
 
 (defun revert-buffer-function (buffer)
@@ -139,13 +139,13 @@
 
 (defun (setf revert-buffer-function) (function buffer)
   (setf (buffer-value buffer 'revert-buffer-function)
-        function))
+	function))
 
 (defun revert-buffer-internal (buffer)
   (with-buffer-read-only buffer nil
     (let* ((point (buffer-point buffer))
-           (line-number (line-number-at-point point))
-           (column (point-column point)))
+	   (line-number (line-number-at-point point))
+	   (column (point-column point)))
       (erase-buffer buffer)
       (insert-file-contents point (buffer-filename buffer))
       (buffer-unmark buffer)
@@ -156,35 +156,35 @@
 
 (define-command revert-buffer (does-not-ask-p) ("P")
   (let ((ask (not does-not-ask-p))
-        (buffer (current-buffer)))
+	(buffer (current-buffer)))
     (alexandria:if-let (fn (revert-buffer-function buffer))
       (funcall fn buffer)
       (when (and (or (buffer-modified-p buffer)
-                     (changed-disk-p buffer))
-                 (if ask
-                     (prompt-for-y-or-n-p (format nil "Revert buffer from file ~A" (buffer-filename)))
-                     t))
-        (revert-buffer-internal buffer)))))
+		     (changed-disk-p buffer))
+		 (if ask
+		     (prompt-for-y-or-n-p (format nil "Revert buffer from file ~A" (buffer-filename)))
+		     t))
+	(revert-buffer-internal buffer)))))
 
 (define-condition ask-revert-buffer (before-executing-command)
   ((last-time :initform nil
-              :allocation :class
-              :accessor ask-revert-buffer-last-time)))
+	      :allocation :class
+	      :accessor ask-revert-buffer-last-time)))
 (defmethod handle-signal ((condition ask-revert-buffer))
   (when (or (null (ask-revert-buffer-last-time condition))
-            (< (* 2 (/ internal-time-units-per-second 10))
-               (- (get-internal-real-time) (ask-revert-buffer-last-time condition))))
+	    (< (* 2 (/ internal-time-units-per-second 10))
+	       (- (get-internal-real-time) (ask-revert-buffer-last-time condition))))
     (setf (ask-revert-buffer-last-time condition) (get-internal-real-time))
     (when (changed-disk-p (current-buffer))
       (revert-buffer t)
       #+(or)
       (cond ((eql (buffer-value (current-buffer) 'no-revert-buffer)
-                  (file-write-date (buffer-filename))))
-            ((prompt-for-y-or-n-p (format nil "Revert buffer from file ~A" (buffer-filename)))
-             (revert-buffer t))
-            (t
-             (setf (buffer-value (current-buffer) 'no-revert-buffer)
-                   (file-write-date (buffer-filename))))))))
+		  (file-write-date (buffer-filename))))
+	    ((prompt-for-y-or-n-p (format nil "Revert buffer from file ~A" (buffer-filename)))
+	     (revert-buffer t))
+	    (t
+	     (setf (buffer-value (current-buffer) 'no-revert-buffer)
+		   (file-write-date (buffer-filename))))))))
 
 (define-command change-directory (directory)
     ((prompt-for-directory "change directory: " :directory (buffer-directory)))

--- a/src/file-command.lisp
+++ b/src/file-command.lisp
@@ -67,11 +67,18 @@
         (save-excursion
           (insert-character p #\newline))))))
 
+(define-editor-variable delete-trailing-whitespace-on-writing-file nil)
+
+(defun clear-trailing-whitespace-on-write (&optional buffer)
+  (when (equal t delete-trailing-whitespace-on-writing-file)
+    (delete-trailing-whitespace buffer)))
+
 (defun save-buffer (buffer &optional force-p)
   (cond
     ((and (or force-p (buffer-modified-p buffer))
           (buffer-filename buffer))
      (add-newline-at-eof buffer)
+     (clear-trailing-whitespace-on-write buffer)
      (write-to-file buffer (buffer-filename buffer))
      (buffer-unmark buffer)
      (buffer-filename buffer))


### PR DESCRIPTION
Changes made in src/file-command.lisp

This change adds the variable `delete-trailing-whitespace-on-writing-file` and the defun `clear-trailing-whitespace-on-write`.
I tried to keep it in the same style as `Add-Newline-at-EOF-on-Writing-File` and `add-newline-at-eof`.

I tested by setting the variable to `t`, introducing trailing whitespace in multiple buffers, then saving using `save-current-buffer` and `save-some-buffers` to ensure the whitespace was removed in the proper places.  I then did the same with the variable set to `nil`, and ensured that the whitespace was not removed.