### PR TITLE
Add lem-lisp-mode:*lisp-repl-mode-hook*.

### DIFF
--- a/extensions/lisp-mode/internal-package.lisp
+++ b/extensions/lisp-mode/internal-package.lisp
@@ -81,6 +81,7 @@
    :slime-self-connect
    ;; repl.lisp
    :*lisp-repl-mode-keymap*
+   :*lisp-repl-mode-hook*
    :open-inspector-by-repl
    :lisp-repl-interrupt
    :repl-buffer

--- a/extensions/lisp-mode/repl.lisp
+++ b/extensions/lisp-mode/repl.lisp
@@ -9,7 +9,8 @@
 (define-major-mode lisp-repl-mode lisp-mode
     (:name "REPL"
      :keymap *lisp-repl-mode-keymap*
-     :syntax-table lem-lisp-syntax:*syntax-table*)
+     :syntax-table lem-lisp-syntax:*syntax-table*
+     :mode-hook *lisp-repl-mode-hook*)
   (cond
     ((eq (repl-buffer) (current-buffer))
      (repl-reset-input)


### PR DESCRIPTION
I need it to enable vi INSERT mode automatically when starting the REPL.