### PR TITLE
Add lisp-search-symbol command

### DIFF
--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -800,13 +800,16 @@
     (list (make-xref-location :filespec (point-buffer point)
                               :position (position-at-point point)))))
 
+(defun find-definitions-by-name (name)
+  (let ((definitions (lisp-eval `(micros:find-definitions-for-emacs ,name))))
+    (definitions-to-locations definitions)))
+
 (defun find-definitions-default (point)
   (let ((name (or (symbol-string-at-point point)
                   (prompt-for-symbol-name "Edit Definition of: "))))
     (alexandria:when-let (result (find-local-definition point name))
       (return-from find-definitions-default result))
-    (let ((definitions (lisp-eval `(micros:find-definitions-for-emacs ,name))))
-      (definitions-to-locations definitions))))
+    (find-definitions-by-name name)))
 
 (defparameter *find-definitions* '(find-definitions-default))
 


### PR DESCRIPTION
Added `M-x lisp-search-symbol (C-c C-d s)`.

Use apropos to search for a symbol and jump to the location of the definition.
Inspired by lsp workspace/symbol.