### PR TITLE
projects: save and switch projects

### DIFF
--- a/src/commands/file.lisp
+++ b/src/commands/file.lisp
@@ -205,7 +205,7 @@
        :test-function (lambda (name) (member name candidates :test #'string=))))))
 
 (define-command find-file-recursively (arg) ("p")
-  "Open a file, from the list of all files present under the buffer's direcotry, recursively."
+  "Open a file, from the list of all files present under the buffer's directory, recursively."
   ;; ARG is currently not used, use it when needed.
   (declare (ignorable arg))
   (let ((cwd (buffer-directory)))

--- a/src/commands/project.lisp
+++ b/src/commands/project.lisp
@@ -10,14 +10,14 @@
            :project-root-directory
            :project-root
            :project-kill-buffers)
-  (:documentation "Defines utilities to find a project root directory and related user-facing commands: project-find-file, project-kill-buffers, project-switch-project etc."))
+  (:documentation "Defines utilities to find a project root directory and related user-facing commands: project-find-file, project-kill-buffers, project-switch etc."))
 
 (in-package :lem-core/commands/project)
 
 (define-key *global-keymap* "C-x p f" 'project-find-file)
 (define-key *global-keymap* "C-x p d" 'project-root-directory)
 (define-key *global-keymap* "C-x p K" 'project-kill-buffers)
-(define-key *global-keymap* "C-x p p" 'project-switch-project)
+(define-key *global-keymap* "C-x p p" 'project-switch)
 (define-key *global-keymap* "C-x p s" 'project-save)
 (define-key *global-keymap* "C-x p u" 'project-unsave)
 
@@ -295,7 +295,7 @@
           (message "No projects.~&~
                    Use project-save to save a project accross sessions.")))))
 
-(define-command project-switch-project () ()
+(define-command project-switch () ()
   "Prompt for a saved project and find a file in this project."
   (let ((project-root (prompt-for-project)))
     (when project-root

--- a/src/commands/project.lisp
+++ b/src/commands/project.lisp
@@ -10,13 +10,16 @@
            :project-root-directory
            :project-root
            :project-kill-buffers)
-  (:documentation "Defines utilities to find a project root directory and related user-facing commands: project-find-file, project-kill-buffers etc."))
+  (:documentation "Defines utilities to find a project root directory and related user-facing commands: project-find-file, project-kill-buffers, project-switch-project etc."))
 
 (in-package :lem-core/commands/project)
 
 (define-key *global-keymap* "C-x p f" 'project-find-file)
 (define-key *global-keymap* "C-x p d" 'project-root-directory)
 (define-key *global-keymap* "C-x p K" 'project-kill-buffers)
+(define-key *global-keymap* "C-x p p" 'project-switch-project)
+(define-key *global-keymap* "C-x p s" 'project-save)
+(define-key *global-keymap* "C-x p u" 'project-unsave)
 
 (defvar *root-directories*
   (list
@@ -221,3 +224,85 @@
                                        (incf count))))
       (delete-buffers (list-project-buffers)))
     (message "~a buffers deleted." count)))
+
+
+
+(defvar *projects-history*)
+
+(defun history ()
+  "Return or create the projects' history struct.
+  The history file is saved on (lem-home)/history/projects"
+  (unless (boundp '*projects-history*)
+    (let* ((pathname (merge-pathnames "history/projects" (lem-home)))
+           (history (lem/common/history:make-history :pathname pathname)))
+      (setf *projects-history* history)))
+  *projects-history*)
+
+(defun remember-project (input)
+  "Add this project path to the history file.
+  Return t if the project was added, nil if it already existed."
+  (let* ((history (history))
+         (data (lem/common/history:history-data history))
+         ;; project roots (pathnames) are converted to strings for the
+         ;; string completion prompt.
+         (input (namestring input)))
+    (cond
+      ((not (find input data :test #'equal))
+       (lem/common/history:add-history history input)
+       (lem/common/history:save-file history)
+       input)
+      (:otherwise
+       nil))))
+
+(defun forget-project (input)
+  "Remove this project (string) from the projects' history file.
+  Return the input."
+  (let ((history (history)))
+    (lem/common/history:remove-history history input)
+    (lem/common/history:save-file history)
+    input))
+
+(defun saved-projects ()
+  "Return the saved projects.
+  Return: a list (of strings), not a vector."
+  (coerce
+   (lem/common/history:history-data (history))
+   'list))
+
+(define-command project-save () ()
+  "Remember the current project for later sessions."
+  (if (remember-project (find-root (buffer-directory)))
+      (message "Project saved.")
+      (message "Already saved.")))
+
+(define-command project-unsave () ()
+  "Prompt for a project and remove it from the list of saved projects."
+  (let ((choice (prompt-for-project)))
+    (and
+     (forget-project choice)
+     (lem/common/history:save-file (history))
+     (message "Project removed."))))
+
+(defun prompt-for-project ()
+  "Prompt for a project saved in the projects history."
+  (let ((candidates (saved-projects)))
+    (if candidates
+        (prompt-for-string
+         "Project: "
+         :completion-function (lambda (x) (completion-strings x candidates))
+         :test-function (lambda (name) (member name candidates :test #'string=)))
+        (let ((lem-core::*message-timeout* 5))
+          (message "No projects.~&~
+                   Use project-save to save a project accross sessions.")))))
+
+(define-command project-switch-project () ()
+  "Prompt for a saved project and find a file in this project."
+  (let ((project-root (prompt-for-project)))
+    (when project-root
+      (uiop:with-current-directory (project-root)
+        (let ((filename (prompt-for-files-recursively)))
+          (alexandria:when-let (buffer (execute-find-file *find-file-executor*
+                                                          (lem-core/commands/file::get-file-mode filename)
+                                                          filename))
+            (when buffer
+              (switch-to-buffer buffer t nil))))))))

--- a/src/common/history.lisp
+++ b/src/common/history.lisp
@@ -1,9 +1,12 @@
 (defpackage :lem/common/history
   (:use :cl)
   (:export :make-history
+           :history-pathname
+           :history-data
            :save-file
            :last-history
            :add-history
+           :remove-history
            :previous-history
            :next-history
            :previous-matching
@@ -21,6 +24,7 @@
   edit-string)
 
 (defun require-additions-to-history-p (input last-input)
+  "Return t if the current input is valid and different than the previous input."
   (and (not (equal input last-input))
        (not (equal input ""))))
 
@@ -56,6 +60,13 @@
   (setf (history-index history)
         (length (history-data history)))
   input)
+
+(defun remove-history (history input)
+  (let* ((new (remove input (history-data history) :test #'equal))
+         (len (length new))
+         (array (make-array len :fill-pointer len :adjustable t :initial-contents new)))
+    (setf (history-data history) array)
+    (setf (history-index history) len)))
 
 (defun previous-history (history)
   (when (< 0 (history-index history))


### PR DESCRIPTION
Continuing the projects feature:

- introduces a command to save the current project in the history, on disk
 -  => (this could be improved further with automatic project discovery later on)
- then project-switch-project prompts to choose a project, then calls project-find-file.

Keybindings: `C-x p p` is similar to Emacs' project.el, the other two on "s" and "u" are not.

In the future, it could be nice to have a setting to choose if we want automatic collecting of projects in the history, each time we visite a file in a new project (it would be the default), or not, if we prefer to have a small list of saved projects and use the "save" command ourselves (as it is the case now).