### PR TITLE
lem-core:config-plist errors out when ~/.lem/config.lisp is empty

### DIFF
--- a/src/config.lisp
+++ b/src/config.lisp
@@ -16,12 +16,14 @@
 (defun config-plist ()
   (let ((pathname (ensure-config-pathname)))
     (if (uiop:file-exists-p pathname)
-        (uiop:read-file-form pathname)
+        (uiop:read-file-forms pathname)
         '())))
 
 (defun config (key &optional default)
   (let ((plist (config-plist)))
-    (getf plist key default)))
+    (if (car plist)
+        (getf (car plist) key default))))
+       
 
 (defun (setf config) (value key &optional default)
   (declare (ignore default))


### PR DESCRIPTION
If .lem/config.el is empty it gives the following error:

```
   Unhandled SB-KERNEL:INDEX-TOO-LARGE-ERROR in thread #<SB-THREAD:THREAD tid=8219 "SDL2 Main Thread" RUNNING
							 {10043281F3}>:
    The index 0 is too large for a list of length 0.

  Backtrace for: #<SB-THREAD:THREAD tid=8219 "SDL2 Main Thread" RUNNING {10043281F3}>
  0: (SB-DEBUG::DEBUGGER-DISABLED-HOOK #<SB-KERNEL:INDEX-TOO-LARGE-ERROR expected-type: (INTEGER 0 (0)) datum: 0> #<unused argument> :QUIT T)
  1: (SB-DEBUG::RUN-HOOK *INVOKE-DEBUGGER-HOOK* #<SB-KERNEL:INDEX-TOO-LARGE-ERROR expected-type: (INTEGER 0 (0)) datum: 0>)
  2: (INVOKE-DEBUGGER #<SB-KERNEL:INDEX-TOO-LARGE-ERROR expected-type: (INTEGER 0 (0)) datum: 0>)
  3: (ERROR SB-KERNEL:INDEX-TOO-LARGE-ERROR :DATUM 0 :SEQUENCE NIL :EXPECTED-TYPE (INTEGER 0 (0)))
  4: (SB-IMPL::SIGNAL-INDEX-TOO-LARGE-ERROR NIL 0)
  5: (ELT NIL 0)
  6: (UIOP/STREAM:CALL-WITH-INPUT-FILE #P"/home/user/.lem/config.lisp" #<FUNCTION (LAMBDA (UIOP/STREAM::INPUT) :IN UIOP/STREAM:READ-FILE-FORM) {100434847B}> :ELEMENT-TYPE NIL :EXTERNAL-FORMAT NIL :IF-DOES-NOT-EXIST :ERROR)
  7: (LEM-CORE:CONFIG :SDL2-FONT-SIZE 15)
  8: (LEM-SDL2/FONT:MAKE-FONT-CONFIG :SIZE NIL :LATIN-NORMAL-FILE NIL :LATIN-BOLD-FILE NIL :CJK-NORMAL-FILE NIL :CJK-BOLD-FILE NIL :EMOJI-FILE NIL :BRAIL-FILE NIL)
  9: ((LAMBDA NIL :IN LEM-SDL2::CREATE-DISPLAY))
  10: (SDL2::HANDLE-MESSAGE (#<FUNCTION (LAMBDA NIL :IN LEM-SDL2::CREATE-DISPLAY) {100432835B}> . #S(TRIVIAL-CHANNELS:CHANNEL :QUEUE #S(TRIVIAL-CHANNELS.QUEUE:QUEUE :HEAD NIL :TAIL NIL) :Q-CONDITION #<SB-THREAD:WAITQUEUE Anonymous condition variable {1004328393}> :Q-MUTEX #<SB-THREAD:MUTEX "Anonymous lock" free owner=0>)))
  11: (SDL2::SDL-MAIN-THREAD)
  12: ((LABELS BORDEAUX-THREADS::%BINDING-DEFAULT-SPECIALS-WRAPPER :IN BORDEAUX-THREADS::BINDING-DEFAULT-SPECIALS))
  13: ((FLET SB-UNIX::BODY :IN SB-THREAD::RUN))
  14: ((FLET "WITHOUT-INTERRUPTS-BODY-174" :IN SB-THREAD::RUN))
  15: ((FLET SB-UNIX::BODY :IN SB-THREAD::RUN))
  16: ((FLET "WITHOUT-INTERRUPTS-BODY-167" :IN SB-THREAD::RUN))
  17: (SB-THREAD::RUN)
  18: ("foreign function: call_into_lisp_")
  19: ("foreign function: funcall1")
```

It looks like it is coming from src/config.lisp. This problem comes
about whether I use sdl2 or ncurses. I just happen to use sdl2.

## A bunch of junk that no one cares about:
sdl2::sdl-main-thread calls sdl2::handle-message which calls
sdl2::create-display which calls lem-sdl2/font:make-font-config which
calls a constructor %make-font-config which constructs a struct. That
struct has multiple slots which call lem-core:config to get config
information. 

## The actual problem: 

If $HOME/.lem/config.lisp is empty we get an error because
lem-core:config (from src/config.lisp) calls lem-core:config-plist
which uses uiop:read-file-form. But uiop:read-file-form uses
uiop:slurp-stream-form which reads a file using loop inside
uiop:slurp-stream-forms, the whole list gets returned to
slurp-stream-form where it then calls uiop:access-at to access
whatever you set the at arg to (which in this case wasnt set so at = 0
and it tries to access element 0, but since the file is empty there is
no first element in that list and it errors out saying
index-too-large-error.


# Solution: Just use uiop:read-file-forms
It gets called anyways and you can just do a check in lem-core:config
to see if its nil or not.
