### PR TITLE
Add ';' for vi-mode to find a char in the same line repeatedly.

### DIFF
--- a/extensions/vi-mode/binds.lisp
+++ b/extensions/vi-mode/binds.lisp
@@ -76,6 +76,7 @@
 (define-key *command-keymap* "F" 'vi-find-char-backward)
 (define-key *command-keymap* "t" 'vi-find-char-before)
 (define-key *command-keymap* "T" 'vi-find-char-backward-after)
+(define-key *command-keymap* ";" 'vi-find-char-repeat)
 (define-key *command-keymap* "z z" 'recenter)
 (define-key *command-keymap* "Z Z" 'vi-write-quit)
 (define-key *command-keymap* "C-w s" 'split-active-window-vertically)


### PR DESCRIPTION
`;` is a key command for finding a char in the same line (`f`, `F`, `t`, `T`) by the last searched query.