### PR TITLE
[VI-MODE] • Migrated lem-vi-mode. -> lem-vi-mode/

### DIFF
--- a/modes/paredit-mode/paredit-mode.lisp
+++ b/modes/paredit-mode/paredit-mode.lisp
@@ -5,7 +5,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 (defpackage :lem-paredit-mode
   (:use :cl
         :lem
-        :lem-vi-mode.word)
+        :lem-vi-mode/word)
   (:export :paredit-mode
            :paredit-forward
            :paredit-backward

--- a/modes/vi-mode/binds.lisp
+++ b/modes/vi-mode/binds.lisp
@@ -1,13 +1,13 @@
-(defpackage :lem-vi-mode.binds
+(defpackage :lem-vi-mode/binds
   (:use :cl
         :lem
         :lem/universal-argument
         :lem/abbrev
-        :lem-vi-mode.core
-        :lem-vi-mode.commands
-        :lem-vi-mode.ex
-        :lem-vi-mode.visual))
-(in-package :lem-vi-mode.binds)
+        :lem-vi-mode/core
+        :lem-vi-mode/commands
+        :lem-vi-mode/ex
+        :lem-vi-mode/visual))
+(in-package :lem-vi-mode/binds)
 
 (define-key *command-keymap* "0" 'vi-move-to-beginning-of-line/universal-argument-0)
 (define-key *command-keymap* "1" 'universal-argument-1)

--- a/modes/vi-mode/commands.lisp
+++ b/modes/vi-mode/commands.lisp
@@ -1,12 +1,12 @@
-(defpackage :lem-vi-mode.commands
+(defpackage :lem-vi-mode/commands
   (:use :cl
         :lem
         :lem/universal-argument
         :lem/show-paren
-        :lem-vi-mode.core
-        :lem-vi-mode.word
-        :lem-vi-mode.visual
-        :lem-vi-mode.jump-motions)
+        :lem-vi-mode/core
+        :lem-vi-mode/word
+        :lem-vi-mode/visual
+        :lem-vi-mode/jump-motions)
   (:export :vi-move-to-beginning-of-line/universal-argument-0
            :vi-forward-char
            :vi-backward-char
@@ -72,7 +72,7 @@
            :vi-jump-next
            :vi-normal
            :vi-keyboard-quit))
-(in-package :lem-vi-mode.commands)
+(in-package :lem-vi-mode/commands)
 
 (defvar *cursor-offset* -1)
 (defvar *vi-clear-recursive* nil)

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -1,4 +1,4 @@
-(defpackage :lem-vi-mode.core
+(defpackage :lem-vi-mode/core
   (:use :cl
         :lem
         :lem/universal-argument)
@@ -14,7 +14,7 @@
            :*inactive-keymap*
            :command
            :insert))
-(in-package :lem-vi-mode.core)
+(in-package :lem-vi-mode/core)
 
 (defvar *default-cursor-color* nil)
 

--- a/modes/vi-mode/ex-command.lisp
+++ b/modes/vi-mode/ex-command.lisp
@@ -1,8 +1,8 @@
-(defpackage :lem-vi-mode.ex-command
-  (:use :cl :lem-vi-mode.ex-core)
-  (:import-from #:lem-vi-mode.jump-motions
+(defpackage :lem-vi-mode/ex-command
+  (:use :cl :lem-vi-mode/ex-core)
+  (:import-from #:lem-vi-mode/jump-motions
                 #:with-jump-motion))
-(in-package :lem-vi-mode.ex-command)
+(in-package :lem-vi-mode/ex-command)
 
 (defun ex-write (range filename touch)
   (case (length range)
@@ -17,7 +17,7 @@
 
 (defun ex-write-quit (range filename force touch)
   (ex-write range filename touch)
-  (lem-vi-mode.commands:vi-quit force))
+  (lem-vi-mode/commands:vi-quit force))
 
 (define-ex-command "^e$" (range filename)
   (declare (ignore range))
@@ -39,7 +39,7 @@
 
 (define-ex-command "^q$" (range argument)
   (declare (ignore range argument))
-  (lem-vi-mode.commands:vi-quit t))
+  (lem-vi-mode/commands:vi-quit t))
 
 (define-ex-command "^qa$" (range argument)
   (declare (ignore range argument))
@@ -47,7 +47,7 @@
 
 (define-ex-command "^q!$" (range argument)
   (declare (ignore range argument))
-  (lem-vi-mode.commands:vi-quit nil))
+  (lem-vi-mode/commands:vi-quit nil))
 
 (define-ex-command "^qa!$" (range argument)
   (declare (ignore range argument))
@@ -92,7 +92,7 @@
          (setf start (first range)
                end (second range))))
       (destructuring-bind (before after flag)
-          (lem-vi-mode.ex-parser:parse-subst-argument argument)
+          (lem-vi-mode/ex-parser:parse-subst-argument argument)
         (if (not (lem:with-point ((s start)
                                   (e end))
                    (lem:search-forward-regexp s before e)))
@@ -131,7 +131,7 @@
   (declare (ignore range))
   (lem:pipe-command
    (format nil "~A ~A"
-          (subseq lem-vi-mode.ex-core:*command* 1)
+          (subseq lem-vi-mode/ex-core:*command* 1)
           command)))
 
 (define-ex-command "^(buffers|ls|files)$" (range argument)

--- a/modes/vi-mode/ex-core.lisp
+++ b/modes/vi-mode/ex-core.lisp
@@ -1,4 +1,4 @@
-(defpackage :lem-vi-mode.ex-core
+(defpackage :lem-vi-mode/ex-core
   (:use :cl)
   (:export :*point*
            :syntax-error
@@ -15,7 +15,7 @@
            :call-ex-command
            :define-ex-command
            :*command*))
-(in-package :lem-vi-mode.ex-core)
+(in-package :lem-vi-mode/ex-core)
 
 (defvar *point*)
 (defvar *command-table* '())

--- a/modes/vi-mode/ex-parser.lisp
+++ b/modes/vi-mode/ex-parser.lisp
@@ -1,10 +1,10 @@
-(defpackage :lem-vi-mode.ex-parser
+(defpackage :lem-vi-mode/ex-parser
   (:use :cl :esrap)
-  (:import-from :lem-vi-mode.ex-core
+  (:import-from :lem-vi-mode/ex-core
                 :syntax-error)
   (:export :parse-ex
            :parse-subst-argument))
-(in-package :lem-vi-mode.ex-parser)
+(in-package :lem-vi-mode/ex-parser)
 
 (defrule whitespace (* #\space)
   (:constant nil))
@@ -15,21 +15,21 @@
 
 (defrule goto-line number
   (:lambda (number)
-    `(lem-vi-mode.ex-core:goto-line ,number)))
+    `(lem-vi-mode/ex-core:goto-line ,number)))
 
 (defrule current-line #\.
   (:lambda (x)
     (declare (ignore x))
-    '(lem-vi-mode.ex-core:current-line)))
+    '(lem-vi-mode/ex-core:current-line)))
 
 (defrule last-line #\$
   (:lambda (x)
     (declare (ignore x))
-    '(lem-vi-mode.ex-core:last-line)))
+    '(lem-vi-mode/ex-core:last-line)))
 
 (defrule marker (and #\' character)
   (:lambda (list)
-    `(lem-vi-mode.ex-core:marker ,(second list))))
+    `(lem-vi-mode/ex-core:marker ,(second list))))
 
 (defun is-not (a b)
   (not (eql a b)))
@@ -49,7 +49,7 @@
 
 (defrule forward-pattern (and #\/ (* forward-pattern-char) (? #\/))
   (:lambda (list)
-    `(lem-vi-mode.ex-core:search-forward
+    `(lem-vi-mode/ex-core:search-forward
       ,(coerce (second list) 'string))))
 
 (defrule escape-question (and #\\ #\?)
@@ -61,12 +61,12 @@
 
 (defrule backward-pattern (and #\? (* backward-pattern-char) (? #\?))
   (:lambda (list)
-    `(lem-vi-mode.ex-core:search-backward
+    `(lem-vi-mode/ex-core:search-backward
       ,(coerce (second list) 'string))))
 
 (defrule offset-line (and (or #\+ #\-) number)
   (:lambda (list)
-    `(lem-vi-mode.ex-core:offset-line
+    `(lem-vi-mode/ex-core:offset-line
       ,(if (string= "-" (first list))
            (- (second list))
            (second list)))))
@@ -90,16 +90,16 @@
 (defrule ex-range-lines (* (or (and ex-lines delimiter) (and ex-lines (? #\;))))
   (:lambda (list)
     (when list
-      `(lem-vi-mode.ex-core:range
+      `(lem-vi-mode/ex-core:range
         ,@(loop :for (lines delim) :in list
                 :collect `(lem:copy-point
                            ,(if (eql delim #\;)
-                                `(lem-vi-mode.ex-core:goto-current-point ,lines)
+                                `(lem-vi-mode/ex-core:goto-current-point ,lines)
                                 lines)
                            :temporary))))))
 
 (defrule ex-range-% #\%
-  (:constant '(lem-vi-mode.ex-core:all-lines)))
+  (:constant '(lem-vi-mode/ex-core:all-lines)))
 
 (defrule ex-range (or ex-range-% ex-range-lines))
 
@@ -130,8 +130,8 @@
           (argument (alexandria:when-let ((argument (third (third list))))
                       (string-trim " " argument))))
       (if (null command)
-          `(lem-vi-mode.ex-core:goto-current-point ,range)
-          `(lem-vi-mode.ex-core:call-ex-command ,range ,command ,(or argument ""))))))
+          `(lem-vi-mode/ex-core:goto-current-point ,range)
+          `(lem-vi-mode/ex-core:call-ex-command ,range ,command ,(or argument ""))))))
 
 
 (defrule subst (and #\/ (* forward-pattern-char) #\/ (* forward-pattern-char)

--- a/modes/vi-mode/ex.lisp
+++ b/modes/vi-mode/ex.lisp
@@ -1,10 +1,10 @@
-(defpackage :lem-vi-mode.ex
+(defpackage :lem-vi-mode/ex
   (:use :cl
         :lem
-        :lem-vi-mode.core
-        :lem-vi-mode.ex-parser)
+        :lem-vi-mode/core
+        :lem-vi-mode/ex-parser)
   (:export :vi-ex))
-(in-package :lem-vi-mode.ex)
+(in-package :lem-vi-mode/ex)
 
 (defvar *ex-keymap* (make-keymap :name '*ex-keymap*))
 
@@ -44,5 +44,5 @@
         :history-symbol 'vi-ex)))))
 
 (defun execute-ex (string)
-  (let ((lem-vi-mode.ex-core:*point* (current-point)))
+  (let ((lem-vi-mode/ex-core:*point* (current-point)))
     (eval (parse-ex string))))

--- a/modes/vi-mode/jump-motions.lisp
+++ b/modes/vi-mode/jump-motions.lisp
@@ -1,10 +1,10 @@
-(defpackage #:lem-vi-mode.jump-motions
+(defpackage #:lem-vi-mode/jump-motions
   (:use #:cl
         #:lem)
   (:export #:with-jump-motion
            #:jump-back
            #:jump-next))
-(in-package #:lem-vi-mode.jump-motions)
+(in-package #:lem-vi-mode/jump-motions)
 
 (defvar *prev-jump-points* '())
 (defvar *current-point* nil)

--- a/modes/vi-mode/vi-mode.lisp
+++ b/modes/vi-mode/vi-mode.lisp
@@ -1,8 +1,8 @@
 (defpackage :lem-vi-mode
   (:use :cl
         :lem
-        :lem-vi-mode.core
-        :lem-vi-mode.ex)
+        :lem-vi-mode/core
+        :lem-vi-mode/ex)
   (:export :vi-mode
            :define-vi-state
            :*command-keymap*

--- a/modes/vi-mode/visual.lisp
+++ b/modes/vi-mode/visual.lisp
@@ -1,7 +1,7 @@
-(defpackage :lem-vi-mode.visual
+(defpackage :lem-vi-mode/visual
   (:use :cl
         :lem
-        :lem-vi-mode.core)
+        :lem-vi-mode/core)
   (:export :vi-visual-end
            :vi-visual-char
            :vi-visual-line
@@ -15,7 +15,7 @@
            :vi-visual-append
            :vi-visual-upcase
            :vi-visual-downcase))
-(in-package :lem-vi-mode.visual)
+(in-package :lem-vi-mode/visual)
 
 (defvar *set-visual-function* nil)
 (defvar *start-point* nil)

--- a/modes/vi-mode/word.lisp
+++ b/modes/vi-mode/word.lisp
@@ -1,9 +1,9 @@
-(defpackage :lem-vi-mode.word
+(defpackage :lem-vi-mode/word
   (:use :cl :lem)
   (:export :forward-word-begin
            :backward-word-begin
            :forward-word-end))
-(in-package :lem-vi-mode.word)
+(in-package :lem-vi-mode/word)
 
 (defun hiragana-p (c)
   (<= #x3042 (char-code c) #x3093))

--- a/tests/e2e/vi-mode.lisp
+++ b/tests/e2e/vi-mode.lisp
@@ -14,17 +14,17 @@
   (lem-vi-mode:vi-mode)
   (test "enable hook"
     (test "initialize-vi-modeline"
-      (ok (and (lem-vi-mode.core::vi-modeline-element-p
-                lem-vi-mode.core::*modeline-element*)))
+      (ok (and (lem-vi-mode/core::vi-modeline-element-p
+                lem-vi-mode/core::*modeline-element*)))
       (ok (find-if (lambda (element)
-                     (and (lem-vi-mode.core::vi-modeline-element-p element)
-                          (equal "[COMMAND]" (lem-vi-mode.core::element-name element))))
+                     (and (lem-vi-mode/core::vi-modeline-element-p element)
+                          (equal "[COMMAND]" (lem-vi-mode/core::element-name element))))
                    lem::*modeline-status-list*)))
     (test "(chagne-state 'command)"
-      (ok (eq lem-vi-mode.core::*current-state* 'lem-vi-mode::command))
+      (ok (eq lem-vi-mode/core::*current-state* 'lem-vi-mode::command))
       (ok (eq (mode-keymap (get 'lem-vi-mode:vi-mode 'lem::global-mode))
-              (lem-vi-mode.core::vi-state-keymap (lem-vi-mode.core::ensure-state 'lem-vi-mode::command))))
-      (ok (equal "[COMMAND]" (lem-vi-mode.core::element-name lem-vi-mode.core::*modeline-element*)))
+              (lem-vi-mode/core::vi-state-keymap (lem-vi-mode/core::ensure-state 'lem-vi-mode::command))))
+      (ok (equal "[COMMAND]" (lem-vi-mode/core::element-name lem-vi-mode/core::*modeline-element*)))
       (ok (string= (if (eq :dark (lem::display-background-mode))
                        "white"
                        "dark")


### PR DESCRIPTION
Migrate "." -> "/" to follow new ASDF project package naming conventions. 