### PR TITLE
Set WM_CLASS in X11

### DIFF
--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -27,6 +27,8 @@
 (defconstant +display-width+ 100)
 (defconstant +display-height+ 40)
 
+(defvar +lem-x11-wm-class+ "Lem SDL2")
+
 (defmacro with-bindings (bindings &body body)
   `(let ,bindings
      (let ((bt:*default-special-bindings*
@@ -56,6 +58,19 @@
 (defmacro with-debug ((&rest args) &body body)
   `(call-with-debug (lambda () (log:debug ,@args))
                     (lambda () ,@body)))
+
+;; this is SDL2 way
+;; if the stable version of SDL is 3, set WM_CLASS is set via hint SDL_HINT_APP_ID
+;;
+;; cf.
+;; - how SDL3 gets WM_CLASS:
+;;     - https://github.com/libsdl-org/SDL/blob/d3f2de7f297d761a7dc5b0dda3c7b5d7bd49eac9/src/video/x11/SDL_x11window.c#L633C40-L633C40
+;; - how to set WM_CLASS in here:
+;;     - SDL_SetHint() function with key SDL_HINT_APP_ID
+;;     - https://wiki.libsdl.org/SDL2/SDL_SetHint
+;;     - https://github.com/libsdl-org/SDL/blob/d3f2de7f297d761a7dc5b0dda3c7b5d7bd49eac9/src/core/unix/SDL_appid.c#L63C45-L63C45
+(defun set-x11-wm-class (classname)
+  (setf (uiop:getenv "SDL_VIDEO_X11_WMCLASS") classname))
 
 (defun create-texture (renderer width height)
   (sdl2:create-texture renderer
@@ -773,6 +788,7 @@
                      nil)))))
 
 (defun create-display (function)
+  (set-x11-wm-class +lem-x11-wm-class+)
   (sdl2:with-init (:video)
     (sdl2-ttf:init)
     (sdl2-image:init '(:png))


### PR DESCRIPTION
Before this PR Lem SDL2 has various WM_CLASS like `sbcl`, `lem-sdl2`, etc... It caused X11's WM_CLASS is not set explicitly. Because of it we cannot configure some software detect Lem process with WM_CLASS e.g. [xkeysnail](https://github.com/mooz/xkeysnail).

This PR sets WM_CLASS as `Lem SDL2` so now users can be find Lem SDL2 process via windos class name.

I checked WM_CLASS is set after this commit like this:

```
;; clicked lem window after launching `lem-sdl2` or `lem -f sdl2` or something
$ xprop | grep WM_CLASS
WM_CLASS(STRING) = "Lem SDL2", "Lem SDL2"
```