### PR TITLE
The powerful print debugger (a.k.a the watcher)

### DIFF
--- a/modes/lisp-mode/eval.lisp
+++ b/modes/lisp-mode/eval.lisp
@@ -100,6 +100,10 @@
     (add-hook (variable-value 'before-change-functions :buffer buffer)
               'remove-touch-overlay)))
 
+(defun redisplay-evaluated-message (start end value)
+  (remove-eval-result-overlay-between start end)
+  (display-evaluated-message start end value))
+
 (defun display-spinner-message (spinner &optional message is-error id)
   (lem/loading-spinner:with-line-spinner-points (start end spinner)
     (display-evaluated-message start end message is-error id)))

--- a/modes/lisp-mode/lem-lisp-mode.asd
+++ b/modes/lisp-mode/lem-lisp-mode.asd
@@ -27,7 +27,7 @@
                (:file "message-definitions")
                (:file "repl")
                (:file "sldb")
-	       (:file "hyperspec")
+               (:file "hyperspec")
                (:file "inspector")
                (:file "apropos-mode")
                (:file "autodoc")


### PR DESCRIPTION
This feature displays evaluation results on the fly.

https://github.com/lem-project/lem/assets/13656378/cdeb8ead-3380-4804-b85b-d487a7e733b1

`(micros:watch form)` you can look the results of form evaluation on the fly.
