### PR TITLE
Reimplementation of the eval commands in lisp-mode

### DIFF
--- a/modes/lisp-mode/eval.lisp
+++ b/modes/lisp-mode/eval.lisp
@@ -1,0 +1,112 @@
+(defpackage :lem-lisp-mode/eval
+  (:use :cl :lem :lem-lisp-mode/internal))
+(in-package :lem-lisp-mode/eval)
+
+(define-attribute eval-error-attribute
+  (t :foreground "white" :background "dark red"))
+
+(define-attribute eval-value-attribute
+  (t :foreground "sky blue" :bold t))
+
+(define-key *lisp-mode-keymap* "C-x C-e" 'lisp-eval-at-point)
+(define-key *lisp-mode-keymap* "M-Return" 'lisp-eval-at-point)
+(define-key *lisp-mode-keymap* "C-Return" 'lisp-eval-at-point)
+(define-key *lisp-mode-keymap* "C-c i" 'lisp-eval-interrupt-at-point)
+
+(defun fold-one-line-message (message)
+  (let ((pos (position #\newline message)))
+    (if (not pos)
+        message
+        (format nil "~A..." (subseq message 0 pos)))))
+
+(defun buffer-eval-result-overlays (buffer)
+  (buffer-value buffer 'eval-result-overlays))
+
+(defun (setf buffer-eval-result-overlays) (value buffer)
+  (setf (buffer-value buffer 'eval-result-overlays) value))
+
+(defun clear-eval-results (buffer)
+  (mapc #'remove-eval-result-overlay
+        (buffer-eval-result-overlays buffer)))
+
+(defun remove-touch-overlay (start end old-len)
+  (declare (ignore old-len))
+  (remove-eval-result-overlay-between start end))
+
+(defun remove-eval-result-overlay (overlay)
+  (delete-overlay overlay)
+  (delete-overlay (overlay-get overlay 'relation-overlay))
+  (alexandria:removef (buffer-eval-result-overlays (overlay-buffer overlay))
+                      overlay))
+
+(defun remove-eval-result-overlay-between (start end)
+  (let ((buffer (point-buffer start)))
+    (dolist (ov (buffer-eval-result-overlays buffer))
+      (unless (or (point< end (overlay-start ov))
+                  (point< (overlay-end ov) start))
+        (delete-overlay ov)
+        (delete-overlay (overlay-get ov 'relation-overlay))
+        (alexandria:removef (buffer-eval-result-overlays buffer)
+                            ov)))))
+
+(defun display-spinner-message (spinner &optional message is-error)
+  (lem/loading-spinner:with-line-spinner-points (start end spinner)
+    (let ((popup-overlay 
+            (make-overlay start 
+                          end
+                          (if is-error
+                              'eval-error-attribute
+                              'eval-value-attribute)))
+          (background-overlay
+            (make-overlay start
+                          end
+                          (make-attribute :underline "white")))
+         (buffer (point-buffer start)))
+      (overlay-put popup-overlay 'relation-overlay background-overlay)
+      (overlay-put popup-overlay :display-line-end t)
+      (overlay-put popup-overlay :display-line-end-offset 1)
+      (overlay-put popup-overlay :text (fold-one-line-message message))
+      (push popup-overlay (buffer-eval-result-overlays buffer))
+      (add-hook (variable-value 'after-change-functions :buffer buffer)
+                'remove-touch-overlay))))
+
+(defun spinner-eval-request-id (spinner)
+  (lem/loading-spinner:spinner-value spinner 'eval-id))
+
+(defun (setf spinner-eval-request-id) (eval-id spinner)
+  (setf (lem/loading-spinner:spinner-value spinner 'eval-id) eval-id))
+
+(defun eval-last-expression (point)
+  (with-point ((start point)
+               (end point))
+    (skip-whitespace-backward end)
+    (form-offset start -1)
+    (remove-eval-result-overlay-between start end)
+    (let ((spinner (lem/loading-spinner:start-loading-spinner :region :start start :end end))
+          (string (points-to-string start end))
+          (request-id (lem-lisp-mode/swank-protocol::new-request-id (current-connection))))
+      (setf (spinner-eval-request-id spinner) request-id)
+      (lem-lisp-mode/internal::with-remote-eval
+          (`(micros:interactive-eval ,string) :request-id request-id)
+        (lambda (value)
+          (alexandria:destructuring-ecase value
+            ((:ok result)
+             (lem/loading-spinner:stop-loading-spinner spinner)
+             (display-spinner-message spinner result nil))
+            ((:abort condition)
+             (lem/loading-spinner:stop-loading-spinner spinner)
+             (display-spinner-message spinner condition t))))))))
+
+(define-command lisp-eval-at-point () ()
+  (check-connection)
+  (cond ((buffer-mark-p (current-buffer))
+         #+TODO
+         (eval-region (current-buffer)))
+        (t
+         (eval-last-expression (current-point)))))
+
+(define-command lisp-eval-interrupt-at-point () ()
+  (dolist (spinner (lem/loading-spinner:get-line-spinners (current-point)))
+    (let ((request-id (spinner-eval-request-id spinner)))
+      (lem-lisp-mode/swank-protocol::send-message (current-connection)
+                                                  `(:interrupt-thread ,request-id)))))

--- a/modes/lisp-mode/eval.lisp
+++ b/modes/lisp-mode/eval.lisp
@@ -9,8 +9,7 @@
   (t :foreground "sky blue" :bold t))
 
 (define-key *lisp-mode-keymap* "C-x C-e" 'lisp-eval-at-point)
-(define-key *lisp-mode-keymap* "M-Return" 'lisp-eval-at-point)
-(define-key *lisp-mode-keymap* "C-Return" 'lisp-eval-at-point)
+(define-key *lisp-mode-keymap* "C-c C-e" 'lisp-eval-at-point)
 (define-key *lisp-mode-keymap* "C-c i" 'lisp-eval-interrupt-at-point)
 
 (defun fold-one-line-message (message)

--- a/modes/lisp-mode/lem-lisp-mode.asd
+++ b/modes/lisp-mode/lem-lisp-mode.asd
@@ -31,6 +31,7 @@
                (:file "inspector")
                (:file "apropos-mode")
                (:file "autodoc")
+               (:file "eval")
                (:file "paren-coloring")
                (:file "misc-commands")
                (:file "package-inferred-system")

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -205,19 +205,22 @@
 (defun call-with-remote-eval (form continuation
                               &key (connection (current-connection))
                                    (thread (current-swank-thread))
-                                   (package (current-package)))
+                                   (package (current-package))
+                                   request-id)
   (remote-eval connection
                form
                :continuation continuation
                :thread thread
-               :package package))
+               :package package
+               :request-id request-id))
 
 (defmacro with-remote-eval ((form &rest args
                                   &key connection
                                        thread
-                                       package)
+                                       package
+                                       request-id)
                             continuation)
-  (declare (ignore connection thread package))
+  (declare (ignore connection thread package request-id))
   `(call-with-remote-eval ,form ,continuation ,@args))
 
 (defun lisp-eval-internal (emacs-rex-fun rex-arg package)

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -53,10 +53,8 @@
 
 (define-key *lisp-mode-keymap* "C-M-q" 'lisp-indent-sexp)
 (define-key *lisp-mode-keymap* "C-c M-p" 'lisp-set-package)
-(define-key *global-keymap* "M-:" 'self-lisp-eval-string)
+(define-key *global-keymap* "M-:" 'lisp-eval-string)
 (define-key *lisp-mode-keymap* "C-c M-:" 'lisp-eval-string)
-(define-key *global-keymap* "C-x C-e" 'self-lisp-eval-last-expression)
-(define-key *lisp-mode-keymap* "C-c C-e" 'lisp-eval-last-expression)
 (define-key *lisp-mode-keymap* "C-M-x" 'lisp-eval-defun)
 (define-key *lisp-mode-keymap* "C-c C-r" 'lisp-eval-region)
 (define-key *lisp-mode-keymap* "C-c C-n" 'lisp-next-compilation-notes)
@@ -399,17 +397,6 @@
   (check-connection)
   (interactive-eval string))
 
-(define-command lisp-eval-last-expression (p) ("P")
-  (check-connection)
-  (with-point ((start (current-point))
-               (end (current-point)))
-    (form-offset start -1)
-    (run-hooks (variable-value 'before-eval-functions) start end)
-    (let ((string (points-to-string start end)))
-      (if p
-          (eval-print string (- (window-width (current-window)) 2))
-          (interactive-eval string)))))
-
 (defun self-current-package ()
   (or (find (or *current-package*
                 (buffer-package (current-buffer))
@@ -418,47 +405,6 @@
             :test 'equalp
             :key 'package-name)
       *package*))
-
-(defmacro with-eval ((&key (values (gensym) values-p)
-                           (stream (error ":stream missing")))
-                     &body body)
-  (alexandria:with-gensyms (io)
-    `(with-open-stream (,io ,stream)
-       (let* ((*package* (self-current-package))
-              (*terminal-io* ,io)
-              (*standard-output* ,io)
-              (*standard-input* ,io)
-              (*error-output* ,io)
-              (*query-io* ,io)
-              (*debug-io* ,io)
-              (*trace-output* ,io)
-              (*terminal-io* ,io)
-              (,values (multiple-value-list (eval (read-from-string string)))))
-         ,@(if (not values-p) `((declare (ignorable ,values))))
-         ,@body))))
-
-(defun self-interactive-eval (string)
-  (with-eval (:values values :stream (make-editor-io-stream))
-    (display-message "=> ~{~S~^, ~}" values)))
-
-(defun self-eval-print (string &optional print-right-margin)
-  (declare (ignore print-right-margin))
-  (with-eval (:values values :stream (make-buffer-output-stream (current-point)))
-    (insert-string (current-point) (format nil "~{~S~^~%~}" values))))
-
-(define-command self-lisp-eval-string (string)
-    ((prompt-for-sexp "Lisp Eval: "))
-  (self-interactive-eval string))
-
-(define-command self-lisp-eval-last-expression (p) ("P")
-  (with-point ((start (current-point))
-               (end (current-point)))
-    (form-offset start -1)
-    (run-hooks (variable-value 'before-eval-functions) start end)
-    (let ((string (points-to-string start end)))
-      (if p
-          (self-eval-print string (- (window-width (current-window)) 2))
-          (self-interactive-eval string)))))
 
 (define-command lisp-eval-defun () ()
   "Evaluate top-level form around point and instrument."


### PR DESCRIPTION
https://github.com/lem-project/lem/assets/13656378/6a8bf3da-73a0-4db9-b216-d940792b0878

I implemented command to evaluate the expression at the cursor position.

`M-x lisp-eval-at-point (C-x C-e)`: Evaluates the expression in backward of the cursor or the range if a region is selected.
`M-x lisp-eval-interrupt-at-point (C-c i)`: Interrupts the evaluation of the cursor position.

The display after evaluation can be erased on the hook of an operation to edit the range.
