### PR TITLE
Implement get-font-list for windows.

### DIFF
--- a/frontends/sdl2/font.lisp
+++ b/frontends/sdl2/font.lisp
@@ -148,3 +148,7 @@
                                                      (uiop:run-program "fc-list" :output :string)
                                                      :remove-empty-subseqs t)
         :collect (first (split-sequence:split-sequence #\: line :count 1))))
+
+(defmethod get-font-list ((platform lem-sdl2/platform:windows))
+  (loop :for file :in (lem:directory-files "C:/Windows/Fonts/*.[otOT][tT][fF]")
+        :collect (uiop:native-namestring file)))


### PR DESCRIPTION
Returns a list of filenames as strings containing TTF and OTF fonts installed on the windows system.

(length (lem-sdl2/font:get-font-list (lem-sdl2/platform:get-platform))) => 2132 on my particular machine