### PR TITLE
Vindarel/image fit to screen

### DIFF
--- a/frontends/sdl2/image-buffer.lisp
+++ b/frontends/sdl2/image-buffer.lisp
@@ -1,7 +1,14 @@
 (defpackage :lem-sdl2/image-buffer
   (:use :cl
-        :lem
-        :lem-sdl2))
+   :lem
+        :lem-sdl2)
+  (:export :image-fit-to-height
+           :image-fit-to-screen
+           :image-fit-to-width
+           :image-zoom-help
+           :image-zoom-in
+           :image-zoom-out
+           :image-zoom-reset))
 (in-package :lem-sdl2/image-buffer)
 
 (defclass image-buffer (text-buffer) ())
@@ -31,6 +38,7 @@
             (lem-sdl2::image-height image)
             (buffer-scaling (window-buffer window)))))
 
+;; Zoom.
 (define-key *image-viewer-keymap* "C-+" 'image-zoom-in)
 (define-key *image-viewer-keymap* "+" 'image-zoom-in)
 (define-key *image-viewer-keymap* "C--" 'image-zoom-out)
@@ -39,6 +47,10 @@
 (define-key *image-viewer-keymap* "0" 'image-zoom-reset)
 (define-key *image-viewer-keymap* "?" 'image-zoom-help)
 (define-key *image-viewer-keymap* "C-h" 'image-zoom-help)
+;; Fit to width, height, screen.
+(define-key *image-viewer-keymap* "f" 'image-fit-to-screen)
+(define-key *image-viewer-keymap* "w" 'image-fit-to-width)
+(define-key *image-viewer-keymap* "h" 'image-fit-to-height)
 
 (defmethod render :before (texture window (buffer image-buffer))
   (sdl2:set-render-target (current-renderer) texture)
@@ -73,6 +85,49 @@
                 :width (lem-sdl2::image-width image)
                 :height (lem-sdl2::image-height image))))
 
+(defun fit-to-width (buffer)
+  (clear-drawables buffer)
+  (let* ((image (buffer-image buffer))
+         (image-width (lem-sdl2::image-width image))
+         (display-width (* (lem-sdl2::char-width)
+                           (window-width (current-window)))))
+    (let* ((ratio (/ image-width display-width))
+           (percent (- 100 (/ 100.0 ratio))))
+      (setf (buffer-scaling buffer) 1)
+      (scale-buffer-image buffer (* -1 (/ percent 100))))))
+
+(defun fit-to-height (buffer)
+  (clear-drawables buffer)
+  (let* ((image (buffer-image buffer))
+         (image-height (lem-sdl2::image-height image))
+         (display-height (* (lem-sdl2::char-height)
+                            (1-
+                             (window-height (current-window))))))
+    (let* ((ratio (/ image-height display-height))
+           (percent (- 100 (/ 100.0 ratio))))
+      (setf (buffer-scaling buffer) 1)
+      (scale-buffer-image buffer (* -1 (/ percent 100))))))
+
+(defun fit-to-screen (buffer)
+  "If the image is bigger that the display, shrink it."
+  (let* ((image (buffer-image buffer))
+         (width (lem-sdl2::image-width image))
+         (display-width (* (lem-sdl2::char-width)
+                           (window-width (current-window))))
+         (display-height (* (lem-sdl2::char-height)
+                            (1-
+                             (window-height (current-window)))))
+         (height (lem-sdl2::image-height image)))
+    (cond
+      ((and (> width display-width)
+            (> width height))
+       (fit-to-width buffer))
+      ((and (> height display-height)
+            (> height width))
+       (fit-to-height buffer))
+      (t
+       nil))))
+
 (define-command image-zoom-in () ()
   (scale-buffer-image (current-buffer) 0.1))
 
@@ -82,12 +137,14 @@
 (define-command image-zoom-reset () ()
   (reset-buffer-scale (current-buffer)))
 
-(define-command image-zoom-help () ()
-  (with-pop-up-typeout-window (s (make-buffer "*image-zoom-help*") :erase t)
-    (format s "Open an image file in Lem and use these keys to zoom in and out:~&")
-    (format s "Zoom in: + or C - + (M-x image-zoom-in)~&")
-    (format s "Zoom out: - or C - - (M-x image-zoom-out)~&")
-    (format s "Zoom reset: 0 or C - 0 (M-x image-zoom-reset)~&")))
+(define-command image-fit-to-width () ()
+  (fit-to-width (current-buffer)))
+
+(define-command image-fit-to-height () ()
+  (fit-to-height (current-buffer)))
+
+(define-command image-fit-to-screen () ()
+  (fit-to-screen (current-buffer)))
 
 (defclass sdl2-find-file-executor (lem:find-file-executor) ())
 
@@ -110,3 +167,15 @@
     buffer))
 
 (setf lem:*find-file-executor* (make-instance 'sdl2-find-file-executor))
+
+(define-command image-zoom-help () ()
+  (with-pop-up-typeout-window (s (make-buffer "*image-zoom-help*") :erase t)
+    (format s "Open an image file in Lem and use these keys to zoom in and out:~&")
+    (format s "Zoom in: + or C - + (M-x image-zoom-in)~&")
+    (format s "Zoom out: - or C - - (M-x image-zoom-out)~&")
+    (format s "Reset: 0 or C - 0 (M-x image-zoom-reset)~&")
+    (format s "~%")
+    (format s "Fit the image to the screen:~&")
+    (format s "Fit to screen: f (M-x image-fit-to-screen)~&")
+    (format s "Fit to width: w (M-x image-fit-to-width)~&")
+    (format s "Fit to height: h (M-x image-fit-to-height)~&")))

--- a/frontends/sdl2/image-buffer.lisp
+++ b/frontends/sdl2/image-buffer.lisp
@@ -1,7 +1,6 @@
 (defpackage :lem-sdl2/image-buffer
   (:use :cl
-   :lem
-        :lem-sdl2)
+   :lem :lem-sdl2)
   (:export :image-fit-to-height
            :image-fit-to-screen
            :image-fit-to-width
@@ -163,6 +162,7 @@
     (setf (buffer-image buffer) image)
     (setf (buffer-scaling buffer) 1)
     (draw-image buffer image :x 0 :y 0)
+    (fit-to-screen buffer)
     (change-buffer-mode buffer 'image-viewer-mode)
     buffer))
 


### PR DESCRIPTION
When opening an image, if it is bigger than the screen, fit it to the screen. We still have the shortcut `0` / C-0 to see it in its original size.