### PR TITLE
Add quote in the inspector function and sort in execute command

### DIFF
--- a/modes/lisp-mode/inspector.lisp
+++ b/modes/lisp-mode/inspector.lisp
@@ -37,7 +37,9 @@
 (define-command lisp-inspect (string)
     ((or (symbol-string-at-point (current-point))
          (prompt-for-sexp "Inspect value (evaluated): ")))
-  (lisp-eval-async `(swank:init-inspector ,string) 'open-inspector))
+  (lisp-eval-async `(swank:init-inspector 
+                     (format nil "(quote ~a)" ,string)) 
+                   'open-inspector))
 
 (defun inspector-buffer ()
   (or (get-buffer "*lisp-inspector*")

--- a/src/commands/other.lisp
+++ b/src/commands/other.lisp
@@ -45,9 +45,11 @@
                     (format nil "~D M-x " arg)
                     "M-x ")
                 :completion-function (lambda (str)
-                                       (if (find #\- str)
-                                           (completion-hypheen str (all-command-names))
-                                           (completion str (all-command-names))))
+                                       (sort 
+                                        (if (find #\- str)
+                                            (completion-hypheen str (all-command-names))
+                                            (completion str (all-command-names)))
+                                        #'string-lessp))
                 :test-function 'exist-command-p
                 :history-symbol 'mh-execute-command))
          (command (find-command name)))


### PR DESCRIPTION
So, I notice these two things:
- When I was trying to inspect a symbol it was complaining triggering this error:

![lem_inspect](https://github.com/lem-project/lem/assets/26670956/79e2f53d-131e-4be3-90ee-bda6fade04be)

Seems like the inspector was assuming that it always was a variable, quoting the value solves the issue and it allow it to inspect any symbol.



- When executing commands, the order seem a little odd (for example, trying to call lisp-aproppos, I got longer commands first)

In this case, I just added a sort function so it always trigger the shortest first, I don't know if this was a design decision and I hope that it doesn't introduce too much overhead having to sort all the time. Still, I  think it's a improvement in usability 