### PR TITLE
Add imenu (detective) support for Lem

### DIFF
--- a/lem.asd
+++ b/lem.asd
@@ -125,7 +125,8 @@
                              (:file "frame-multiplexer")
                              (:file "filer")
                              (:file "deepl")
-                             (:file "themes")))))
+                             (:file "themes")
+                             (:file "detective")))))
 
 (defsystem "lem/extensions"
   :depends-on (#+sbcl

--- a/modes/lisp-mode/detective.lisp
+++ b/modes/lisp-mode/detective.lisp
@@ -1,0 +1,32 @@
+(defpackage :lem-lisp-mode/detective
+  (:use :cl :lem)
+  (:export :capture-reference))
+
+(in-package :lem-lisp-mode/detective)
+
+(defun %default-capture (class position)
+  (let* ((line (str:split #\Space (line-string position)))
+         (name (second line)))
+    (make-instance class
+                   :reference-name name
+                   :reference-point position)))
+
+(defmethod capture-reference ((position lem:point) (class (eql :function-reference)))
+  (let* ((line (str:split #\Space (line-string position)))
+         (pname (second line))
+         (name (or (and (str:starts-with-p "(setf" pname)
+                        (str:concat pname " " (third line)))
+                   pname)))
+    (make-instance 'lem/detective:function-reference
+                   :reference-name name
+                   :reference-point position)))
+
+(defmethod capture-reference ((position lem:point) (class (eql :class-reference)))
+  (%default-capture 'lem/detective:class-reference position))
+
+(defmethod capture-reference ((position lem:point) (class (eql :variable-reference)))
+  (%default-capture 'lem/detective:variable-reference position))
+
+(defmethod capture-reference ((position lem:point) (class (eql :package-reference)))
+  (%default-capture 'lem/detective:package-reference position))
+

--- a/modes/lisp-mode/lem-lisp-mode.asd
+++ b/modes/lisp-mode/lem-lisp-mode.asd
@@ -22,6 +22,7 @@
                (:file "internal-package")
                (:file "completion")
                (:file "message")
+               (:file "detective")
                (:file "file-conversion")
                (:file "lisp-mode")
                (:file "message-definitions")

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -44,21 +44,21 @@
   (setf (variable-value 'idle-function) 'lisp-idle-function)
   (setf (variable-value 'root-uri-patterns) '(".asd"))
   (setf (variable-value 'detective-search) 
-        (make-instance 'lem/detective::search-regex 
+        (make-instance 'lem/detective:search-regex
                        :function-regex
-                       (lem/detective::make-capture-regex 
+                       (lem/detective:make-capture-regex
                         :regex "^\\(defun "
                         :function #'capture-reference)
                        :class-regex
-                       (lem/detective::make-capture-regex
+                       (lem/detective:make-capture-regex
                         :regex "^\\(defclass "
                         :function #'capture-reference)
                        :package-regex
-                       (lem/detective::make-capture-regex
+                       (lem/detective:make-capture-regex
                         :regex "^\\(in-package "
                         :function #'capture-reference)
 		       :variable-regex
-                       (lem/detective::make-capture-regex
+                       (lem/detective:make-capture-regex
                         :regex "^\\(defvar |\\(defparameter "
                         :function #'capture-reference)))
   (set-syntax-parser lem-lisp-syntax:*syntax-table*
@@ -1217,21 +1217,21 @@
          (name (or (and (str:starts-with-p "(setf" pname)
                         (str:concat pname " " (third line)))
                    pname)))
-    (make-instance 'lem/detective::function-reference
+    (make-instance 'lem/detective:function-reference
                    :reference-name name
                    :reference-point position)))
 
 (defmethod capture-reference ((position lem:point) (class (eql :class-reference)))
   (let* ((line (str:split #\Space (line-string position)))
          (name (second line)))
-    (make-instance 'lem/detective::class-reference
+    (make-instance 'lem/detective:class-reference
                    :reference-name name
                    :reference-point position)))
 
 (defmethod capture-reference ((position lem:point) (class (eql :variable-reference)))
   (let* ((line (str:split #\Space (line-string position)))
          (name (second line)))
-    (make-instance 'lem/detective::variable-reference
+    (make-instance 'lem/detective:variable-reference
                    :reference-name name
                    :reference-point position
                    :variable-reference-value (third line))))
@@ -1239,7 +1239,7 @@
 (defmethod capture-reference ((position lem:point) (class (eql :package-reference)))
   (let* ((line (str:split #\Space (line-string position)))
          (name (second line)))
-    (make-instance 'lem/detective::package-reference
+    (make-instance 'lem/detective:package-reference
                    :reference-name name
                    :reference-point position)))
 

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -50,8 +50,16 @@
                         :regex "^\\(defun "
                         :function #'capture-reference)
                        :class-regex
-                       (lem/detective::make-capture-regex 
+                       (lem/detective::make-capture-regex
                         :regex "^\\(defclass "
+                        :function #'capture-reference)
+                       :package-regex
+                       (lem/detective::make-capture-regex
+                        :regex "^\\(in-package "
+                        :function #'capture-reference)
+		       :variable-regex
+                       (lem/detective::make-capture-regex
+                        :regex "^\\(defvar |\\(defparameter "
                         :function #'capture-reference)))
   (set-syntax-parser lem-lisp-syntax:*syntax-table*
                      (make-tmlanguage-lisp))
@@ -1217,6 +1225,21 @@
   (let* ((line (str:split #\Space (line-string position)))
          (name (second line)))
     (make-instance 'lem/detective::class-reference
+                   :reference-name name
+                   :reference-point position)))
+
+(defmethod capture-reference ((position lem:point) (class (eql :variable-reference)))
+  (let* ((line (str:split #\Space (line-string position)))
+         (name (second line)))
+    (make-instance 'lem/detective::variable-reference
+                   :reference-name name
+                   :reference-point position
+                   :variable-reference-value (third line))))
+
+(defmethod capture-reference ((position lem:point) (class (eql :package-reference)))
+  (let* ((line (str:split #\Space (line-string position)))
+         (name (second line)))
+    (make-instance 'lem/detective::package-reference
                    :reference-name name
                    :reference-point position)))
 

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -48,6 +48,10 @@
                        :function-regex
                        (lem/detective::make-capture-regex 
                         :regex "^\\(defun "
+                        :function #'capture-reference)
+                       :class-regex
+                       (lem/detective::make-capture-regex 
+                        :regex "^\\(defclass "
                         :function #'capture-reference)))
   (set-syntax-parser lem-lisp-syntax:*syntax-table*
                      (make-tmlanguage-lisp))
@@ -1206,6 +1210,13 @@
                         (str:concat pname " " (third line)))
                    pname)))
     (make-instance 'lem/detective::function-reference
+                   :reference-name name
+                   :reference-point position)))
+
+(defmethod capture-reference ((position lem:point) (class (eql :class-reference)))
+  (let* ((line (str:split #\Space (line-string position)))
+         (name (second line)))
+    (make-instance 'lem/detective::class-reference
                    :reference-name name
                    :reference-point position)))
 

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -48,19 +48,19 @@
                        :function-regex
                        (lem/detective:make-capture-regex
                         :regex "^\\(defun "
-                        :function #'capture-reference)
+                        :function #'lem-lisp-mode/detective:capture-reference)
                        :class-regex
                        (lem/detective:make-capture-regex
                         :regex "^\\(defclass "
-                        :function #'capture-reference)
+                        :function #'lem-lisp-mode/detective:capture-reference)
                        :package-regex
                        (lem/detective:make-capture-regex
                         :regex "^\\(in-package "
-                        :function #'capture-reference)
+                        :function #'lem-lisp-mode/detective:capture-reference)
 		       :variable-regex
                        (lem/detective:make-capture-regex
                         :regex "^(?:\\(defvar |\\(defparameter )"
-                        :function #'capture-reference)))
+                        :function #'lem-lisp-mode/detective:capture-reference)))
   (set-syntax-parser lem-lisp-syntax:*syntax-table*
                      (make-tmlanguage-lisp))
   (unless (connected-p) (self-connect))
@@ -1210,38 +1210,6 @@
 
 (add-hook (variable-value 'before-eval-functions :global)
           'highlight-evaluation-region)
-
-(defmethod capture-reference ((position lem:point) (class (eql :function-reference)))
-  (let* ((line (str:split #\Space (line-string position)))
-         (pname (second line))
-         (name (or (and (str:starts-with-p "(setf" pname)
-                        (str:concat pname " " (third line)))
-                   pname)))
-    (make-instance 'lem/detective:function-reference
-                   :reference-name name
-                   :reference-point position)))
-
-(defmethod capture-reference ((position lem:point) (class (eql :class-reference)))
-  (let* ((line (str:split #\Space (line-string position)))
-         (name (second line)))
-    (make-instance 'lem/detective:class-reference
-                   :reference-name name
-                   :reference-point position)))
-
-(defmethod capture-reference ((position lem:point) (class (eql :variable-reference)))
-  (let* ((line (str:split #\Space (line-string position)))
-         (name (second line)))
-    (make-instance 'lem/detective:variable-reference
-                   :reference-name name
-                   :reference-point position
-                   :variable-reference-value (third line))))
-
-(defmethod capture-reference ((position lem:point) (class (eql :package-reference)))
-  (let* ((line (str:split #\Space (line-string position)))
-         (name (second line)))
-    (make-instance 'lem/detective:package-reference
-                   :reference-name name
-                   :reference-point position)))
 
 ;; workaround for windows
 #+win32

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -59,7 +59,7 @@
                         :function #'capture-reference)
 		       :variable-regex
                        (lem/detective:make-capture-regex
-                        :regex "^\\(defvar |\\(defparameter "
+                        :regex "^(?:\\(defvar |\\(defparameter )"
                         :function #'capture-reference)))
   (set-syntax-parser lem-lisp-syntax:*syntax-table*
                      (make-tmlanguage-lisp))

--- a/src/base/buffer.lisp
+++ b/src/base/buffer.lisp
@@ -30,6 +30,10 @@
     :initarg :%enable-undo-p
     :accessor buffer-%enable-undo-p
     :type boolean)
+   (references 
+    :initform (make-hash-table :test 'equal)
+    :reader buffer-references
+    :accessor buffer-references )
    (read-only-p
     :initarg :read-only-p
     :accessor buffer-read-only-p

--- a/src/base/buffer.lisp
+++ b/src/base/buffer.lisp
@@ -30,10 +30,6 @@
     :initarg :%enable-undo-p
     :accessor buffer-%enable-undo-p
     :type boolean)
-   (references 
-    :initform (make-hash-table :test 'equal)
-    :reader buffer-references
-    :accessor buffer-references )
    (read-only-p
     :initarg :read-only-p
     :accessor buffer-read-only-p

--- a/src/base/package.lisp
+++ b/src/base/package.lisp
@@ -153,6 +153,7 @@
    :point<=
    :point>
    :point>=
+   :point-closest
    :point-min
    :point-max)
   ;; basic.lisp

--- a/src/base/point.lisp
+++ b/src/base/point.lisp
@@ -193,6 +193,32 @@ When using `:left-inserting` or `:right-inserting`, you must explicitly delete t
         :always (or (%point< point2 point1)
                     (%point= point2 point1))))
 
+(defun point-closest (point point-list &key (direction :up) (same-line nil))
+  "Return the closest point on the POINT-LIST compare to POINT.
+DIRECTION can be :up or :down depending on the desired point.
+SAME-LINE if T the point in POINT-LIST can be in the same line as POINT."
+  (loop :for p :in point-list
+        :for flag := t :then nil
+        :with closest := nil
+        :do (progn
+              (when flag (setf closest p))
+
+              (when (or (and (eq direction :up)
+                             (and (point> point p closest)
+                                  (or same-line
+                                      (not (same-line-p p point)))))
+                        (and (eq direction :down)
+                             (point< closest point p)
+                             (or same-line
+                                 (not (same-line-p p point)))))
+
+                (setf closest p)))
+        :finally (return (and (or (and (eq direction :up)
+                                       (point> point closest))
+                                  (and (eq direction :down)
+                                       (point< point closest)))
+                              closest ))))
+
 (defun point-min (point &rest more-points)
   (assert (%always-same-buffer point more-points))
   (loop :with min := point

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -1,6 +1,55 @@
 (defpackage :lem/detective
   (:use :cl :lem)
-  (:export)
+  (:export
+
+   :reference
+   :reference-name
+   :reference-point
+
+   :function-reference
+   :function-arguments
+
+   :package-reference
+   :package-use
+   :package-export
+
+   :class-reference
+   :class-parents
+   :class-attributes
+
+   :variable-reference
+   :variable-reference-value
+
+   :misc-reference
+   :misc-custom-type
+
+   :capture-regex
+   :make-capture-regex
+
+   :detective-search
+
+   :search-regex
+
+   :search-function-regex
+   :set-function-regex
+   :search-package-regex
+   :set-package-regex
+   :search-class-regex
+   :set-class-regex
+   :search-variable-regex
+   :set-variable-regex
+   :search-misc-regex
+   :set-misc-regex
+
+   :buffer-references
+
+   :search-references
+
+   :capture-references
+
+   :navigate-reference
+
+   :move-to-reference)
   
   #+sbcl
   (:lock t))

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -52,18 +52,23 @@
 (defclass search-regex (imenu-search)
   ((function-regex :initform nil
                    :initarg :function-regex
+                   :writer set-function-regex
                    :reader search-function-regex)
    (package-regex :initform nil
                   :initarg :package-regex
+                  :writer set-package-regex
                   :reader search-package-regex)
    (class-regex :initform nil
                 :initarg :class-regex
+                :writer set-class-regex
                 :reader search-class-regex)
    (variable-regex :initform nil
                    :initarg :variable-regex
+                   :writer set-variable-regex
                    :reader search-variable-regex )
    (misc-regex :initform nil
                :initarg :misc-regex
+               :writer set-misc-regex
                :reader search-misc-regex)))
 
 

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -141,7 +141,7 @@
                (loop :for point = (search-forward-regexp p (capture-regex-regex regex))
                      :while point
                      :collect (funcall (capture-regex-function regex) 
-                                       (copy-point point)
+                                       (copy-point point :temporary)
                                        class)))))
     (with-accessors ((function-regex search-function-regex)
                      (package-regex search-package-regex)

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -148,21 +148,21 @@
                      (class-regex search-class-regex)
                      (variable-regex search-variable-regex)
                      (misc-regex search-misc-regex))
-      search
-    (let ((slots 
-            (list (cons (cons "functions" function-regex):function-reference)
-                  (cons (cons "classes" class-regex) :class-reference)
-                  (cons (cons "packages" package-regex) :package-reference)
-                  (cons (cons "variables" variable-regex) :variable-reference)
-                  (cons (cons "misc" misc-regex) :misc-reference))))
+        search
+      (let ((slots
+              (list (cons (cons "functions" function-regex):function-reference)
+                    (cons (cons "classes" class-regex) :class-reference)
+                    (cons (cons "packages" package-regex) :package-reference)
+                    (cons (cons "variables" variable-regex) :variable-reference)
+                    (cons (cons "misc" misc-regex) :misc-reference))))
     
-    (setf (buffer-references (current-buffer))
-          (make-hash-table :test 'equal))
+        (setf (buffer-references (current-buffer))
+              (make-hash-table :test 'equal))
 
-      (loop :for ((id . regex) . class) :in slots
-            :when (and regex (capture-regex-function regex))
-            :do (setf (gethash id (buffer-references (current-buffer)))
-                      (find-ref regex class)))))))
+        (loop :for ((id . regex) . class) :in slots
+              :when (and regex (capture-regex-function regex))
+              :do (setf (gethash id (buffer-references (current-buffer)))
+                        (find-ref regex class)))))))
 
 (defgeneric capture-reference (point class))
 

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -189,7 +189,8 @@
 
 (defmethod move-to-reference ((reference reference))
   (let ((location (reference-point reference)))
-    (move-point (current-point) location)))
+    (move-point (current-point) location)
+    (lem/peek-source:highlight-matched-line location)))
 
 (defmethod move-to-reference (reference)
   (message "Not reference available in current buffer."))

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -139,9 +139,15 @@
      (variable-value 'lem/language-mode:detective-search :buffer)))
    
    ((changed-disk-p (current-buffer))
-    (search-references (variable-value 'lem/language-mode:detective-search :buffer) ))))
+    (search-references (variable-value 'lem/language-mode:detective-search :buffer)))))
 
 (define-command detective-function () ()
   (check-change)
   (let ((reference (navigate-reference "functions")))
     (move-to-reference reference)))
+
+(define-command detective-class () ()
+  (check-change)
+  (let ((reference (navigate-reference "classes")))
+    (move-to-reference reference)))
+

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -46,27 +46,33 @@
                 :type string
                 :reader misc-custom-type)))
 
+(defstruct capture-regex regex function)
 
-(defclass imenu-search () ())
+(defclass detective-search () ())
 
-(defclass search-regex (imenu-search)
-  ((function-regex :initform nil
+(defclass search-regex (detective-search)
+  ((function-regex :type (or capture-regex null)
+                   :initform nil
                    :initarg :function-regex
                    :writer set-function-regex
                    :reader search-function-regex)
-   (package-regex :initform nil
+   (package-regex :type (or capture-regex null)
+                  :initform nil
                   :initarg :package-regex
                   :writer set-package-regex
                   :reader search-package-regex)
-   (class-regex :initform nil
+   (class-regex :type (or capture-regex null)
+                :initform nil
                 :initarg :class-regex
                 :writer set-class-regex
                 :reader search-class-regex)
-   (variable-regex :initform nil
+   (variable-regex :type (or capture-regex null)
+                   :initform nil
                    :initarg :variable-regex
                    :writer set-variable-regex
                    :reader search-variable-regex )
-   (misc-regex :initform nil
+   (misc-regex :type (or capture-regex null)
+               :initform nil
                :initarg :misc-regex
                :writer set-misc-regex
                :reader search-misc-regex)))

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -138,10 +138,10 @@
 (defmethod search-references ((search search-regex))
   (labels ((find-ref (regex class)
              (with-point ((p (buffer-start-point (point-buffer (current-point)))))
-               (loop :for position = (search-forward-regexp p (capture-regex-regex regex))
-                     :while position
+               (loop :for point = (search-forward-regexp p (capture-regex-regex regex))
+                     :while point
                      :collect (funcall (capture-regex-function regex) 
-                                       (copy-point position)
+                                       (copy-point point)
                                        class)))))
     (with-accessors ((function-regex search-function-regex)
                      (package-regex search-package-regex)
@@ -164,7 +164,7 @@
             :do (setf (gethash id (buffer-references (current-buffer)))
                       (find-ref regex class)))))))
 
-(defgeneric capture-reference (position class))
+(defgeneric capture-reference (point class))
 
 (defun %get-reference (references)
   (alexandria:when-let* ((name-references (mapcar #'reference-name references))

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -117,16 +117,24 @@
 
 (defgeneric capture-reference (position class))
 
-(defun navigate-reference (type)
-  (alexandria:when-let* ((references (gethash type (buffer-references (current-buffer))))
-                         (name-references (mapcar #'reference-name references))
-                         (item 
+(defun %get-reference (references)
+  (alexandria:when-let* ((name-references (mapcar #'reference-name references))
+                         (item
                           (prompt-for-string "Navigate: "
                                              :completion-function (lambda (x) (completion-strings x name-references))
-           
+
                                              :test-function (lambda (name)
                                                               (member name name-references :test #'string=)))))
     (find item references :key #'reference-name :test #'string=)))
+
+(defgeneric navigate-reference (references))
+
+(defmethod navigate-reference ((type String))
+  (alexandria:when-let ((references (gethash type (buffer-references (current-buffer)))))
+    (%get-reference references)))
+
+(defmethod navigate-reference ((references List))
+  (%get-reference references))
 
 (defgeneric move-to-reference (reference))
 

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -156,3 +156,13 @@
   (let ((reference (navigate-reference "classes")))
     (move-to-reference reference)))
 
+(define-command detective-package () ()
+  (check-change)
+  (let ((reference (navigate-reference "packages")))
+    (move-to-reference reference)))
+
+(define-command detective-variable () ()
+  (check-change)
+  (let ((reference (navigate-reference "variables")))
+    (move-to-reference reference)))
+

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -223,3 +223,11 @@
   (let ((reference (navigate-reference "variables")))
     (move-to-reference reference)))
 
+(define-command detective-all () ()
+  (check-change)
+  (let* ((references
+          (alexandria:flatten
+           (alexandria:hash-table-values (buffer-references (current-buffer)))))
+        (reference (navigate-reference references)))
+     (move-to-reference reference)))
+

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -143,11 +143,11 @@
                      :collect (funcall (capture-regex-function regex) 
                                        (copy-point position)
                                        class)))))
-  (with-slots (function-regex
-               package-regex
-               class-regex
-               variable-regex
-               misc-regex)
+    (with-accessors ((function-regex search-function-regex)
+                     (package-regex search-package-regex)
+                     (class-regex search-class-regex)
+                     (variable-regex search-variable-regex)
+                     (misc-regex search-misc-regex))
       search
     (let ((slots 
             (list (cons (cons "functions" function-regex):function-reference)

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -146,6 +146,30 @@
    ((changed-disk-p (current-buffer))
     (search-references (variable-value 'lem/language-mode:detective-search :buffer)))))
 
+(define-command detective-next () ()
+  (check-change)
+  (let* ((references (buffer-references (current-buffer)))
+         (lreferences (alexandria:hash-table-values references))
+         closest )
+    (loop :for ref :in (alexandria:flatten lreferences)
+          :for flag = t then nil
+          :with cline = (+ (line-number-at-point (current-point)) 1)
+          :for rline = (line-number-at-point (reference-point ref))
+          :do (progn
+                (when flag (setf closest ref))
+                (let* ((cdiff (- (line-number-at-point (reference-point closest)) cline))
+                       (ldiff (- rline cline)))
+
+                  (when  (or (and (> rline cline)
+                                  (<  ldiff cdiff))
+                             (< cdiff 0))
+                    (setf closest ref)))))
+
+    (if (< (- (+ (line-number-at-point (current-point)) 1)
+              (line-number-at-point (reference-point closest))) 0)
+        (move-to-reference closest)
+        (message "No next reference."))))
+
 (define-command detective-function () ()
   (check-change)
   (let ((reference (navigate-reference "functions")))

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -170,6 +170,31 @@
         (move-to-reference closest)
         (message "No next reference."))))
 
+
+(define-command detective-prev () ()
+  (check-change)
+  (let* ((references (buffer-references (current-buffer)))
+         (lreferences (alexandria:hash-table-values references))
+         closest )
+    (loop :for ref :in (alexandria:flatten lreferences)
+          :for flag = t then nil
+          :with cline = (- (line-number-at-point (current-point)) 1)
+          :for rline = (line-number-at-point (reference-point ref))
+          :do (progn
+                (when flag (setf closest ref))
+                (let* ((cdiff (- (line-number-at-point (reference-point closest)) cline))
+                       (ldiff (- rline cline)))
+
+                  (when  (or (and (< rline cline)
+                                  (>  ldiff cdiff))
+                             (> cdiff 0))
+                    (setf closest ref)))))
+
+    (if (> (- (- (line-number-at-point (current-point)) 1)
+              (line-number-at-point (reference-point closest))) 0)
+        (move-to-reference closest)
+        (message "No previous reference."))))
+
 (define-command detective-function () ()
   (check-change)
   (let ((reference (navigate-reference "functions")))

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -228,7 +228,7 @@
         (message "No next reference."))))
 
 
-(define-command detective-prev () ()
+(define-command detective-previous () ()
   (check-change)
   (let* ((references (buffer-references (current-buffer)))
          (lreferences (alexandria:hash-table-values references))

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -200,8 +200,12 @@
    ((null (buffer-references (current-buffer)))
     (search-references 
      (variable-value 'lem/language-mode:detective-search :buffer)))
-   
-   ((changed-disk-p (current-buffer))
+
+   ((not (eql (buffer-value (current-buffer) 'prev-tick)
+              (buffer-modified-tick (current-buffer))))
+
+    (setf (buffer-value (current-buffer) 'prev-tick)
+          (buffer-modified-tick (current-buffer)))
     (search-references (variable-value 'lem/language-mode:detective-search :buffer)))))
 
 (define-command detective-next () ()

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -97,9 +97,9 @@
 
 (defstruct capture-regex regex function)
 
-(defclass detective-search () ())
+(defclass <detective-search> () ())
 
-(defclass search-regex (detective-search)
+(defclass search-regex (<detective-search>)
   ((function-regex :type (or capture-regex null)
                    :initform nil
                    :initarg :function-regex

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -1,0 +1,137 @@
+(defpackage :lem/detective
+  (:use :cl :lem)
+  (:export)
+  
+  #+sbcl
+  (:lock t))
+
+(in-package :lem/detective)
+
+(defclass reference ()
+  ((name :type string 
+         :initarg :reference-name
+         :reader reference-name)
+
+   (point :initarg :reference-point
+          :reader reference-point)))
+
+(defclass function-reference (reference)
+  ((arguments :type list
+              :initarg :function-arguments
+              :reader function-arguments)))
+
+(defclass package-reference (reference)
+  ((use :type list
+        :initarg :package-use
+        :reader package-use )
+   (export :type list
+           :initarg :package-export
+           :reader package-export)))
+
+(defclass class-reference (reference)
+  ((parents :type list
+            :initarg :class-parents
+            :reader class-parents)
+   (attributes :type list
+               :initarg :class-attributes
+               :reader class-attributes)))
+
+(defclass variable-reference (reference)
+  ((value :initarg :variable-reference-value
+          :reader variable-reference-value)))
+
+
+(defclass misc-reference (reference)
+  ((custom-type :initarg :misc-custom-type
+                :type string
+                :reader misc-custom-type)))
+
+
+(defclass imenu-search () ())
+
+(defclass search-regex (imenu-search)
+  ((function-regex :initform nil
+                   :initarg :function-regex
+                   :reader search-function-regex)
+   (package-regex :initform nil
+                  :initarg :package-regex
+                  :reader search-package-regex)
+   (class-regex :initform nil
+                :initarg :class-regex
+                :reader search-class-regex)
+   (variable-regex :initform nil
+                   :initarg :variable-regex
+                   :reader search-variable-regex )
+   (misc-regex :initform nil
+               :initarg :misc-regex
+               :reader search-misc-regex)))
+
+
+(defgeneric search-references (type))
+
+
+(defmethod search-references ((search search-regex))
+  (with-slots (function-regex
+               package-regex
+               class-regex
+               variable-regex
+               misc-regex)
+        search
+      (when function-regex
+        (setf 
+         
+         ;; Search functions
+         (gethash "functions" (lem-base::buffer-references (current-buffer)))
+       
+         (with-point ((p (buffer-start-point (point-buffer (current-point)))))
+           (loop :for position = (search-forward-regexp p function-regex)
+                 :while position
+                 :for line = (str:split #\Space (line-string position))
+                 :collect (make-instance 'function-reference
+                                         :reference-point position
+                                         :reference-name (second line)))))) 
+      (when package-regex
+        (setf 
+         
+         (gethash "packages" (lem-base::buffer-references (current-buffer)))
+      
+         (with-point ((p (buffer-start-point (point-buffer (current-point)))))
+           (loop :for position = (search-forward-regexp p package-regex)
+                 :while position
+                 :for line = (str:split #\Space (line-string position))
+                 :collect (make-instance 'package-reference
+                                         :reference-point position
+                                         :reference-name (second line))))))
+
+      (when class-regex
+        (setf
+
+         (gethash "classes" (lem-base::buffer-references (current-buffer)))
+         (with-point ((p (buffer-start-point (point-buffer (current-point)))))
+           (loop :for position = (search-forward-regexp p class-regex)
+                 :while position
+                 :for line = (str:split #\Space (line-string position))
+                 :collect (make-instance 'package-reference
+                                         :reference-point position
+                                         :reference-name (second line))))))
+    (when variable-regex
+      (setf
+
+       (gethash "variables" (lem-base::buffer-references (current-buffer)))
+       (with-point ((p (buffer-start-point (point-buffer (current-point)))))
+         (loop :for position = (search-forward-regexp p variable-regex)
+               :while position
+               :for line = (str:split #\Space (line-string position))
+               :collect (make-instance 'package-reference
+                                       :reference-point position
+                                       :reference-name (second line))))))))
+
+
+
+
+
+
+;(with-point ((p (buffer-start-point (point-buffer (current-point)))))
+;    (loop :for position = (search-forward-regexp p "^\\(defun ")
+;          :while position
+;          :collect position))

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -128,9 +128,14 @@
                                                               (member name name-references :test #'string=)))))
     (find item references :key #'reference-name :test #'string=)))
 
-(defun move-to-reference (reference)
+(defgeneric move-to-reference (reference))
+
+(defmethod move-to-reference ((reference reference))
   (let ((location (reference-point reference)))
     (move-point (current-point) location)))
+
+(defmethod move-to-reference (reference)
+  (message "Not reference available in current buffer."))
 
 (defun check-change ()
   (cond 

--- a/src/ext/language-mode.lisp
+++ b/src/ext/language-mode.lisp
@@ -17,6 +17,7 @@
    :completion-spec
    :indent-size
    :root-uri-patterns
+   :detective-search
    :go-to-location
    :indent
    :newline-and-indent
@@ -53,6 +54,7 @@
 (define-editor-variable completion-spec nil)
 (define-editor-variable indent-size 2)
 (define-editor-variable root-uri-patterns '())
+(define-editor-variable detective-search nil)
 
 (defun prompt-for-symbol (prompt history-name)
   (prompt-for-string prompt :history-symbol history-name))


### PR DESCRIPTION
The idea of this new feature is to have a version of imenu ready to work with regex but also with other external tools (like for example tree-sitter).

One of the interesting challenges of this approach is to parse the buffer efficiently with regex and organize all of them correctly. I'll focus on this the last part given that initially I don't think the overhead is that much.