### PR TITLE
Add trace commands to lisp-mode

### DIFF
--- a/modes/lisp-mode/lem-lisp-mode.asd
+++ b/modes/lisp-mode/lem-lisp-mode.asd
@@ -38,6 +38,7 @@
                (:file "organize-imports")
                (:file "connection-list")
                (:file "self-insert-hook")
+               (:file "trace")
                (:file "class-browser")
                (:file "package")))
 

--- a/modes/lisp-mode/trace.lisp
+++ b/modes/lisp-mode/trace.lisp
@@ -1,0 +1,43 @@
+(defpackage :lem-lisp-mode/trace
+  (:use :cl :lem :lem-lisp-mode/internal)
+  (:import-from :lem/multi-column-list
+                :multi-column-list
+                :multi-column-list-of-window
+                :display
+                :quit
+                :update
+                :collect-checked-items
+                :delete-checked-items))
+(in-package :lem-lisp-mode/trace)
+
+(define-key *lisp-mode-keymap* "C-c T" 'lisp-trace-list)
+(define-key *lisp-mode-keymap* "C-c C-t" 'lisp-toggle-trace)
+
+(defvar *traces*)
+
+(defun search-ignore-case (str1 str2)
+  (search str1 str2 :test #'char-equal))
+
+(define-command lisp-trace-list () ()
+  (setf *traces* (lisp-eval '(micros/trace:micros-trace-list)))
+  (display
+   (make-instance 'multi-column-list
+                  :columns '("Trace (untrace selected elements)")
+                  :column-function (lambda (component item)
+                                     (declare (ignore component))
+                                     (list item))
+                  :items *traces*
+                  :filter-function (lambda (string)
+                                     (completion string *traces* :test #'search-ignore-case))
+                  :select-callback (lambda (component item)
+                                     (lisp-eval `(micros/trace:micros-untrace ,item))
+                                     (update component)
+                                     (quit component))
+                  :delete-callback (lambda (component item)
+                                     (lisp-eval `(micros/trace:micros-untrace ,item))
+                                     (update component))
+                  :use-check t)))
+
+(define-command lisp-toggle-trace (name)
+    ((prompt-for-symbol-name "(Un)Trace: " (symbol-string-at-point (current-point))))
+  (eval-with-transcript `(micros/trace:toggle-trace ,name)))


### PR DESCRIPTION
The following two commands have been added.
- `M-x lisp-trace-list (C-c T)`
- `M-x lisp-toggle-trace (C-c C-t)`