### PR TITLE
Add lem-lisp-mode:*lisp-sldb-mode-hook*.

### DIFF
--- a/extensions/lisp-mode/sldb.lisp
+++ b/extensions/lisp-mode/sldb.lisp
@@ -17,6 +17,7 @@
            :local-value-attribute
            :catch-tag-attribute
            :*sldb-keymap*
+           :*lisp-sldb-mode-hook*
            :sldb-down
            :sldb-up
            :sldb-details-down
@@ -85,7 +86,8 @@
 
 (define-major-mode sldb-mode lisp-ui-mode
     (:name "SLDB"
-     :keymap *sldb-keymap*))
+     :keymap *sldb-keymap*
+     :mode-hook *lisp-sldb-mode-hook*))
 
 (define-key *sldb-keymap* "n" 'sldb-down)
 (define-key *sldb-keymap* "p" 'sldb-up)


### PR DESCRIPTION
Similarly to #896, I want to change the vi-mode state to NORMAL in SLDB mode.

ex. https://github.com/fukamachi/.lem/commit/ba23d4569c8d226d6378fb2ac64a03f7a49e310b