### PR TITLE
add time-stamp command

### DIFF
--- a/lem.asd
+++ b/lem.asd
@@ -126,7 +126,8 @@
                              (:file "filer")
                              (:file "deepl")
                              (:file "themes")
-                             (:file "detective")))))
+                             (:file "detective")
+                             (:file "time-stamp")))))
 
 (defsystem "lem/extensions"
   :depends-on (#+sbcl

--- a/src/ext/time-stamp.lisp
+++ b/src/ext/time-stamp.lisp
@@ -1,0 +1,20 @@
+(defpackage :lem/time-stamp
+  (:use :cl
+        :lem)
+  (:export :*time-stamp-format*
+           :time-stamp))
+
+(in-package :lem/time-stamp)
+
+(defvar *time-stamp-format*
+  ;; Equals Emacs org-mode's default format.
+  '("<" :year "-" (:month 2) "-" (:day 2) " " :short-weekday ">")
+  "Time-stamp format.
+  By default, prints year, month, day, and short english day: \"<2023-07-05 Wed>\"")
+
+(defun format-time-stamp (&key (day (local-time:now)) (stream nil))
+  (local-time:format-timestring stream day :format *time-stamp-format*))
+
+(define-command time-stamp () ()
+  "Print a timestamp of today, in the form <2042-12-01 Mon>."
+  (insert-string (current-point) (format-time-stamp :stream t)))


### PR DESCRIPTION
I often use `org-time-stamp` when taking notes. I replicate the behaviour and the file format: 

     <2023-07-05 Wed>

(although org-mode has an interactive date picker)