### PR TITLE
Add a launcher script for SDL2 frontend for roswell users

### DIFF
--- a/roswell/lem-sdl2.ros
+++ b/roswell/lem-sdl2.ros
@@ -1,0 +1,22 @@
+#!/bin/sh
+#|-*- mode:lisp -*-|#
+#| lem launcher for SDL2 frontend
+exec ros -Q -m lem-sdl2 -L sbcl-bin -- $0 "$@"
+|#
+(progn
+  (unless (find-package :lem)
+    (ql:quickload :lem-sdl2 :silent t)
+    (uiop:symbol-call :lem :load-site-init))
+  (when (find :roswell.dump.executable *features*)
+    (mapc (lambda (x)
+            (load x :verbose t))
+          (directory (merge-pathnames "scripts/build/*.lisp"
+                                      (asdf/system:system-source-directory :lem))))))
+
+(defpackage :ros.script.lem-sdl2.3891688398
+  (:use :cl))
+(in-package :ros.script.lem-sdl2.3891688398)
+
+(defun main (&rest argv)
+  (apply #'lem:lem argv))
+;;; vim: set ft=lisp lisp:


### PR DESCRIPTION
This is a  launcher script enabled when lem is installed via [roswell](https://github.com/roswell/roswell).