### PR TITLE
[VI-MODE] • State CLOS refactor

### DIFF
--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -14,8 +14,8 @@
            :*insert-keymap*
            :*inactive-keymap*
            :post-command-hook
-           :state-enable-hook
-           :state-disable-hook
+           :state-enabled-hook
+           :state-disabled-hook
            :normal
            :insert))
 (in-package :lem-vi-mode/core)
@@ -95,13 +95,13 @@
 
 (defmethod post-command-hook ((state vi-state)))
 
-(defgeneric state-enable-hook (state &rest args))
+(defgeneric state-enabled-hook (state &rest args))
 
-(defmethod state-enable-hook ((state vi-state) &rest args))
+(defmethod state-enabled-hook ((state vi-state) &rest args))
 
-(defgeneric state-disable-hook (state))
+(defgeneric state-disabled-hook (state))
 
-(defmethod state-disable-hook ((state vi-state)))
+(defmethod state-disabled-hook ((state vi-state)))
 
 (defun current-state ()
   *current-state*)
@@ -116,12 +116,12 @@
 
 (defun change-state (name &rest args)
   (and *current-state*
-       (state-disable-hook (ensure-state *current-state*))) 
+       (state-disabled-hook (ensure-state *current-state*))) 
   (let ((state (ensure-state name)))
     (setf *current-state* name)
     (change-global-mode-keymap 'vi-mode (state-keymap state))
     (change-element-name (format nil "[~A]" name))
-    (state-enable-hook state args)
+    (state-enabled-hook state args)
     (unless *default-cursor-color*
       (setf *default-cursor-color*
             (attribute-background (ensure-attribute 'cursor nil))))
@@ -147,7 +147,7 @@
 
 (define-vi-state insert (:keymap *insert-keymap* :cursor-color "IndianRed"))
 
-(defmethod state-enable-hook ((state insert) &rest args)
+(defmethod state-enabled-hook ((state insert) &rest args)
   (message " -- INSERT --"))
 
 (define-vi-state modeline (:keymap *inactive-keymap*))

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -77,14 +77,14 @@
 
 ;;; vi-state methods
 (defmacro define-vi-state (name (&key tag message cursor-type keymap cursor-color) &body spec)
-    `(progn
-      (defclass ,name (vi-state) ())
-      (setf (get ',name 'state)
-           (make-instance ',name
-                          :message ,message
-                          :cursor-type ,cursor-type
-                          :keymap ,keymap
-                          :cursor-color ,cursor-color))))
+  `(progn
+     (defclass ,name (vi-state) ())
+       (setf (get ',name 'state)
+             (make-instance ',name
+                            :message ,message
+                            :cursor-type ,cursor-type
+                            :keymap ,keymap
+                            :cursor-color ,cursor-color))))
 
 (defgeneric post-command-hook (state))
 

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -78,8 +78,7 @@
 ;;; vi-state methods
 (defmacro define-vi-state (name (&key tag message cursor-type keymap cursor-color) &body spec)
     `(progn
-      (cl-package-locks:without-package-locks
-       (defclass ,name (vi-state) ()))
+      (defclass ,name (vi-state) ())
       (setf (get ',name 'state)
            (make-instance ',name
                           :message ,message
@@ -144,11 +143,11 @@
 (define-vi-state insert (:keymap *insert-keymap* :cursor-color "IndianRed"))
 
 (defmethod state-enabled-hook ((state insert) &rest args)
-  (message " -- INSERT --"))
+  (message "-- INSERT --"))
 
-(define-vi-state modeline (:keymap *inactive-keymap*))
+(define-vi-state vi-modeline (:keymap *inactive-keymap*))
 
-(defun prompt-activate-hook () (change-state 'modeline))
+(defun prompt-activate-hook () (change-state 'vi-modeline))
 (defun prompt-deactivate-hook () (change-state 'normal))
 
 (defun vi-post-command-hook ()

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -71,7 +71,7 @@
   :reader cursor-type)
   (keymap
   :initarg :keymap
-  :reader kmap)
+  :reader state-keymap)
   (cursor-color
   :initarg :cursor-color
   :accessor cursor-color)))
@@ -119,7 +119,7 @@
        (state-disable-hook (ensure-state *current-state*))) 
   (let ((state (ensure-state name)))
     (setf *current-state* name)
-    (change-global-mode-keymap 'vi-mode (kmap state))
+    (change-global-mode-keymap 'vi-mode (state-keymap state))
     (change-element-name (format nil "[~A]" name))
     (state-enable-hook state args)
     (unless *default-cursor-color*

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -60,21 +60,18 @@
 
 
 (defclass vi-state ()
-  ((tag
-  :initarg :tag
-  :reader tag)
-  (message
+  ((message
   :initarg :message
-  :reader msg)
+  :reader state-message)
   (cursor-type 
   :initarg :cursor-type
-  :reader cursor-type)
+  :reader state-cursor-type)
   (keymap
   :initarg :keymap
   :reader state-keymap)
   (cursor-color
   :initarg :cursor-color
-  :accessor cursor-color)))
+  :accessor state-cursor-color)))
 
 (defvar *current-state* nil)
 
@@ -85,7 +82,6 @@
        (defclass ,name (vi-state) ()))
       (setf (get ',name 'state)
            (make-instance ',name
-                          :tag ,tag
                           :message ,message
                           :cursor-type ,cursor-type
                           :keymap ,keymap
@@ -111,7 +107,7 @@
         (if (symbolp state)
             (get state 'state)
             state))
-  (assert (or (subtypep (type-of state) 'vi-state) (typep 'vi-state (type-of state))))
+  (assert (typep state 'vi-state))
   state)
 
 (defun change-state (name &rest args)
@@ -125,7 +121,7 @@
     (unless *default-cursor-color*
       (setf *default-cursor-color*
             (attribute-background (ensure-attribute 'cursor nil))))
-    (set-attribute 'cursor :background (or (cursor-color state) *default-cursor-color*))))
+    (set-attribute 'cursor :background (or (state-cursor-color state) *default-cursor-color*))))
 
 (defmacro with-state (state &body body)
   (alexandria:with-gensyms (old-state)

--- a/modes/vi-mode/visual.lisp
+++ b/modes/vi-mode/visual.lisp
@@ -29,14 +29,15 @@
 (define-key *visual-keymap* "U" 'vi-visual-upcase)
 (define-key *visual-keymap* "u" 'vi-visual-downcase)
 
-(define-vi-state visual (:keymap *visual-keymap*
-                         :post-command-hook 'post-command-hook)
-  (:disable ()
+(define-vi-state visual (:keymap *visual-keymap*))
+
+(defmethod state-enable-hook ((state visual) &rest args)
+   (setf *set-visual-function* (caar args))
+   (setf *start-point* (copy-point (current-point))))
+
+(defmethod state-disable-hook ((state visual))
    (delete-point *start-point*)
    (clear-visual-overlays))
-  (:enable (function)
-   (setf *set-visual-function* function)
-   (setf *start-point* (copy-point (current-point)))))
 
 (defun disable ()
   (clear-visual-overlays))
@@ -45,7 +46,7 @@
   (mapc 'delete-overlay *visual-overlays*)
   (setf *visual-overlays* '()))
 
-(defun post-command-hook ()
+(defmethod post-command-hook ((state visual))
   (clear-visual-overlays)
   (if (not (eq (current-buffer) (point-buffer *start-point*)))
       (vi-visual-end)

--- a/modes/vi-mode/visual.lisp
+++ b/modes/vi-mode/visual.lisp
@@ -31,11 +31,11 @@
 
 (define-vi-state visual (:keymap *visual-keymap*))
 
-(defmethod state-enable-hook ((state visual) &rest args)
+(defmethod state-enabled-hook ((state visual) &rest args)
    (setf *set-visual-function* (caar args))
    (setf *start-point* (copy-point (current-point))))
 
-(defmethod state-disable-hook ((state visual))
+(defmethod state-disabled-hook ((state visual))
    (delete-point *start-point*)
    (clear-visual-overlays))
 

--- a/tests/e2e/vi-mode.lisp
+++ b/tests/e2e/vi-mode.lisp
@@ -21,7 +21,7 @@
                           (equal "[COMMAND]" (lem-vi-mode/core::element-name element))))
                    lem::*modeline-status-list*)))
     (test "(change-state 'normal)"
-      (ok (eq lem-vi-mode.core::*current-state* 'lem-vi-mode::command))
+      (ok (eq lem-vi-mode/core::*current-state* 'lem-vi-mode::command))
 
       (ok (eq (mode-keymap (get 'lem-vi-mode:vi-mode 'lem::global-mode))
               (lem-vi-mode/core::vi-state-keymap (lem-vi-mode/core::ensure-state 'lem-vi-mode::command))))


### PR DESCRIPTION
Using CLOS to simplify implementation of VI State. Perviously, there was a lot of functions custom handling hooks and state changes.