### PR TITLE
hyperspec: message the user if symbol not found

### DIFF
--- a/modes/lisp-mode/hyperspec.lisp
+++ b/modes/lisp-mode/hyperspec.lisp
@@ -1008,8 +1008,9 @@ It can also be a path to load it locally:
 (define-command hyperspec-at-point (point) ((current-point))
   (let* ((symbol (symbol-string-at-point point))
          (url (hlookup symbol)))
-    (when (typep url 'lem/thingatp:url)
-      (open-external-file url))))
+    (if (typep url 'lem/thingatp:url)
+        (open-external-file url)
+        (message "This symbol isn't referenced in the HyperSpec."))))
 
 (define-command hyperspec-lookup () ()
   (let* ((symbol-list (mapcar #'car *symbols-list*))


### PR DESCRIPTION
If the user right clicks on, say, "save-lisp-and-die", nothing would happen, because this symbol isn't in the index.
Display a message.