### PR TITLE
[VI-MODE] • Missing change from vi-mode package name migration

### DIFF
--- a/tests/e2e/vi-mode.lisp
+++ b/tests/e2e/vi-mode.lisp
@@ -21,7 +21,7 @@
                           (equal "[COMMAND]" (lem-vi-mode/core::element-name element))))
                    lem::*modeline-status-list*)))
     (test "(change-state 'normal)"
-      (ok (eq lem-vi-mode.core::*current-state* 'lem-vi-mode::command))
+      (ok (eq lem-vi-mode/core::*current-state* 'lem-vi-mode::command))
 
       (ok (eq (mode-keymap (get 'lem-vi-mode:vi-mode 'lem::global-mode))
               (lem-vi-mode/core::vi-state-keymap (lem-vi-mode/core::ensure-state 'lem-vi-mode::command))))


### PR DESCRIPTION
Also notice that `e2e` tests are currently not being run by rove. Is this intentional? 