### PR TITLE
Add lisp-disassemble command

### DIFF
--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -340,6 +340,21 @@
 (defun interactive-eval (string &key (package (current-package)))
   (eval-with-transcript `(micros:interactive-eval ,string) :package package))
 
+(defun %lisp-disassemble (symbol &key (package (current-package)))
+  (car (lisp-eval
+        `(micros:eval-and-grab-output
+          ,(format nil "(disassemble '~a)" symbol))
+        package)))
+
+(define-command lisp-disassemble () ()
+  (check-connection)
+  (let* ((name (or (symbol-string-at-point (current-point))
+                   (prompt-for-symbol-name "Disassemble: ")))
+         (buffer (make-buffer "*lisp-dissasemble*")))
+
+    (with-pop-up-typeout-window (s  buffer :erase t)
+      (format s (%lisp-disassemble name)))))
+
 (defun new-package (name prompt-string)
   (setf (connection-package (current-connection)) name)
   (setf (connection-prompt-string (current-connection)) prompt-string)


### PR DESCRIPTION
Simple command that display the disassembly information about the symbol at point, I was thinking of using a major mode to syntax highlight the assembly code, but that's not standard, and some distributions may even have a different representation,

So, the idea on the future is to extend this command and let each implementation to specialize on it.