### PR TITLE
project: add keybindings (C-x p f)

### DIFF
--- a/src/commands/project.lisp
+++ b/src/commands/project.lisp
@@ -14,6 +14,10 @@
 
 (in-package :lem-core/commands/project)
 
+(define-key *global-keymap* "C-x p f" 'project-find-file)
+(define-key *global-keymap* "C-x p d" 'project-root-directory)
+(define-key *global-keymap* "C-x p K" 'project-delete-buffers)
+
 (defvar *root-directories*
   (list
    ".git"

--- a/src/commands/window.lisp
+++ b/src/commands/window.lisp
@@ -52,6 +52,7 @@
 (define-key *global-keymap* "C-x 4 f" 'find-file-other-window)
 (define-key *global-keymap* "C-x 4 r" 'read-file-other-window)
 (define-key *global-keymap* "C-x 4 b" 'select-buffer-other-window)
+(define-key *global-keymap* "C-x 4 p f" 'project-find-file-other-window)
 
 (defvar *balance-after-split-window* t)
 


### PR DESCRIPTION
I propose to add default keybindings.

C-x p f is modeled after Emacs' project.el, but

C-x p d (open directory) and C-x p K (upper case k) differ. There is no confirmation prompt to delete the project buffers, so I put it further away with the uppercase letter.

That being said… maybe it should with a "D", like "Delete", or rename the command to `project-kill-buffers`, like `kill-buffer`?

Emacs' C-x p d is project-find-dir, which we can do in Lem with project-find-file (it includes subdirectories).