### PR TITLE
Add modified buffers information when exit Lem

### DIFF
--- a/src/base/buffers.lisp
+++ b/src/base/buffers.lisp
@@ -25,7 +25,7 @@
   (remove-if (lambda (buffer)
                (not (and (buffer-filename buffer)
                          (buffer-modified-p buffer))))
-          (buffer-list)))
+             (buffer-list)))
 
 (defun get-buffer (buffer-or-name)
   "`buffer-or-name`がバッファならそのまま返し、

--- a/src/base/buffers.lisp
+++ b/src/base/buffers.lisp
@@ -21,6 +21,12 @@
                (buffer-modified-p buffer)))
         (buffer-list)))
 
+(defun modified-buffers ()
+  (remove-if (lambda (buffer)
+               (not (and (buffer-filename buffer)
+                         (buffer-modified-p buffer))))
+          (buffer-list)))
+
 (defun get-buffer (buffer-or-name)
   "`buffer-or-name`がバッファならそのまま返し、
 文字列ならその名前のバッファを返します。"

--- a/src/base/package.lisp
+++ b/src/base/package.lisp
@@ -128,6 +128,7 @@
    :kill-buffer-hook
    :buffer-list
    :any-modified-buffer-p
+   :modified-buffers
    :get-buffer
    :get-or-create-buffer
    :unique-buffer-name

--- a/src/commands/other.lisp
+++ b/src/commands/other.lisp
@@ -36,10 +36,16 @@
 
 (define-command exit-lem (&optional (ask t)) ()
   "Ask for modified buffers before exiting lem."
-  (when (or (null ask)
-            (not (any-modified-buffer-p))
-            (prompt-for-y-or-n-p "Modified buffers exist. Leave anyway"))
-    (exit-editor)))
+  (let ((modified-buffers
+          (mapcar #'buffer-name (modified-buffers))))
+    (and (or
+          (null ask)
+          (not modified-buffers)
+          (prompt-for-y-or-n-p
+           (format nil
+                   "Modified buffers exist:~%~{~a~%~}Leave anyway?"
+                   modified-buffers)))
+         (exit-editor))))
 
 (define-command quick-exit () ()
   "Exit the lem job and kill it."


### PR DESCRIPTION
Yesterday I was working on Lem with 30+ buffers open, and when closing the editor, it told me that I had some that were modified but not saved, so I spent a few minutes going around trying to realize which one were the ones that were open.

This patch aims to solved this issue providing information on which buffers are modified but not saved.