### PR TITLE
Remove elixir server-path variable and add a way to change the lsp spec

### DIFF
--- a/modes/elixir-mode/lsp-config.lisp
+++ b/modes/elixir-mode/lsp-config.lisp
@@ -1,17 +1,12 @@
 (defpackage :lem-elixir-mode/lsp-config
-  (:use :cl
-         :lem-lsp-mode
-         :lem-lsp-base/type))
+  (:use :cl :lem-lsp-mode :lem-lsp-base/type))
 
 (in-package :lem-elixir-mode/lsp-config)
-
-;;TODO: Add this variable to the documentation on how to use lsp with elixir-mode
-(defvar *server-path* "language_server.sh")
 
 (define-language-spec (elixir-spec lem-elixir-mode:elixir-mode)
   :language-id "elixir"
   :root-uri-patterns '("mix.exs")
-  :command `("sh" ,*server-path*)
+  :command '("sh" "language_server.sh")
   :install-command ""
   :readme-url "https://github.com/elixir-lsp/elixir-ls"
   :connection-mode :stdio)

--- a/modes/lsp-mode/spec.lisp
+++ b/modes/lsp-mode/spec.lisp
@@ -55,6 +55,10 @@
   (check-type spec spec)
   (setf (get major-mode 'spec) spec))
 
+(defmethod (setf spec-command) ((command list)
+				(spec lem-lsp-mode/spec::spec))
+  (setf (slot-value spec 'command) command))
+
 (defun get-spec-command (spec &rest args)
   (let ((command (spec-command spec)))
     (if (functionp command)

--- a/modes/lsp-mode/spec.lisp
+++ b/modes/lsp-mode/spec.lisp
@@ -56,7 +56,7 @@
   (setf (get major-mode 'spec) spec))
 
 (defmethod (setf spec-command) ((command list)
-				(spec lem-lsp-mode/spec::spec))
+				(spec spec))
   (setf (slot-value spec 'command) command))
 
 (defun get-spec-command (spec &rest args)


### PR DESCRIPTION
So... I just realize that the variable only get expanded at compilation time, so when I changed the variable in the config the value doesn't get updated.

The idea is to just change the value in the user configuration with a good old setf command:
```
(defvar *fer/elixir-lsp-path*
  '("sh" "path-to"))

(setf (lem-lsp-mode/spec:spec-command
       (lem-lsp-mode/spec:get-language-spec 'lem-elixir-mode:elixir-mode))
      *fer/elixir-lsp-path*)

```