### PR TITLE
Add repository patch as a solution for dependency hell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ GIT_IGNORE.*
 lem
 lem-ncurses
 
+build/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "submodules/micros"]
 	path = submodules/micros
 	url = https://github.com/lem-project/micros
+[submodule "submodules/quick-patch"]
+	path = submodules/quick-patch
+	url = https://github.com/Sasanidas/quick-patch.git

--- a/patch-build.lisp
+++ b/patch-build.lisp
@@ -1,0 +1,18 @@
+;; usage: sbcl --eval '(ql:quickload :lem-ncurses)' --load build.lisp
+(ql:quickload :quick-patch)
+
+(quick-patch:register "https://github.com/sharplispers/log4cl"
+		      "fe3da517147d023029782ced7cd989ba24f1e62d")
+
+
+(quick-patch:register "https://github.com/scymtym/esrap.git"
+		      "d806138342a6b27327649fd5f36e0fe2e0966867")
+
+(quick-patch:checkout-all "build/quick-patch/")
+
+
+(ql:quickload :lem-ncurses)
+
+
+
+(load "build.lisp")


### PR DESCRIPTION
So, using quick-patch as a submodule, we can use it to have certain versions of repositories loaded when compiling Lem.

For now it's only used in the patch-build script, and  it can be used the same as the build.lisp:
```
sbcl --load "patch-build.lisp"
```