### PR TITLE
fix blurry text on Apple retina display

### DIFF
--- a/frontends/sdl2/font.lisp
+++ b/frontends/sdl2/font.lisp
@@ -42,8 +42,9 @@
   char-width
   char-height)
 
-(defun save-font-size (font-config)
-  (setf (lem:config :sdl2-font-size) (font-config-size font-config)))
+(defun save-font-size (font-config &optional (ratio 1))
+  (setf (lem:config :sdl2-font-size)
+        (round (/ (font-config-size font-config) ratio))))
 
 (defun make-font-config (&key (size (lem:config :sdl2-font-size *default-font-size*))
                               latin-normal-file


### PR DESCRIPTION
![imagen](https://github.com/lem-project/lem/assets/1756956/0c3d350b-fedd-4373-97af-90689241f163)


This patch handles the text rendering on high-DPI screen for macOS.

I mark this PR Work-in-Progress, because I haven't fully tested this patch, here is the check list:

For MacOS

- [x] no more blurry text on macOS with retina screen
- [x] automatic font resizing when moving window between high-DPI screen and low-DPI screen
- [x] don't break low-DPI screen rendering (when start from the low-DPI screen)

For other platforms 

- [x] does it break the rendering on Windows?
    It was broken by itself, this patch didn't make it worse.
    #801
- [x] does it break the rendering on Linux?
    It was broken by itself, this patch didn't make it worse.
    #802