### PR TITLE
Attempt #2: config-plist errors out when ~/.lem/config.lisp is empty

### DIFF
--- a/src/config.lisp
+++ b/src/config.lisp
@@ -21,8 +21,7 @@
 
 (defun config (key &optional default)
   (let ((plist (config-plist)))
-    (if (car plist)
-        (getf (car plist) key default))))
+    (getf (car plist) key default)))
        
 
 (defun (setf config) (value key &optional default)


### PR DESCRIPTION
Sorry, I made a mistake in the altered config function. 

I should not have included the if statement otherwise config returns nil, not even the default value. Instead we just needed to add (car plist) otherwise everything else stays the way you wrote it.

My previous commit leaves all the settings unset.