### PR TITLE
Fixed overlays not being considered when finding the x position in a window

### DIFF
--- a/src/frame.lisp
+++ b/src/frame.lisp
@@ -192,9 +192,10 @@ redraw-display関数でキャッシュを捨てて画面全体を再描画しま
                           (reverse (frame-floating-windows frame))
                           (window-list frame)))
     (when (within-window-p window x y)
-      (return (values window
-                      (- x (window-x window))
-                      (- y (window-y window)))))))
+      (let ((overlay-x-offset (screen-left-width (window-screen window))))
+        (return (values window
+                        (- x (window-x window) overlay-x-offset)
+                        (- y (window-y window))))))))
 
 (defun focus-separator-position (frame x y)
   (when (and (frame-leftside-window frame)


### PR DESCRIPTION
As the title says this should fix the x position of a mouse click when the line numbers overlay is active.