### PR TITLE
Associate object with printed in REPL

### DIFF
--- a/modes/lisp-mode/message-definitions.lisp
+++ b/modes/lisp-mode/message-definitions.lisp
@@ -6,6 +6,9 @@
   (when thread
     (send-message *connection* `(:write-done ,thread))))
 
+(define-message (:write-object string id)
+  (write-object-to-repl string id))
+
 (define-message (:read-string thread tag)
   (repl-read-string thread tag))
 

--- a/modes/lisp-mode/message-definitions.lisp
+++ b/modes/lisp-mode/message-definitions.lisp
@@ -6,8 +6,8 @@
   (when thread
     (send-message *connection* `(:write-done ,thread))))
 
-(define-message (:write-object string id)
-  (write-object-to-repl string id))
+(define-message (:write-object string id type)
+  (write-object-to-repl string id type))
 
 (define-message (:read-string thread tag)
   (repl-read-string thread tag))

--- a/modes/lisp-mode/repl.lisp
+++ b/modes/lisp-mode/repl.lisp
@@ -4,6 +4,10 @@
   (:dark :foreground "white" :bold t)
   (:light :foreground "black" :bold t))
 
+(define-attribute repl-result-attribute
+  (:dark :foreground "red" :bold t)
+  (:light :foreground "black" :bold t))
+
 (define-major-mode lisp-repl-mode lisp-mode
     (:name "REPL"
      :keymap *lisp-repl-mode-keymap*
@@ -270,13 +274,16 @@
       (insert-character point #\newline)
       (character-offset point -1))))
 
-(defun write-object-to-repl (string id)
+(defun write-object-to-repl (string id type)
+  (assert (member type '(:standard-output :repl-result)))
   (with-repl-point (point)
     (with-point ((start point))
       (insert-string point
                      string
                      'object-id id
-                     :attribute 'printed-object-attribute)
+                     :attribute (if (eq type :repl-result)
+                                    'printed-object-attribute
+                                    'repl-result-attribute))
       (lem/button:apply-button-between-points
        start
        point

--- a/modes/lisp-mode/repl.lisp
+++ b/modes/lisp-mode/repl.lisp
@@ -47,6 +47,12 @@
            (insert-character (current-point) #\newline)
            (indent-line (current-point))))))
 
+(defmethod execute :before
+    ((mode lisp-repl-mode)
+     (command lem/listener-mode:listener-clear-buffer)
+     argument)
+  (lisp-eval-async '(micros:clear-printed-objects)))
+
 (defvar *lisp-repl-shortcuts* '())
 
 (defun prompt-for-shortcuts ()

--- a/modes/lisp-mode/repl.lisp
+++ b/modes/lisp-mode/repl.lisp
@@ -37,11 +37,14 @@
                                    :repl-thread))))
 
 (defmethod execute ((mode lisp-repl-mode) (command lem/listener-mode:listener-return) argument)
-  (cond ((repl-paren-correspond-p (buffer-end-point (current-buffer)))
-         (call-next-method))
-        (t
-         (insert-character (current-point) #\newline)
-         (indent-line (current-point)))))
+  (let (button)
+    (cond ((setf button (button-at (current-point)))
+           (button-action button))
+          ((repl-paren-correspond-p (buffer-end-point (current-buffer)))
+           (call-next-method))
+          (t
+           (insert-character (current-point) #\newline)
+           (indent-line (current-point))))))
 
 (defvar *lisp-repl-shortcuts* '())
 
@@ -267,12 +270,13 @@
                      string
                      'object-id id
                      :attribute 'printed-object-attribute)
-      (lem-core::set-clickable start
-                               point
-                               (lambda (window point)
-                                 (declare (ignore window point))
-                                 (lisp-eval-async `(micros:inspect-printed-object ,id)
-                                                  #'open-inspector))))))
+      (lem/button:apply-button-between-points
+       start
+       point
+       (lambda (&rest args)
+         (declare (ignore args))
+         (lisp-eval-async `(micros:inspect-printed-object ,id)
+                          #'open-inspector))))))
 
 (defvar *escape-sequence-argument-specs*
   '(("0" :bold nil :reverse nil :underline nil)

--- a/modes/lisp-mode/repl.lisp
+++ b/modes/lisp-mode/repl.lisp
@@ -1,7 +1,8 @@
 (in-package :lem-lisp-mode/internal)
 
 (define-attribute printed-object-attribute
-  (t :foreground "light cyan"))
+  (:dark :foreground "white" :bold t)
+  (:light :foreground "black" :bold t))
 
 (define-major-mode lisp-repl-mode lisp-mode
     (:name "REPL"

--- a/modes/lisp-mode/repl.lisp
+++ b/modes/lisp-mode/repl.lisp
@@ -5,7 +5,7 @@
   (:light :foreground "black" :bold t))
 
 (define-attribute repl-result-attribute
-  (:dark :foreground "red" :bold t)
+  (:dark :foreground "aquamarine" :bold t)
   (:light :foreground "black" :bold t))
 
 (define-major-mode lisp-repl-mode lisp-mode
@@ -282,8 +282,8 @@
                      string
                      'object-id id
                      :attribute (if (eq type :repl-result)
-                                    'printed-object-attribute
-                                    'repl-result-attribute))
+                                    'repl-result-attribute
+                                    'printed-object-attribute))
       (lem/button:apply-button-between-points
        start
        point

--- a/modes/lisp-mode/repl.lisp
+++ b/modes/lisp-mode/repl.lisp
@@ -250,28 +250,29 @@
       (let ((*inhibit-read-only* t))
         (funcall function point)))))
 
+(defmacro with-repl-point ((point) &body body)
+  `(call-with-repl-point (lambda (,point) ,@body)))
+
 (defun write-string-to-repl (string)
-  (call-with-repl-point
-   (lambda (point)
-     (insert-escape-sequence-string point string)
-     (when (text-property-at point :field)
-       (insert-character point #\newline)
-       (character-offset point -1)))))
+  (with-repl-point (point)
+    (insert-escape-sequence-string point string)
+    (when (text-property-at point :field)
+      (insert-character point #\newline)
+      (character-offset point -1))))
 
 (defun write-object-to-repl (string id)
-  (call-with-repl-point
-   (lambda (point)
-     (with-point ((start point))
-       (insert-string point
-                      string
-                      'object-id id
-                      :attribute 'printed-object-attribute)
-       (lem-core::set-clickable start
-                                point
-                                (lambda (window point)
-                                  (declare (ignore window point))
-                                  (lisp-eval-async `(micros:inspect-printed-object ,id)
-                                                   #'open-inspector)))))))
+  (with-repl-point (point)
+    (with-point ((start point))
+      (insert-string point
+                     string
+                     'object-id id
+                     :attribute 'printed-object-attribute)
+      (lem-core::set-clickable start
+                               point
+                               (lambda (window point)
+                                 (declare (ignore window point))
+                                 (lisp-eval-async `(micros:inspect-printed-object ,id)
+                                                  #'open-inspector))))))
 
 (defvar *escape-sequence-argument-specs*
   '(("0" :bold nil :reverse nil :underline nil)

--- a/modes/lisp-mode/swank-protocol.lisp
+++ b/modes/lisp-mode/swank-protocol.lisp
@@ -212,10 +212,6 @@ Parses length information to determine how many characters to read."
           (getf (getf data :package) :prompt)
           ))
 
-  ;; Start it up
-  (log:debug "Initializing presentations")
-  (read-return-message connection)
-
   (log:debug "Creating the REPL")
   (remote-eval-from-string connection "(micros/repl:create-repl nil :coding-system \"utf-8-unix\")")
   ;; Wait for startup

--- a/modes/lisp-mode/swank-protocol.lisp
+++ b/modes/lisp-mode/swank-protocol.lisp
@@ -214,7 +214,6 @@ Parses length information to determine how many characters to read."
 
   ;; Start it up
   (log:debug "Initializing presentations")
-  (remote-eval-from-string connection "(micros:init-presentations)")
   (read-return-message connection)
 
   (log:debug "Creating the REPL")

--- a/src/ext/button.lisp
+++ b/src/ext/button.lisp
@@ -5,6 +5,7 @@
            :button-end
            :button-get
            :insert-button
+           :apply-button-between-points
            :button-action
            :forward-button
            :backward-button
@@ -38,6 +39,10 @@
            (if button-tag
                `(,button-tag t)
                '()))))
+
+(defun apply-button-between-points (start end callback)
+  (lem-core::set-clickable start end callback)
+  (put-text-property start end 'button (make-button :callback callback)))
 
 (defun button-action (button)
   (funcall (button-callback button)))


### PR DESCRIPTION
[Screencast from 2023-06-25 00-31-23.webm](https://github.com/lem-project/lem/assets/13656378/002dd97c-5af5-4951-b3a9-679fa1c376c8)

This feature is an alternative to slime-presentation.

- You can inspect objects printed by micros:micros-print
- You can inspect the evaluation results
- You can also perform actions in the context menu by right-clicking