### PR TITLE
[VI-MODE] • Enhance define-vi-state to allow expose more of the defclass CLOS functionality.

### DIFF
--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -6,7 +6,6 @@
   (:export :*enable-hook*
            :*disable-hook*
            :vi-state
-           :state-message
            :vi-mode
            :define-vi-state
            :current-state
@@ -75,6 +74,7 @@
   :initarg :cursor-color
   :accessor state-cursor-color))
   (:default-initargs
+        :message nil
         :cursor-color "IndianRed"
         :keymap *global-keymap*))
 
@@ -97,7 +97,10 @@
 
 (defgeneric state-enabled-hook (state))
 
-(defmethod state-enabled-hook ((state vi-state)))
+(defmethod state-enabled-hook ((state vi-state))
+  (let ((msg (state-message state)))
+    (unless (null msg)
+      (message msg))))
 
 (defgeneric state-disabled-hook (state))
 
@@ -143,16 +146,13 @@
   (:default-initargs
    :keymap *command-keymap*))
 
-
 ;; insert state
 (defvar *insert-keymap* (make-keymap :name '*insert-keymap* :parent *global-keymap*))
 
 (define-vi-state insert () () 
   (:default-initargs
+   :message "-- INSERT --"
    :keymap *insert-keymap*))
-
-(defmethod state-enabled-hook ((state insert))
-  (message "-- INSERT --"))
 
 (define-vi-state vi-modeline () () 
   (:default-initargs

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -75,7 +75,7 @@
   :accessor state-cursor-color))
   (:default-initargs
         :message nil
-        :cursor-color "IndianRed"
+        :cursor-color nil
         :keymap *global-keymap*))
 
 (defvar *current-state* nil)

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -82,7 +82,7 @@
 (defmacro define-vi-state (name direct-super-classes direct-slot-specs &rest options)
   (let ((cleaned-super-classes (if (null direct-super-classes) '(vi-state) direct-super-classes)))
     `(progn
-       (assert (find 'vi-state ',cleaned-super-classes :test #'(lambda (expected-class class) (closer-mop:subclassp class expected-class))) (',cleaned-super-classes) "At least one of the direct-super-classes should be vi-state or subclass of vi-state!")
+       (assert (find 'vi-state ',cleaned-super-classes :test #'(lambda (expected-class class) (closer-mop:subclassp class expected-class))) (',cleaned-super-classes) "At least one of the direct-super-classes should be vi-state or a subclass of vi-state!")
        (defclass ,name ,cleaned-super-classes
          ,direct-slot-specs
          ,@options)

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -82,7 +82,7 @@
 (defmacro define-vi-state (name direct-super-classes direct-slot-specs &rest options)
   (let ((cleaned-super-classes (if (null direct-super-classes) '(vi-state) direct-super-classes)))
     `(progn
-       (assert (find 'vi-state ',cleaned-super-classes :test #'(lambda (expected-class class) (closer-mop:subclassp class expected-class))) (',cleaned-super-classes) "At least one of the direct super-classes should be vi-state!")
+       (assert (find 'vi-state ',cleaned-super-classes :test #'(lambda (expected-class class) (closer-mop:subclassp class expected-class))) (',cleaned-super-classes) "At least one of the direct-super-classes should be vi-state or subclass of vi-state!")
        (defclass ,name ,cleaned-super-classes
          ,direct-slot-specs
          ,@options)

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -152,6 +152,7 @@
 (define-vi-state insert () () 
   (:default-initargs
    :message "-- INSERT --"
+   :cursor-color "IndianRed"
    :keymap *insert-keymap*))
 
 (define-vi-state vi-modeline () () 

--- a/modes/vi-mode/core.lisp
+++ b/modes/vi-mode/core.lisp
@@ -5,6 +5,8 @@
   (:import-from :cl-package-locks)
   (:export :*enable-hook*
            :*disable-hook*
+           :vi-state
+           :state-message
            :vi-mode
            :define-vi-state
            :current-state
@@ -93,9 +95,9 @@
 
 (defmethod post-command-hook ((state vi-state)))
 
-(defgeneric state-enabled-hook (state &rest args))
+(defgeneric state-enabled-hook (state))
 
-(defmethod state-enabled-hook ((state vi-state) &rest args))
+(defmethod state-enabled-hook ((state vi-state)))
 
 (defgeneric state-disabled-hook (state))
 
@@ -112,14 +114,14 @@
   (assert (typep state 'vi-state))
   state)
 
-(defun change-state (name &rest args)
+(defun change-state (name)
   (and *current-state*
        (state-disabled-hook (ensure-state *current-state*))) 
   (let ((state (ensure-state name)))
     (setf *current-state* name)
     (change-global-mode-keymap 'vi-mode (state-keymap state))
     (change-element-name (format nil "[~A]" name))
-    (state-enabled-hook state args)
+    (state-enabled-hook state)
     (unless *default-cursor-color*
       (setf *default-cursor-color*
             (attribute-background (ensure-attribute 'cursor nil))))
@@ -149,7 +151,7 @@
   (:default-initargs
    :keymap *insert-keymap*))
 
-(defmethod state-enabled-hook ((state insert) &rest args)
+(defmethod state-enabled-hook ((state insert))
   (message "-- INSERT --"))
 
 (define-vi-state vi-modeline () () 

--- a/modes/vi-mode/ex.lisp
+++ b/modes/vi-mode/ex.lisp
@@ -8,7 +8,9 @@
 
 (defvar *ex-keymap* (make-keymap :name '*ex-keymap*))
 
-(define-vi-state ex (:keymap *ex-keymap*))
+(define-vi-state ex () () 
+  (:default-initargs
+   :keymap *ex-keymap*))
 
 (define-command vi-ex () ()
   (let ((directory (lem:buffer-directory)))

--- a/modes/vi-mode/lem-vi-mode.asd
+++ b/modes/vi-mode/lem-vi-mode.asd
@@ -1,5 +1,7 @@
 (defsystem "lem-vi-mode"
-  :depends-on ("esrap" "lem")
+  :depends-on ("esrap"
+               "closer-mop"
+               "lem")
   :serial t
   :components ((:file "core")
                (:file "word")

--- a/modes/vi-mode/visual.lisp
+++ b/modes/vi-mode/visual.lisp
@@ -107,20 +107,17 @@
 (define-command vi-visual-char () ()
   (if (visual-char-p)
       (vi-visual-end)
-      (progn
-        (change-state 'visual-char))))
+      (change-state 'visual-char)))
 
 (define-command vi-visual-line () ()
   (if (visual-line-p)
       (vi-visual-end)
-      (progn
-        (change-state 'visual-line))))
+      (change-state 'visual-line)))
 
 (define-command vi-visual-block () ()
   (if (visual-block-p)
       (vi-visual-end)
-      (progn
-        (change-state 'visual-block))))
+      (change-state 'visual-block)))
 
 (defun visual-p ()
   (eq 'visual (current-state)))

--- a/modes/vi-mode/visual.lisp
+++ b/modes/vi-mode/visual.lisp
@@ -29,7 +29,9 @@
 (define-key *visual-keymap* "U" 'vi-visual-upcase)
 (define-key *visual-keymap* "u" 'vi-visual-downcase)
 
-(define-vi-state visual (:keymap *visual-keymap*))
+(define-vi-state visual () () 
+  (:default-initargs
+   :keymap *visual-keymap*))
 
 (defmethod state-enabled-hook ((state visual) &rest args)
    (setf *set-visual-function* (caar args))

--- a/modes/vi-mode/visual.lisp
+++ b/modes/vi-mode/visual.lisp
@@ -36,20 +36,20 @@
 (define-vi-state visual-char (visual) ())
 
 (define-vi-state visual-line (visual) ()
-(:default-initargs
+  (:default-initargs
    :message "-- VISUAL LINE --"))
 
 (define-vi-state visual-block (visual) ()
-(:default-initargs
+  (:default-initargs
    :message "-- VISUAL BLOCK --"))
 
 (defmethod state-enabled-hook ((state visual))
-   (message (state-message state))
-   (setf *start-point* (copy-point (current-point))))
+  (message (state-message state))
+  (setf *start-point* (copy-point (current-point))))
 
 (defmethod state-disabled-hook ((state visual))
-   (delete-point *start-point*)
-   (clear-visual-overlays))
+  (delete-point *start-point*)
+  (clear-visual-overlays))
 
 (defun disable ()
   (clear-visual-overlays))

--- a/modes/vi-mode/visual.lisp
+++ b/modes/vi-mode/visual.lisp
@@ -43,8 +43,7 @@
   (:default-initargs
    :message "-- VISUAL BLOCK --"))
 
-(defmethod state-enabled-hook ((state visual))
-  (message (state-message state))
+(defmethod state-enabled-hook :after ((state visual))
   (setf *start-point* (copy-point (current-point))))
 
 (defmethod state-disabled-hook ((state visual))


### PR DESCRIPTION
The plan is to use inheritance to reduce code redundancy and improve the extensibility of vi-states, such as `visual` state. Currently, `visual` state has three sub states (`visual-char`, `visual-line`, `visual-block`), which produce code redundancy with state changes.

TODO: Follow-up with PR to refactor redundancy `visual` state.