### PR TITLE
Added C-S-Backspace command that kills the whole line

### DIFF
--- a/docs/default-keybindings.md
+++ b/docs/default-keybindings.md
@@ -1,3 +1,4 @@
+
 ## Move
 | Command                                                                                                       | Key bindings  | Documentation                                         |
 |---------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------------|
@@ -33,6 +34,7 @@
 | [kill-region](https://github.com/lem-project/lem/blob/main/src/commands/edit.lisp#L161)                | C-w            | Kill the text of region.                                                             |
 | [kill-region-to-clipboard](https://github.com/lem-project/lem/blob/main/src/commands/edit.lisp#L170)   |                | Kill the text of region and copy to the clipboard.                                   |
 | [kill-line](https://github.com/lem-project/lem/blob/main/src/commands/edit.lisp#L175)                  | C-k            | Kill from the current cursor position to the end of the line.                        |
+| [kill-whole-line](https://github.com/lem-project/lem/blob/main/src/commands/edit.lisp#L165)            | C-S-Backspace  | Kill the whole line and the remaining whitespace .                        		 |
 | [yank](https://github.com/lem-project/lem/blob/main/src/commands/edit.lisp#L205)                       | C-y            | Paste the copied text.                                                               |
 | [yank-pop](https://github.com/lem-project/lem/blob/main/src/commands/edit.lisp#L209)                   | M-y            | Replaces the immediately pasted text with the next text in the killring.             |
 | [yank-pop-next](https://github.com/lem-project/lem/blob/main/src/commands/edit.lisp#L222)              |                | Replaces the immediately preceding yank-pop text with the text before the kill ring. |
@@ -174,4 +176,3 @@
 | [execute-command](https://github.com/lem-project/lem/blob/main/src/commands/other.lisp#L49)   | M-x            | Read a command name, then read the ARG and call the command. |
 | [show-context-menu](https://github.com/lem-project/lem/blob/main/src/commands/other.lisp#L68) | Shift-F10, M-h |                                                              |
 | [load-library](https://github.com/lem-project/lem/blob/main/src/commands/other.lisp#L74)      |                | Load the Lisp library named NAME.                            |
-

--- a/src/commands/edit.lisp
+++ b/src/commands/edit.lisp
@@ -17,6 +17,7 @@
            :kill-region
            :kill-region-to-clipboard
            :kill-line
+           :kill-whole-line
            :yank
            :yank-pop
            :yank-pop-next
@@ -45,6 +46,7 @@
 (define-key *global-keymap* "M-w" 'copy-region)
 (define-key *global-keymap* "C-w" 'kill-region)
 (define-key *global-keymap* "C-k" 'kill-line)
+(define-key *global-keymap* "C-Shift-Backspace" 'kill-whole-line)
 (define-key *global-keymap* "C-y" 'yank)
 (define-key *global-keymap* "M-y" 'yank-pop)
 (define-key *global-keymap* "C-x C-o" 'delete-blank-lines)
@@ -190,6 +192,13 @@
              (buffer-end (current-point)))
          (let ((end (current-point)))
            (kill-region start end)))))))
+
+(define-command kill-whole-line () ()
+   (with-point ((start (current-point))
+                (end (current-point)))
+     (line-end end)
+     (kill-region start end))
+   (delete-previous-char))
 
 (defun yank-1 (arg)
   (let ((string (if (null arg)

--- a/src/commands/edit.lisp
+++ b/src/commands/edit.lisp
@@ -194,6 +194,7 @@
            (kill-region start end)))))))
 
 (define-command kill-whole-line () ()
+  "Kill the entire line and the remaining whitespace"
    (with-point ((start (current-point))
                 (end (current-point)))
      (line-end end)


### PR DESCRIPTION
Just added this little command I use all the time in Emacs. The keybindings wasn't in use, so it's fairly inconsequential.
Does the documentation markdown file update the links automatically somehow?