### PR TITLE
Allow hover to focus

### DIFF
--- a/src/ext/hover.lisp
+++ b/src/ext/hover.lisp
@@ -25,4 +25,6 @@
   (setf *hover-window*
         (display-popup-message buffer-or-string
                                :timeout nil
-                               :style '(:gravity :cursor))))
+                               :style '(:gravity :cursor)))
+  (setf (floating-window-focusable-p *hover-window*) t)
+  (values))

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -261,6 +261,7 @@
    :floating-window
    :floating-window-border
    :floating-window-border-shape
+   :floating-window-focusable-p
    :floating-window-p
    :side-window
    :make-leftside-window

--- a/src/window.lisp
+++ b/src/window.lisp
@@ -191,6 +191,8 @@
            (active-prompt-window))
           (alexandria:ensure-list
            (frame-leftside-window (current-frame)))
+          (remove-if-not #'floating-window-focusable-p
+                         (frame-floating-windows (current-frame)))
           (window-list)))
 
 (defun one-window-p ()
@@ -1150,7 +1152,10 @@ You can pass in the optional argument WINDOW-LIST to replace the default
    (background-color
     :initarg :background-color
     :initform nil
-    :reader floating-window-background-color)))
+    :reader floating-window-background-color)
+   (focusable
+    :initform nil
+    :accessor floating-window-focusable-p)))
 
 (defmethod initialize-instance :before ((floating-window floating-window) &rest initargs)
   (declare (ignore initargs))


### PR DESCRIPTION
Until now, only the mouse could focus on the window displayed by the `M-x lisp-describe-symbol (C-c C-d d)` command, but now you can switch to that window with other-window.