### PR TITLE
Fix abbrev duplication keywords

### DIFF
--- a/src/ext/abbrev.lisp
+++ b/src/ext/abbrev.lisp
@@ -45,10 +45,12 @@
       (nreverse (remove-duplicates words :test #'equal)))))
 
 (defun filter-word (current-word words)
-  (remove-if-not (lambda (word)
-                   (and (string/= word current-word)
-                        (alexandria:starts-with-subseq current-word word)))
-                 words))
+  (loop :with output = nil
+        :for word :in words
+        :when (and (string/= word current-word)
+                   (alexandria:starts-with-subseq current-word word))
+        :do (pushnew word output :test #'string=)
+        :finally (return output)))
 
 (defun scan-all-buffer-words (word &optional point)
   (unless (string= word "")


### PR DESCRIPTION
I realize that it checks for repeat keywords in each buffer, but not when they are combined, this solves de issue :+1: 