### PR TITLE
Set last focused window in switch-to-window.

### DIFF
--- a/src/commands/window.lisp
+++ b/src/commands/window.lisp
@@ -158,9 +158,9 @@
 
 (define-command switch-to-last-focused-window () ()
   "Go to the window that was last in focus."
-  (let ((window (or (and (not (null *last-focused-window*))
-                         (not (deleted-window-p *last-focused-window*))
-                         *last-focused-window*)
+  (let ((window (or (and (not (null (last-focused-window)))
+                         (not (deleted-window-p (last-focused-window)))
+                         (last-focused-window))
                     (get-next-window (current-window)))))
     (switch-to-window window)))
 

--- a/src/commands/window.lisp
+++ b/src/commands/window.lisp
@@ -144,18 +144,12 @@
   (unless n
     (maybe-balance-windows)))
 
-(defvar *last-focused-window* nil)
-
-(defun update-last-focused-window ()
-  (setf *last-focused-window* (current-window)))
-
 (define-command other-window (&optional (n 1)) ("p")
   "Go to the next window."
   (let ((window-list
           (compute-window-list (current-window))))
     (when (minusp n)
       (setf n (- (length window-list) (abs n))))
-    (update-last-focused-window)
     (let ((window (current-window)))
       (dotimes (_ n t)
         (setf window
@@ -168,28 +162,27 @@
                          (not (deleted-window-p *last-focused-window*))
                          *last-focused-window*)
                     (get-next-window (current-window)))))
-    (update-last-focused-window)
-    (setf (current-window) window)))
+    (switch-to-window window)))
 
 (define-command window-move-down () ()
   "Go to the window on the down."
   (alexandria:when-let ((window (down-window (current-window))))
-    (setf (current-window) window)))
+    (switch-to-window window)))
 
 (define-command window-move-up () ()
   "Go to the window on the up."
   (alexandria:when-let ((window (up-window (current-window))))
-    (setf (current-window) window)))
+    (switch-to-window window)))
 
 (define-command window-move-right () ()
   "Go to the window on the right."
   (alexandria:when-let ((window (right-window (current-window))))
-    (setf (current-window) window)))
+    (switch-to-window window)))
 
 (define-command window-move-left () ()
   "Go to the window on the left."
   (alexandria:when-let ((window (left-window (current-window))))
-    (setf (current-window) window)))
+    (switch-to-window window)))
 
 (define-command delete-other-windows () ()
   "Delete all other windows."

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -203,6 +203,7 @@
    :*window-scroll-functions*
    :*window-size-change-functions*
    :*window-show-buffer-functions*
+   :*last-focused-window*
    :window-parent
    :scroll
    :window-view-point

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -203,7 +203,6 @@
    :*window-scroll-functions*
    :*window-size-change-functions*
    :*window-show-buffer-functions*
-   :*last-focused-window*
    :window-parent
    :scroll
    :window-view-point
@@ -227,6 +226,7 @@
    :window-use-modeline-p
    :window-redraw
    :current-window
+   :last-focused-window
    :window-list
    :compute-window-list
    :one-window-p

--- a/src/window.lisp
+++ b/src/window.lisp
@@ -12,6 +12,8 @@
 (defparameter *use-new-vertical-move-function* t)
 (defparameter *use-cursor-movement-workaround* t)
 
+(defvar *last-focused-window* nil)
+
 (defgeneric %delete-window (window))
 (defgeneric window-parent (window)
   (:method (window)
@@ -180,7 +182,8 @@
 
 (defun switch-to-window (new-window)
   (unless (eq (current-window) new-window)
-    (run-hooks (window-leave-hook (current-window)) (current-window)))
+    (run-hooks (window-leave-hook (current-window)) (current-window))
+    (setf *last-focused-window* (current-window)))
   (setf (current-window) new-window))
 
 (defun window-list (&optional (frame (current-frame)))

--- a/src/window.lisp
+++ b/src/window.lisp
@@ -180,6 +180,9 @@
                   (%window-point new-window)))
     (setf (frame-current-window frame) new-window)))
 
+(defun last-focused-window ()
+  *last-focused-window*)
+
 (defun switch-to-window (new-window)
   (unless (eq (current-window) new-window)
     (run-hooks (window-leave-hook (current-window)) (current-window))


### PR DESCRIPTION
I would like to be able to switch to the repl and then use `switch-to-last-focused-window` to return to the buffer I was last editing. Currently the use of `switch-to-last-focused-window` is limited because commands which switch windows are left to set `*last-focused-window*` themselves and most of them don't.

To resolve this I added a line to set `*last-focused-window*` in the `switch-to-window` function.

The next step would be to make all the commands which directly call (setf (current window)) use `switch-to-window` so that `*last-focused-window*` is set and `window-leave-hook` is run.