### PR TITLE
Remove jsonrcp/http dependency from elisp-mode

### DIFF
--- a/modes/elisp-mode/elisp-mode.lisp
+++ b/modes/elisp-mode/elisp-mode.lisp
@@ -213,11 +213,10 @@
                                 (lem-elisp-mode/rpc:get-completions (points-to-string start end)))
 		    #'string-lessp)))))
 
+;;TODO: Show more information about the connection without loading jsonrpc/http
 (define-command elisp-connect () ()
   (if (lem-elisp-mode/rpc:connected-p)
-    (message "Already connected to ~a"
-             (jsonrpc/transport/http::http-transport-url
-                      (jsonrpc/class:jsonrpc-transport lem-elisp-mode/rpc:*elisp-rpc-client*)))
+    (message "Already connected.")
     (lem-elisp-mode/rpc:connect-to-server)))
 
 (defun elisp-find-definitions (point)

--- a/modes/elisp-mode/lem-elisp-mode.asd
+++ b/modes/elisp-mode/lem-elisp-mode.asd
@@ -2,7 +2,6 @@
   :depends-on ("lem"
                "jsonrpc"
                "lem-lisp-mode"
-               "jsonrpc/transport/http"
                #+#.(cl:if (asdf:find-system :async-process cl:nil) '(and) '(or)) "lem-process")
   :serial t
   :components ((:file "rpc")


### PR DESCRIPTION
Seems like there are a few unwanted dependencies form the jsonrpc/http transport class, and in this case I'm just calling it for a simple information prompt. So for now, it will load only when the user setup the rpc server as mention here https://github.com/lem-project/lem/pull/810#discussion_r1257303942