### PR TITLE
find files recursively

### DIFF
--- a/lem.asd
+++ b/lem.asd
@@ -10,6 +10,7 @@
                "yason"
                "log4cl"
                "split-sequence"
+               "str"
                "dexador"
                "lem-base"
                "lem-encodings"

--- a/src/base/buffer.lisp
+++ b/src/base/buffer.lisp
@@ -19,7 +19,8 @@
     :accessor buffer-%filename)
    (%directory
     :initform nil
-    :accessor buffer-%directory)
+    :accessor buffer-%directory
+    :documentation "The buffer's directory. See: `buffer-directory'.")
    (%modified-p
     :initform 0
     :reader buffer-modified-tick

--- a/src/commands/file.lisp
+++ b/src/commands/file.lisp
@@ -34,8 +34,6 @@
   Must be symbols of program names, for example \":find\" for the unix \"find\" program.")
 
 (defvar *find-program*)                 ;; unbound: search and set at first use.
-#+(or)
-(setf lem-core/commands/file::*find-program* :lisp)
 
 (defun expand-files* (filename)
   (directory-files (expand-file-name filename (buffer-directory))))
@@ -103,24 +101,6 @@
       #+windows
       (uiop:run-program (list "explorer" (namestring pathname))))))
 
-(defun which (program)
-  "Simple, slow and unix-only function to know if this program exists on the system.
-  Returns either the full path (string) or NIL."
-  ;; note: the program path is eventually not used.
-  #+unix
-  (str:trim
-   (first
-    (str:lines (uiop:run-program (list "which" program)
-                                 :output :string
-                                 :ignore-error-status t))))
-  #-unix
-  (progn
-    (warn "which is not defined for your implementation.")
-    (string program)))
-#+(or)
-(assert (equal (which "find")
-               "/usr/bin/find"))
-
 (defun find-program ()
   "Return the first program of *find-programs* that exists on this system.
   Cache the result on *find-program*.
@@ -137,7 +117,7 @@
             if (eql :lisp key)
               do (setf *find-program* :lisp)
             else do
-              (when (which name)
+              (when (exist-program-p name)
                 (setf *find-program* key)
                 (return key)))))
 


### PR DESCRIPTION
This makes using Lem more efficient :sunglasses: 

![Selection_143](https://github.com/lem-project/lem/assets/3721004/06135e91-580c-41c5-888f-e097efee1526)

The new command should work for all platforms. 
We have a choice of programs to find files: 
  - [fd](https://github.com/sharkdp/fd), which is`fdfind` in Debian, excludes .git, node_modules and the like by default
  - find
  - a lisp way

This is NOT like "find file in project", which could be done later on. This is only "find a file with a choice of all files in subdirectories, starting from this buffer's directory".

I settled on CLOS `eql` specializers to dispatch by the chosen finder program, so the user has built-in configuration options (around methods, etc).

subject to review:

- I introduced my STR library as a dependency. It is lightweight and, albeit not strictly necessary for this PR, I believe it is very handy (and popular!).
- on `#+unix` (I believe it includes Mac OS?) I call `which` to check that a program is present in the system. On non-unix, we fallback to the lispy method.
- a couple comments inline.


