### PR TITLE
SDL2: change renderer option from `accelerated` to `software`

### DIFF
--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -749,7 +749,7 @@
                                        :w window-width
                                        :h window-height
                                        :flags '(:shown :resizable))
-               (sdl2:with-renderer (renderer window :index -1 :flags '(:accelerated))
+               (sdl2:with-renderer (renderer window :index -1 :flags '(:software))
                  (let ((texture (create-texture renderer
                                                 window-width
                                                 window-height)))


### PR DESCRIPTION
I had a problem with SDL2 frontend not working on some GPUs.
https://github.com/lem-project/lem/issues/754
https://github.com/lem-project/lem/issues/690
https://github.com/lem-project/lem/issues/630

My environment is AMD Radeon and I had the same problem when I installed the driver with amdgpu-install.
After some trial and error, I changed the renderer option from accelerated to software and it works.