### PR TITLE
Use (switch-to-window) where appropriate.

### DIFF
--- a/modes/elisp-mode/run-elisp.lisp
+++ b/modes/elisp-mode/run-elisp.lisp
@@ -59,7 +59,7 @@
     (when (ppcre:scan "^[0-9]+>" (line-string p))
       (lem/listener-mode:refresh-prompt buffer nil))
     (unless already-exists
-      (setf (current-window) (pop-to-buffer buffer)))
+      (switch-to-window (pop-to-buffer buffer)))
     (alexandria:when-let (window (first (get-buffer-windows buffer)))
       (with-current-window window
         (buffer-end p)

--- a/modes/elixir-mode/run-elixir.lisp
+++ b/modes/elixir-mode/run-elixir.lisp
@@ -56,7 +56,7 @@
     (when (ppcre:scan "^(iex|...)(.+)" (line-string p))
       (lem/listener-mode:refresh-prompt buffer nil))
     (unless already-exists
-      (setf (current-window) (pop-to-buffer buffer)))
+      (switch-to-window (pop-to-buffer buffer)))
     (alexandria:when-let (window (first (get-buffer-windows buffer)))
       (with-current-window window
         (buffer-end p)

--- a/modes/lisp-mode/inspector.lisp
+++ b/modes/lisp-mode/inspector.lisp
@@ -103,7 +103,7 @@
                  (move-to-line point (car inspector-position))
                  (line-offset point 0 (cdr inspector-position))))))
       (cond (focus
-             (setf (current-window) (pop-to-buffer buffer :split-action :negative))
+             (switch-to-window (pop-to-buffer buffer :split-action :negative))
              (body))
             (t
              (with-current-window (pop-to-buffer buffer :split-action :negative)

--- a/modes/lisp-mode/lisp-mode.lisp
+++ b/modes/lisp-mode/lisp-mode.lisp
@@ -975,7 +975,7 @@
      (let ((xref-location (source-location-to-xref-location source-location)))
        (go-to-location xref-location
                        (lambda (buffer)
-                         (setf (current-window)
+                         (switch-to-window
                                (pop-to-buffer buffer))))))))
 
 (defun source-location-to-xref-location (location &optional content no-errors)

--- a/modes/lisp-mode/repl.lisp
+++ b/modes/lisp-mode/repl.lisp
@@ -232,7 +232,7 @@
   (let ((buffer (ensure-repl-buffer-exist)))
     (push thread (read-string-thread-stack))
     (push tag (read-string-tag-stack))
-    (setf (current-window) (pop-to-buffer buffer))
+    (switch-to-window (pop-to-buffer buffer))
     (buffer-end (current-point))
     (lem/listener-mode:change-input-start-point (current-point))
     (repl-change-read-line-input)))
@@ -263,7 +263,7 @@
   (check-connection)
   (flet ((switch (buffer split-window-p)
            (if split-window-p
-               (setf (current-window) (pop-to-buffer buffer))
+               (switch-to-window (pop-to-buffer buffer))
                (switch-to-buffer buffer))))
     (lem/listener-mode:listener-start
      "*lisp-repl*"
@@ -273,7 +273,7 @@
 (define-command lisp-switch-to-repl-buffer () ()
   (let ((buffer (repl-buffer)))
     (if buffer
-        (setf (current-window) (pop-to-buffer buffer))
+        (switch-to-window (pop-to-buffer buffer))
         (start-lisp-repl))))
 
 (defun copy-down-to-repl (slimefun &rest args)

--- a/modes/lisp-mode/sldb.lisp
+++ b/modes/lisp-mode/sldb.lisp
@@ -145,8 +145,7 @@
 
 (defun sldb-setup (thread level condition restarts frames conts)
   (let ((buffer (get-sldb-buffer-create thread)))
-    (let ((window (pop-to-buffer buffer :split-action :negative)))
-      (setf (current-window) window))
+    (switch-to-window (pop-to-buffer buffer :split-action :negative))
     (change-buffer-mode buffer 'sldb-mode)
     (setf (buffer-read-only-p buffer) nil)
     (setf (variable-value 'line-wrap :buffer buffer) nil)
@@ -500,7 +499,7 @@
   (save-excursion
     (lem/language-mode:go-to-location source-location
                                       (lambda (buffer)
-                                        (setf (current-window)
+                                        (switch-to-window
                                               (pop-to-buffer buffer))))
     (lisp-compile-defun)))
 

--- a/modes/python-mode/run-python.lisp
+++ b/modes/python-mode/run-python.lisp
@@ -57,7 +57,7 @@
               (ppcre:scan "^... " (line-string p)))
       (lem/listener-mode:refresh-prompt buffer nil))
     (unless already-exists
-      (setf (current-window) (pop-to-buffer buffer)))
+      (switch-to-window (pop-to-buffer buffer)))
     (alexandria:when-let (window (first (get-buffer-windows buffer)))
       (with-current-window window
         (buffer-end p)

--- a/modes/scheme-mode/repl.lisp
+++ b/modes/scheme-mode/repl.lisp
@@ -61,14 +61,14 @@
      (lem/listener-mode:listener-start "*scheme-repl*" 'scheme-repl-mode))
     ((:scheme-process)
      (scheme-run-process)
-     (setf (current-window) (pop-to-buffer (scheme-process-buffer))))
+     (switch-to-window (pop-to-buffer (scheme-process-buffer))))
     (t
      (editor-error "Scheme repl is not available."))))
 
 (define-command scheme-switch-to-repl-buffer () ()
   (let ((buffer (repl-buffer)))
     (if buffer
-        (setf (current-window) (pop-to-buffer buffer))
+        (switch-to-window (pop-to-buffer buffer))
         (start-scheme-repl))))
 
 (define-command scheme-eval-or-newline () ()
@@ -368,7 +368,7 @@
   (let ((buffer (repl-buffer)))
     (push thread (read-string-thread-stack))
     (push tag (read-string-tag-stack))
-    (setf (current-window) (pop-to-buffer buffer))
+    (switch-to-window (pop-to-buffer buffer))
     (buffer-end (current-point))
     (lem/listener-mode:change-input-start-point (current-point))
     (repl-change-read-line-input)))

--- a/modes/scheme-mode/swank-connection.lisp
+++ b/modes/scheme-mode/swank-connection.lisp
@@ -896,7 +896,7 @@
      (let ((xref-location (source-location-to-xref-location source-location)))
        (go-to-location xref-location
                        (lambda (buffer)
-                         (setf (current-window)
+                         (switch-to-window
                                (pop-to-buffer buffer))))))))
 
 (defun source-location-to-xref-location (location &optional content no-errors)

--- a/modes/shell-mode/shell-mode.lisp
+++ b/modes/shell-mode/shell-mode.lisp
@@ -81,5 +81,5 @@
                             :output-callback-type :process-input)))
 
 (define-command run-shell () ()
-  (setf (current-window)
+  (switch-to-window
         (pop-to-buffer (run-shell-internal))))

--- a/src/ext/directory-mode.lisp
+++ b/src/ext/directory-mode.lisp
@@ -373,7 +373,7 @@
                                    (let ((buffer (execute-find-file *find-file-executor*
                                                                     (get-file-mode pathname)
                                                                     pathname)))
-                                     (setf (current-window)
+                                     (switch-to-window
                                            (pop-to-buffer buffer))))))
 
 (define-command directory-mode-next-line (p) ("p")

--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -88,7 +88,7 @@
   (listener-history (current-buffer)))
 
 (defun default-switch-to-buffer (buffer)
-  (setf (current-window) (pop-to-buffer buffer)))
+  (switch-to-window (pop-to-buffer buffer)))
 
 (defun listener-start (buffer-name mode &key (switch-to-buffer-function 'default-switch-to-buffer))
   (let ((buffer (make-buffer buffer-name)))

--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -76,7 +76,6 @@
 
 (defun move-current-point-to-x-y-position (window x y)
   (switch-to-window window)
-  (setf (current-window) window)
   (move-point (current-point) (window-view-point window))
   (move-to-next-virtual-line (current-point) y)
   (move-to-virtual-line-column (current-point) x))


### PR DESCRIPTION
This replaces all the uses of `(setf (current-window))`to switch windows (except pop-up windows) with `(switch-to-window)`.