### PR TITLE
vindarel/directory-sort-by-size

### DIFF
--- a/src/base/file-utils.lisp
+++ b/src/base/file-utils.lisp
@@ -75,6 +75,8 @@
   (cond
     ((eql sort-method :mtime)
      (sort-files files :test #'> :key #'file-mtime))
+    ((eql sort-method :size)
+     (sort-files files :test #'> :key #'file-size))
     (t
      (sort-files files))))
 

--- a/src/base/file-utils.lisp
+++ b/src/base/file-utils.lisp
@@ -96,6 +96,8 @@
                                                     :sort-method sort-method))))))
 
 (defun file-size (pathname)
+  #+sbcl
+  (sb-posix:stat-size (sb-posix:stat pathname))
   #+lispworks
   (system:file-size pathname)
   #+(and (not lispworks) win32)

--- a/src/ext/directory-mode.lisp
+++ b/src/ext/directory-mode.lisp
@@ -7,13 +7,13 @@
 (in-package :lem/directory-mode)
 
 (deftype sort-method ()
-  '(member :pathname :mtime))
+  '(member :pathname :mtime :size))
 
 (declaim (type (sort-method) *default-sort-method*))
 (defvar *default-sort-method* :pathname
   "Default method to sort files when opening a directory.
 
-  A keyword, one of :pathname (sort by file name) and :mtime (last modification time).")
+  A keyword, one of :pathname (sort by file name), :mtime (last modification time) and :size.")
 
 (define-attribute header-attribute
   (:light :foreground "dark green")
@@ -431,12 +431,18 @@
   (update-all))
 
 (define-command directory-mode-sort-files () ()
-  "Sort files: by name, then by last modification time.
+  "Sort files: by name, by last modification time, then by size.
 
   Each new directory buffer first uses the default sort method (`lem/directory-mode:*default-sort-method*')"
   (cond
+    ;; mtime -> size
     ((eql (buffer-value (current-buffer) :sort-method) :mtime)
-     (message "Sorting by file name")
+     (message "Sorting by size")
+     (setf (buffer-value (current-buffer) :sort-method) :size)
+     (update (current-buffer) :sort-method :size))
+    ;; size -> pathname
+    ((eql (buffer-value (current-buffer) :sort-method) :size)
+     (message "Sorting by name")
      (setf (buffer-value (current-buffer) :sort-method) :pathname)
      (update (current-buffer) :sort-method :pathname))
     (t


### PR DESCRIPTION
I added a third sort method on the "s" key, sorting by file size.

It's handy, but there might be a usability concern: pressing "s" twice doesn't get us back to normal and there is no visual clue about the current sort order (only the message that disappears).

One possibility could be sorting by size with another key like "S" (capital s), but it won't be discoverable by Emacs users (and by the way, sorting by size is a surprisingly difficult feature in Emacs' Dired IMO, which is to be done with a third-party package).. Also, "S" is to create a symlink in Dired. I probably should investigate a visual clue.