### PR TITLE
Basic support for Elixir language

### DIFF
--- a/modes/elixir-mode/elixir-mode.lisp
+++ b/modes/elixir-mode/elixir-mode.lisp
@@ -1,0 +1,107 @@
+(defpackage :lem-elixir-mode
+  (:use :cl :lem :lem/language-mode :lem/language-mode-tools)
+  (:export :*elixir-mode-hook*
+           :elixir-mode))
+(in-package :lem-elixir-mode)
+
+(defvar *elixir-keywords*
+  '("case" "cond" "for" "if" "quote" "raise" "receive" "send" 
+    "super" "throw" "try" "unless" "unquote" "unquote_splicing" "with" 
+    
+    "import" "require" "use" "alias"
+    
+    "def" "defp" "defmodule" "defprotocol"
+    "defmacro" "defmacrop" "defdelegate"
+    "defexception" "defstruct" "defimpl"
+    "defguard" "defguardp" "defcallback"
+    "defoverridable" 
+    "end" "after" "else" "rescue" "catch" 
+
+    "not" "and" "or" "when" "in"
+
+    "fn" "do" "end" "after" "else" "rescue" "catch"
+
+    "->" "<-" "=>" "|>"))
+
+(defvar *elixir-boolean-literals*
+  '("true" "false"))
+
+(defvar *elixir-null-literal*
+  '("nil"))
+
+;; From:  http://elixir-lang.org/getting-started/basic-operators.html
+(defvar *elixir-operators*
+  '("+" "*" "++" "--" "<>" "||" "&&" "!"
+    "==" "!=" "===" "!==" ">=" "<="))
+
+
+(defun tokens (boundary strings)
+  (let ((alternation
+          `(:alternation ,@(sort (copy-list strings) #'> :key #'length))))
+    (if boundary
+        `(:sequence ,boundary ,alternation ,boundary)
+        alternation)))
+
+
+
+(defun make-tmlanguage-elixir ()
+  (let* ((patterns (make-tm-patterns
+                    (make-tm-match ":\\w+" 
+                                   :name 'syntax-constant-attribute) 
+                    (make-tm-match "\\w+:"
+                                   :name 'syntax-constant-attribute)
+                    (make-tm-line-comment-region "#")
+                    (make-tm-string-region "\"")
+                    (make-tm-string-region "'")
+                    (make-tm-string-region "\"\"\"")
+                    (make-tm-match (tokens :word-boundary 
+                                           (append *elixir-boolean-literals*
+                                                   *elixir-null-literal*))
+                                   :name 'syntax-constant-attribute)
+                    (make-tm-match (tokens :word-boundary *elixir-keywords*)
+                                   :name 'syntax-keyword-attribute)
+                    (make-tm-match (tokens nil *elixir-operators*)
+                                   :name 'syntax-builtin-attribute))))
+    (make-tmlanguage :patterns patterns)))
+
+(defvar *elixir-syntax-table*
+  (let ((table (make-syntax-table
+                :space-chars '(#\space #\tab #\newline)
+                :paren-pairs '((#\( . #\))
+                               (#\{ . #\})
+                               (#\[ . #\]))
+                :string-quote-chars '(#\" #\')
+                :block-string-pairs '(("\"\"\"" . "\"\"\"")
+                                      ("'''" . "'''"))
+                :line-comment-string "#"))
+        (tmlanguage (make-tmlanguage-elixir)))
+    (set-syntax-parser table tmlanguage)
+    table))
+
+(define-major-mode elixir-mode language-mode
+    (:name "elixir"
+     :keymap *elixir-mode-keymap*
+     :syntax-table *elixir-syntax-table*
+     :mode-hook *elixir-mode-hook*)
+  (setf (variable-value 'enable-syntax-highlight) t
+        (variable-value 'indent-tabs-mode) nil
+        (variable-value 'tab-width) 4
+        (variable-value 'line-comment) "#"
+        (variable-value 'beginning-of-defun-function) 'beginning-of-defun
+        (variable-value 'end-of-defun-function) 'end-of-defun))
+
+(defun beginning-of-defun (point n)
+  (loop :with regex = "^ *def(?:callback|delegate|exception|guardp?|impl|m(?:acrop?|odule)|overridable|p(?:rotocol)?|struct)?"
+        :repeat n 
+        :do (search-backward-regexp point regex)))
+
+
+(defun end-of-defun (point n)
+  (with-point ((p point))
+    (loop :repeat n
+          :do (line-offset p 1)
+              (unless (search-forward-regexp p "^  end") (return)))
+    (line-start p)
+    (move-point point p)))
+
+(define-file-type ("ex" "exs" "elixir") elixir-mode)

--- a/modes/elixir-mode/lem-elixir-mode.asd
+++ b/modes/elixir-mode/lem-elixir-mode.asd
@@ -1,0 +1,9 @@
+
+(defsystem "lem-elixir-mode"
+  :depends-on ("lem"
+               #+#.(cl:if (asdf:find-system :async-process cl:nil) '(and) '(or)) "lem-process")
+  :serial t
+  :components ((:file "elixir-mode")
+	       (:file "lsp-config")
+	       #+#.(cl:if (asdf:find-system :async-process cl:nil) '(and) '(or))
+               (:file "run-elixir")))

--- a/modes/elixir-mode/lsp-config.lisp
+++ b/modes/elixir-mode/lsp-config.lisp
@@ -1,0 +1,14 @@
+(defpackage :lem-elixir-mode/lsp-config
+  (:use :cl
+         :lem-lsp-mode
+         :lem-lsp-base/type))
+
+(in-package :lem-elixir-mode/lsp-config)
+
+(define-language-spec (elixir-spec lem-elixir-mode:elixir-mode)
+  :language-id "elixir"
+  :root-uri-patterns '("mix.exs")
+  :command '("sh" "language_server.sh")
+  :install-command ""
+  :readme-url "https://github.com/elixir-lsp/elixir-ls"
+  :connection-mode :stdio)

--- a/modes/elixir-mode/run-elixir.lisp
+++ b/modes/elixir-mode/run-elixir.lisp
@@ -1,0 +1,86 @@
+(defpackage :lem-elixir-mode.run-elixir
+  (:use :cl :lem :lem-elixir-mode)
+  (:export :*elixir-run-command*
+           :run-elixir))
+
+(in-package :lem-elixir-mode.run-elixir)
+
+(defvar *elixir-run-command* "iex")
+
+(defvar *process* nil)
+
+(define-major-mode run-elixir-mode lem-elixir-mode:elixir-mode
+    (:name "elixir"
+     :keymap *run-elixir-mode-keymap*
+     :syntax-table lem-elixir-mode::*elixir-syntax-table*)
+  (reset-listener-variables (current-buffer))
+  (lem/listener-mode:start-listener-mode))
+
+(define-key lem-elixir-mode::*elixir-mode-keymap* "C-c C-r" 'elixir-eval-region)
+
+(defun reset-listener-variables (buffer)
+  (setf (variable-value 'lem/listener-mode:listener-set-prompt-function :buffer buffer)
+        #'identity
+        (variable-value 'lem/listener-mode:listener-check-input-function :buffer buffer)
+        (constantly t)
+        (variable-value 'lem/listener-mode:listener-execute-function :buffer buffer)
+        'execute-input))
+
+(defun execute-input (point string)
+  (declare (ignore point))
+  (unless (alive-process-p)
+    (editor-error "Elixir process doesn't exist."))
+  (lem-process:process-send-input *process*
+                                  (concatenate 'string string (string #\newline))))
+
+(defun alive-process-p ()
+  (and *process*
+       (lem-process:process-alive-p *process*)))
+
+(defun repl-buffer-exists-p ()
+  (get-buffer "*elixir*"))
+
+(defun get-repl-buffer ()
+  (let ((buffer (make-buffer "*elixir*")))
+    (unless (eq (buffer-major-mode buffer) 'run-elixir-mode)
+      (change-buffer-mode buffer 'run-elixir-mode))
+    buffer))
+
+(defun output-callback (string)
+  (let* ((already-exists (repl-buffer-exists-p))
+         (buffer (get-repl-buffer))
+         (p (buffer-point buffer)))
+    (buffer-end p)
+    (setf string (ppcre:regex-replace-all "\\r\\n" string (string #\newline)))
+    (insert-string p string)
+    (when (ppcre:scan "^(iex|\.\.\.)\(.+\)" (line-string p))
+      (lem/listener-mode:refresh-prompt buffer nil))
+    (unless already-exists
+      (setf (current-window) (display-buffer buffer)))
+    (alexandria:when-let (window (first (get-buffer-windows buffer)))
+      (with-current-window window
+        (buffer-end p)
+        (window-see window)))
+    (redraw-display)))
+
+(defun run-elixir-internal ()
+  (unless (alive-process-p)
+    (when *process*
+      (lem-process:delete-process *process*))
+    (setf *process*
+          (lem-process:run-process *elixir-run-command*
+                                   :name "run-elixir"
+                                   :output-callback 'output-callback))))
+
+(define-command elixir-eval-region (start end) ("r")
+  (unless (alive-process-p)
+    (editor-error "elixir process doesn't exist."))
+  (lem-process:process-send-input *process* (points-to-string start end)))
+
+(define-command run-elixir () ()
+  (run-elixir-internal))
+
+(add-hook *exit-editor-hook*
+          (lambda ()
+            (when *process*
+              (lem-process:delete-process *process*))))


### PR DESCRIPTION
This commit has basic support for the Elixir programming language, still there are a couple of thing to improve/fix:

- The end function is not the best, there is a better way to calculate the end that have the same indentation as the function header,
this method can also be used for other languages that also end functions in "end" (like Lua).

- The lsp doesn't work, I think the configuration it's correct and at the beginning it's showing some log messages that for example GNU Emacs eglot ignores.


This is the output that eglot ignores and keep working, Lem only show this in a buffer and trigger the next error:
```
(:jsonrpc "2.0" :method "window/logMessage" :params
	  (:message "Started ElixirLS v0.14.6" :type 3))
[server-notification] Mon May 29 13:45:59 2023:
(:jsonrpc "2.0" :method "window/logMessage" :params
	  (:message "Running in /mnt/Data/Programming/atlas/remo" :type 3))
[server-notification] Mon May 29 13:45:59 2023:
(:jsonrpc "2.0" :method "window/logMessage" :params
	  (:message "ElixirLS built with elixir \"1.14.4\" on OTP \"24\"" :type 3))
[server-notification] Mon May 29 13:45:59 2023:
(:jsonrpc "2.0" :method "window/logMessage" :params
	  (:message "Running on elixir \"1.14.4 (compiled with Erlang/OTP 24)\" on OTP \"24\"" :type 3))
[server-notification] Mon May 29 13:45:59 2023:
(:jsonrpc "2.0" :method "window/logMessage" :params
	  (:message "Protocols are not consolidated" :type 3))
[server-notification] Mon May 29 13:45:59 2023:
(:jsonrpc "2.0" :method "window/showMessage" :params
	  (:message "OTP compiled without EEP48 documentation chunks" :type 2))
[server-notification] Mon May 29 13:45:59 2023:
(:jsonrpc "2.0" :method "window/logMessage" :params
	  (:message "OTP compiled without EEP48 documentation chunks. Language features for erlang modules will run in limited mode. Please reinstall or rebuild OTP with appropriate flags." :type 2))

```

 **This is the error that it triggers:**

![Selection_002](https://github.com/lem-project/lem/assets/26670956/bfa5c447-f68f-45cb-89c6-3d0408c0b486)


- The run-elixir "works" but sometimes it returns the same thing instead of processing it (input 2+2 -> output 2+2, not performing the sum), also by default iex have a lot of colors in the terminal, Lem doesn't seem to like that.

I'm using GNU Emacs regex for inspiration, using this package [pcre2el](https://github.com/joddie/pcre2el) helped a lot converting the default Emacs regex to PCRE.


This was my first major mode, and I'm still not that familiar with the code base, so any tips or additions are more than welcome.

