### PR TITLE
Make `M-q` the key binding for the standard close operation

### DIFF
--- a/modes/lisp-mode/apropos-mode.lisp
+++ b/modes/lisp-mode/apropos-mode.lisp
@@ -14,6 +14,7 @@
   (t :bold t))
 
 (define-key *lisp-apropos-mode-keymap* "q" 'quit-active-window)
+(define-key *lisp-apropos-mode-keymap* "M-q" 'quit-active-window)
 (define-key *lisp-apropos-mode-keymap* "Return" 'lem/language-mode::find-definitions)
 
 (defun show-apropos (data package)

--- a/modes/lisp-mode/inspector.lisp
+++ b/modes/lisp-mode/inspector.lisp
@@ -32,6 +32,7 @@
 (define-key *lisp-inspector-keymap* "." 'lisp-inspector-show-source)
 (define-key *lisp-inspector-keymap* ">" 'lisp-inspector-fetch-all)
 (define-key *lisp-inspector-keymap* "q" 'lisp-inspector-quit)
+(define-key *lisp-inspector-keymap* "M-q" 'lisp-inspector-quit)
 (define-key *lisp-inspector-keymap* "M-Return" 'lisp-inspector-copy-down-to-repl)
 (define-key *lisp-inspector-keymap* "C-Return" 'lisp-inspector-copy-down-to-repl)
 

--- a/modes/lisp-mode/sldb.lisp
+++ b/modes/lisp-mode/sldb.lisp
@@ -37,6 +37,7 @@
 (define-key *sldb-keymap* "M-n" 'sldb-details-down)
 (define-key *sldb-keymap* "M-p" 'sldb-details-up)
 (define-key *sldb-keymap* "q" 'sldb-quit)
+(define-key *sldb-keymap* "M-q" 'sldb-quit)
 (define-key *sldb-keymap* "c" 'sldb-continue)
 (define-key *sldb-keymap* "a" 'sldb-abort)
 (define-key *sldb-keymap* "r" 'sldb-restart-frame)

--- a/modes/lisp-mode/ui-mode.lisp
+++ b/modes/lisp-mode/ui-mode.lisp
@@ -18,6 +18,7 @@
 (define-key *lisp-ui-keymap* "Return" 'lisp-ui-default-action)
 (define-key *lisp-ui-keymap* "Tab" 'lisp-ui-forward-button)
 (define-key *lisp-ui-keymap* "q" 'quit-active-window)
+(define-key *lisp-ui-keymap* "M-q" 'quit-active-window)
 
 (define-command lisp-ui-default-action () ()
   (let ((button (button-at (current-point))))

--- a/src/commands/window.lisp
+++ b/src/commands/window.lisp
@@ -41,6 +41,7 @@
 (define-key *global-keymap* "M-o" 'other-window)
 (define-key *global-keymap* "C-x 1" 'delete-other-windows)
 (define-key *global-keymap* "C-x 0" 'delete-active-window)
+(define-key *global-keymap* "M-q" 'delete-active-window)
 (define-key *global-keymap* "C-x ^" 'grow-window)
 (define-key *global-keymap* "C-x C-z" 'shrink-window)
 (define-key *global-keymap* "C-x }" 'grow-window-horizontally)

--- a/src/ext/directory-mode.lisp
+++ b/src/ext/directory-mode.lisp
@@ -36,6 +36,7 @@
   (setf (variable-value 'highlight-line :buffer (current-buffer)) nil))
 
 (define-key *directory-mode-keymap* "q" 'quit-active-window)
+(define-key *directory-mode-keymap* "M-q" 'quit-active-window)
 (define-key *directory-mode-keymap* "g" 'directory-mode-update-buffer)
 (define-key *directory-mode-keymap* "^" 'directory-mode-up-directory)
 (define-key *directory-mode-keymap* "Return" 'directory-mode-find-file)

--- a/src/typeout.lisp
+++ b/src/typeout.lisp
@@ -7,6 +7,7 @@
                     (setf (variable-value 'line-wrap :buffer (current-buffer)) nil))))
 
 (define-key *typeout-mode-keymap* "q" 'dismiss-typeout-window)
+(define-key *typeout-mode-keymap* "M-q" 'dismiss-typeout-window)
 (define-key *typeout-mode-keymap* "Space" 'next-page-or-dismiss-typeout-window)
 (define-key *typeout-mode-keymap* "Backspace" 'previous-page)
 (define-key *typeout-mode-keymap* 'delete-active-window 'dismiss-typeout-window)


### PR DESCRIPTION
There were inconsistent key bindings for exiting a state, such as "q" for typeout-window and directory-mode, and `C-x 0` for peek-source window.
In this PR, M-q has been changed to be a close operation to make it consistent.