### PR TITLE
Fix some minor SDL2 paper cuts

### DIFF
--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -877,6 +877,18 @@
         ;; return the title instead of nil
         title))))
 
+(defmethod lem-if:display-fullscreen-p ((implementation sdl2))
+  (with-debug ("lem-if:display-fullscreen-p")
+    (not (null (member :fullscreen (sdl2:get-window-flags (display-window *display*)))))))
+
+(defmethod lem-if:set-display-fullscreen-p ((implementation sdl2) fullscreen-p)
+  (with-debug ("lem-if:set-display-fullscreen-p")
+    (sdl2:in-main-thread ()
+      (with-renderer ()
+        ;; always send :desktop over :fullscreen due to weird bugs on macOS
+        (sdl2:set-window-fullscreen (display-window *display*)
+                                    (if fullscreen-p :desktop))))))
+
 (defmethod lem-if:make-view ((implementation sdl2) window x y width height use-modeline)
   (with-debug ("lem-if:make-view" window x y width height use-modeline)
     (with-renderer ()

--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -835,10 +835,17 @@
              (declare (ignore editor-thread))
              nil)))
     (if (sbcl-on-darwin-p)
-        (sdl2:make-this-thread-main
-         (lambda ()
-           (create-display #'thunk)
-           (cffi:foreign-funcall "_exit")))
+        (progn
+          ;; called *before* any sdl windows are created
+          (sdl2:set-hint :video-mac-fullscreen-spaces
+                         ;; the sdl2 library expects zero or one NOTE since this
+                         ;; is a preference let's not change the default here
+                         ;; because it's easy enough to change it via a user's
+                         ;; config
+                         (if (lem:config :darwin-use-native-fullscreen) 1 0))
+          (sdl2:make-this-thread-main (lambda ()
+                                        (create-display #'thunk)
+                                        (cffi:foreign-funcall "_exit"))))
         (let ((thread (bt:make-thread (lambda ()
                                         (create-display #'thunk)))))
           (bt:join-thread thread)))))

--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -865,6 +865,18 @@
     (with-renderer ()
       (floor (display-height *display*) (char-height)))))
 
+(defmethod lem-if:display-title ((implementation sdl2))
+  (with-debug ("lem-if:display-title")
+    (sdl2:get-window-title (display-window *display*))))
+
+(defmethod lem-if:set-display-title ((implementation sdl2) title)
+  (with-debug ("lem-if:set-display-title")
+    (sdl2:in-main-thread ()
+      (with-renderer ()
+        (sdl2:set-window-title (display-window *display*) title)
+        ;; return the title instead of nil
+        title))))
+
 (defmethod lem-if:make-view ((implementation sdl2) window x y width height use-modeline)
   (with-debug ("lem-if:make-view" window x y width height use-modeline)
     (with-renderer ()

--- a/lem.asd
+++ b/lem.asd
@@ -85,7 +85,8 @@
                              (:file "process")
                              (:file "help")
                              (:file "font")
-                             (:file "other" :depends-on ("file"))))
+                             (:file "other" :depends-on ("file"))
+                             (:file "frame")))
 
                (:file "external-packages")
 

--- a/src/commands/frame.lisp
+++ b/src/commands/frame.lisp
@@ -1,0 +1,8 @@
+(defpackage :lem-core/commands/frame
+  (:use :cl :lem-core)
+  (:export :toggle-frame-fullscreen))
+(in-package :lem-core/commands/frame)
+
+(define-command toggle-frame-fullscreen () ()
+  "Toggles fullscreen."
+  (setf (display-fullscreen-p) (not (display-fullscreen-p))))

--- a/src/external-packages.lisp
+++ b/src/external-packages.lisp
@@ -13,7 +13,8 @@
   (:use-reexport :lem-core/commands/process)
   (:use-reexport :lem-core/commands/help)
   (:use-reexport :lem-core/commands/font)
-  (:use-reexport :lem-core/commands/other))
+  (:use-reexport :lem-core/commands/other)
+  (:use-reexport :lem-core/commands/frame))
 #+sbcl
 (sb-ext:lock-package :lem)
 

--- a/src/interface.lisp
+++ b/src/interface.lisp
@@ -44,6 +44,8 @@
 (defgeneric lem-if:update-background (implementation color-name))
 (defgeneric lem-if:display-width (implementation))
 (defgeneric lem-if:display-height (implementation))
+(defgeneric lem-if:display-title (implementation))
+(defgeneric lem-if:set-display-title (implementation title))
 (defgeneric lem-if:make-view (implementation window x y width height use-modeline))
 (defgeneric lem-if:delete-view (implementation view))
 (defgeneric lem-if:clear (implementation view))
@@ -139,6 +141,9 @@
 
 (defun display-width () (lem-if:display-width (implementation)))
 (defun display-height () (lem-if:display-height (implementation)))
+(defun display-title () (lem-if:display-title (implementation)))
+(defun (setf display-title) (title)
+  (lem-if:set-display-title (implementation) title))
 
 (defun invoke-frontend (function &key (implementation
                                        (get-default-implementation)))

--- a/src/interface.lisp
+++ b/src/interface.lisp
@@ -46,6 +46,8 @@
 (defgeneric lem-if:display-height (implementation))
 (defgeneric lem-if:display-title (implementation))
 (defgeneric lem-if:set-display-title (implementation title))
+(defgeneric lem-if:display-fullscreen-p (implementation))
+(defgeneric lem-if:set-display-fullscreen-p (implementation fullscreen-p))
 (defgeneric lem-if:make-view (implementation window x y width height use-modeline))
 (defgeneric lem-if:delete-view (implementation view))
 (defgeneric lem-if:clear (implementation view))
@@ -144,6 +146,9 @@
 (defun display-title () (lem-if:display-title (implementation)))
 (defun (setf display-title) (title)
   (lem-if:set-display-title (implementation) title))
+(defun display-fullscreen-p () (lem-if:display-fullscreen-p (implementation)))
+(defun (setf display-fullscreen-p) (fullscreen-p)
+  (lem-if:set-display-fullscreen-p (implementation) fullscreen-p))
 
 (defun invoke-frontend (function &key (implementation
                                        (get-default-implementation)))

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -487,7 +487,8 @@
    :set-foreground
    :set-background
    :display-width
-   :display-height)
+   :display-height
+   :display-title)
   ;; color-theme.lisp
   (:export
    :color-theme-names
@@ -514,6 +515,8 @@
    :update-background
    :display-width
    :display-height
+   :display-title
+   :set-display-title
    :make-view
    :delete-view
    :clear

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -488,7 +488,8 @@
    :set-background
    :display-width
    :display-height
-   :display-title)
+   :display-title
+   :display-fullscreen-p)
   ;; color-theme.lisp
   (:export
    :color-theme-names
@@ -517,6 +518,8 @@
    :display-height
    :display-title
    :set-display-title
+   :display-fullscreen-p
+   :set-display-fullscreen-p
    :make-view
    :delete-view
    :clear


### PR DESCRIPTION
These patches add the ability to get/set the gui window's title along with toggling fullscreen.