### PR TITLE
Introduce Vim's options feature, and add `:set` & `:cd`

### DIFF
--- a/extensions/vi-mode/core.lisp
+++ b/extensions/vi-mode/core.lisp
@@ -3,7 +3,7 @@
         :lem
         :lem/universal-argument)
   (:import-from :cl-package-locks)
-  (:import-from #:cl-ppcre)
+  (:import-from :cl-ppcre)
   (:export :*enable-hook*
            :*disable-hook*
            :vi-state

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -1,13 +1,13 @@
 (defpackage :lem-vi-mode/ex-command
   (:use :cl :lem-vi-mode/ex-core)
-  (:import-from #:lem-vi-mode/core
-                #:expand-filename-modifiers)
-  (:import-from #:lem-vi-mode/jump-motions
-                #:with-jump-motion)
-  (:import-from #:lem-vi-mode/options
-                #:execute-set-command)
-  (:import-from #:lem-vi-mode/core
-                #:change-directory))
+  (:import-from :lem-vi-mode/core
+                :expand-filename-modifiers)
+  (:import-from :lem-vi-mode/jump-motions
+                :with-jump-motion)
+  (:import-from :lem-vi-mode/options
+                :execute-set-command)
+  (:import-from :lem-vi-mode/core
+                :change-directory))
 (in-package :lem-vi-mode/ex-command)
 
 (defun ex-write (range filename touch)

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -3,7 +3,9 @@
   (:import-from #:lem-vi-mode/jump-motions
                 #:with-jump-motion)
   (:import-from #:lem-vi-mode/options
-                #:execute-set-command))
+                #:execute-set-command)
+  (:import-from #:lem-vi-mode/core
+                #:change-directory))
 (in-package :lem-vi-mode/ex-command)
 
 (defun ex-write (range filename touch)
@@ -157,20 +159,7 @@
           (lem:message "~A: ~S => ~S" option-name old-value option-value)
           (lem:message "~A: ~S" option-name option-value)))))
 
-(defvar *previous-cwd* nil)
-
 (define-ex-command "^cd$" (range new-directory)
   (declare (ignore range))
-  (let* ((previous-directory (uiop:getcwd))
-         (new-directory (cond
-                          ((string= new-directory "")
-                           (user-homedir-pathname))
-                          ((string= new-directory "-")
-                           (or *previous-cwd* previous-directory))
-                          (t
-                           (truename
-                            (merge-pathnames (uiop:ensure-directory-pathname new-directory) previous-directory))))))
-    (uiop:chdir new-directory)
-    (unless (uiop:pathname-equal *previous-cwd* previous-directory)
-      (setf *previous-cwd* previous-directory))
+  (let ((new-directory (change-directory new-directory)))
     (lem:message "~A" new-directory)))

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -156,3 +156,21 @@
                (not (equal option-value old-value)))
           (lem:message "~A: ~S => ~S" option-name old-value option-value)
           (lem:message "~A: ~S" option-name option-value)))))
+
+(defvar *previous-cwd* nil)
+
+(define-ex-command "^cd$" (range new-directory)
+  (declare (ignore range))
+  (let* ((previous-directory (uiop:getcwd))
+         (new-directory (cond
+                          ((string= new-directory "")
+                           (user-homedir-pathname))
+                          ((string= new-directory "-")
+                           (or *previous-cwd* previous-directory))
+                          (t
+                           (truename
+                            (merge-pathnames (uiop:ensure-directory-pathname new-directory) previous-directory))))))
+    (uiop:chdir new-directory)
+    (unless (uiop:pathname-equal *previous-cwd* previous-directory)
+      (setf *previous-cwd* previous-directory))
+    (lem:message "~A" new-directory)))

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -1,7 +1,9 @@
 (defpackage :lem-vi-mode/ex-command
   (:use :cl :lem-vi-mode/ex-core)
   (:import-from #:lem-vi-mode/jump-motions
-                #:with-jump-motion))
+                #:with-jump-motion)
+  (:import-from #:lem-vi-mode/options
+                #:execute-set-command))
 (in-package :lem-vi-mode/ex-command)
 
 (defun ex-write (range filename touch)
@@ -147,3 +149,13 @@
 (define-ex-command "^(buffers|ls|files)$" (range argument)
   (declare (ignore range argument))
   (lem/list-buffers:list-buffers))
+
+(define-ex-command "^set?$" (range option-string)
+  (declare (ignore range))
+  (multiple-value-bind (option-value option-name old-value isset)
+      (execute-set-command option-string)
+    (let ((lem-core::*message-timeout* 10))
+      (if (and isset
+               (not (equal option-value old-value)))
+          (lem:message "~A: ~S => ~S" option-name old-value option-value)
+          (lem:message "~A: ~S" option-name option-value)))))

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -23,18 +23,7 @@
 
 (define-ex-command "^e$" (range filename)
   (declare (ignore range))
-  (lem:find-file (merge-pathnames filename
-                                  (lem:buffer-directory))))
-
-(define-ex-command "^(b|buffer)$" (range buffer-name)
-  (declare (ignore range))
-  (lem:select-buffer buffer-name))
-
-(define-ex-command "^bd(?:elete)?$" (range buffer-name)
-  (declare (ignore range))
-  (lem:kill-buffer (if (string= buffer-name "")
-                       (lem:current-buffer)
-                       buffer-name)))
+  (lem:find-file (merge-pathnames filename (uiop:getcwd))))
 
 (define-ex-command "^(w|write)$" (range filename)
   (ex-write range filename t))
@@ -83,15 +72,13 @@
   (declare (ignore range))
   (lem:split-active-window-vertically)
   (unless (string= filename "")
-    (lem:find-file (merge-pathnames filename
-                                    (lem:buffer-directory)))))
+    (lem:find-file (merge-pathnames filename (uiop:getcwd)))))
 
 (define-ex-command "^(vs|vsplit)$" (range filename)
   (declare (ignore range))
   (lem:split-active-window-horizontally)
   (unless (string= filename "")
-    (lem:find-file (merge-pathnames filename
-                                    (lem:buffer-directory)))))
+    (lem:find-file (merge-pathnames filename (uiop:getcwd)))))
 
 (define-ex-command "^(s|substitute)$" (range argument)
   (with-jump-motion
@@ -149,6 +136,16 @@
 (define-ex-command "^(buffers|ls|files)$" (range argument)
   (declare (ignore range argument))
   (lem/list-buffers:list-buffers))
+
+(define-ex-command "^(b|buffer)$" (range buffer-name)
+  (declare (ignore range))
+  (lem:select-buffer buffer-name))
+
+(define-ex-command "^bd(?:elete)?$" (range buffer-name)
+  (declare (ignore range))
+  (lem:kill-buffer (if (string= buffer-name "")
+                       (lem:current-buffer)
+                       buffer-name)))
 
 (define-ex-command "^set?$" (range option-string)
   (declare (ignore range))

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -1,5 +1,7 @@
 (defpackage :lem-vi-mode/ex-command
   (:use :cl :lem-vi-mode/ex-core)
+  (:import-from #:lem-vi-mode/core
+                #:expand-filename-modifiers)
   (:import-from #:lem-vi-mode/jump-motions
                 #:with-jump-motion)
   (:import-from #:lem-vi-mode/options
@@ -25,7 +27,7 @@
 
 (define-ex-command "^e$" (range filename)
   (declare (ignore range))
-  (lem:find-file (merge-pathnames filename (uiop:getcwd))))
+  (lem:find-file (merge-pathnames (expand-filename-modifiers filename) (uiop:getcwd))))
 
 (define-ex-command "^(w|write)$" (range filename)
   (ex-write range filename t))
@@ -74,13 +76,13 @@
   (declare (ignore range))
   (lem:split-active-window-vertically)
   (unless (string= filename "")
-    (lem:find-file (merge-pathnames filename (uiop:getcwd)))))
+    (lem:find-file (merge-pathnames (expand-filename-modifiers filename) (uiop:getcwd)))))
 
 (define-ex-command "^(vs|vsplit)$" (range filename)
   (declare (ignore range))
   (lem:split-active-window-horizontally)
   (unless (string= filename "")
-    (lem:find-file (merge-pathnames filename (uiop:getcwd)))))
+    (lem:find-file (merge-pathnames (expand-filename-modifiers filename) (uiop:getcwd)))))
 
 (define-ex-command "^(s|substitute)$" (range argument)
   (with-jump-motion
@@ -161,5 +163,5 @@
 
 (define-ex-command "^cd$" (range new-directory)
   (declare (ignore range))
-  (let ((new-directory (change-directory new-directory)))
+  (let ((new-directory (change-directory (expand-filename-modifiers new-directory))))
     (lem:message "~A" new-directory)))

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -155,11 +155,10 @@
   (declare (ignore range))
   (multiple-value-bind (option-value option-name old-value isset)
       (execute-set-command option-string)
-    (let ((lem-core::*message-timeout* 10))
-      (if (and isset
-               (not (equal option-value old-value)))
-          (lem:message "~A: ~S => ~S" option-name old-value option-value)
-          (lem:message "~A: ~S" option-name option-value)))))
+    (if (and isset
+             (not (equal option-value old-value)))
+        (lem:show-message (format nil "~A: ~S => ~S" option-name old-value option-value) :timeout 10)
+        (lem:show-message (format nil "~A: ~S" option-name option-value) :timeout 10))))
 
 (define-ex-command "^cd$" (range new-directory)
   (declare (ignore range))

--- a/extensions/vi-mode/ex.lisp
+++ b/extensions/vi-mode/ex.lisp
@@ -13,7 +13,7 @@
    :keymap *ex-keymap*))
 
 (define-command vi-ex () ()
-  (let ((directory (lem:buffer-directory)))
+  (let ((directory (uiop:getcwd)))
     (with-state 'ex
       (execute-ex
        (prompt-for-string
@@ -21,8 +21,8 @@
         :completion-function
         (lambda (str)
           (cond
-            ((ppcre:scan "^(e|vs|sp)[ \\.]" str)
-             (let ((comp-str (ppcre:regex-replace "^(e|vs|sp)\\s*" str "")))
+            ((ppcre:scan "^(?:(?:e|vs|sp)[ \\.]|cd )" str)
+             (let ((comp-str (ppcre:regex-replace "^(e|vs|sp|cd)\\s*" str "")))
                (if (string= comp-str ".")
                    (list (format nil "~A/" str))
                    ;; Almost same as prompt-file-complete in lem-core/completion-file.lisp
@@ -43,7 +43,8 @@
                                   :end (line-end e)))))
                            (lem/completion-mode::completion-file
                             comp-str
-                            directory)))))
+                            directory
+                            :directory-only (and (ppcre:scan "^cd " str) t))))))
             ((ppcre:scan "^(?:b(?:uffer)?|bd(?:elete)?) " str)
              (let ((comp-str (ppcre:regex-replace "^(?:b(?:uffer)?|bd(?:elete)?)\\s+" str "")))
                (mapcar (lambda (buffer)

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -1,13 +1,17 @@
 (defsystem "lem-vi-mode"
   :depends-on ("esrap"
                "closer-mop"
-               "lem")
+               "lem"
+               "cl-ppcre"
+               "parse-number"
+               "alexandria")
   :serial t
   :components ((:file "core")
                (:file "word")
                (:file "visual")
                (:file "jump-motions")
                (:file "commands")
+               (:file "options")
                (:file "ex-core")
                (:file "ex-parser")
                (:file "ex-command")

--- a/extensions/vi-mode/options.lisp
+++ b/extensions/vi-mode/options.lisp
@@ -54,7 +54,7 @@
         (gethash name *options*)
       (when (and (null exists)
                  error-if-not-exists)
-        (error "Unknown option: ~A" name))
+        (lem:editor-error "Unknown option: ~A" name))
       option)))
 
 (defun vi-option-value (option)
@@ -67,8 +67,8 @@
 (defun (setf vi-option-value) (new-value option)
   (with-slots (type set-hook) option
     (unless (typep new-value type)
-      (error "Option '~A' accepts only ~S, but given ~S"
-             (vi-option-name option) type new-value))
+      (lem:editor-error "Option '~A' accepts only ~S, but given ~S"
+                        (vi-option-name option) type new-value))
     (let ((old-value (vi-option-value option)))
       (multiple-value-prog1
           (values
@@ -86,7 +86,7 @@
 (defun toggle-option-value (option)
   (with-slots (name type) option
     (unless (eq type 'boolean)
-      (error "Can't toggle non-boolean option: '~A' (type=~S)" name type)))
+      (lem:editor-error "Can't toggle non-boolean option: '~A' (type=~S)" name type)))
   (setf (vi-option-value option)
         (not (vi-option-value option))))
 

--- a/extensions/vi-mode/options.lisp
+++ b/extensions/vi-mode/options.lisp
@@ -1,0 +1,151 @@
+(defpackage #:lem-vi-mode/options
+  (:use #:cl)
+  (:import-from #:parse-number
+                #:parse-number)
+  (:import-from #:cl-ppcre
+                #:scan-to-strings)
+  (:import-from #:alexandria
+                #:if-let
+                #:when-let
+                #:once-only
+                #:with-gensyms)
+  (:export #:define-vi-option
+           #:get-option
+           #:vi-option
+           #:vi-option-name
+           #:vi-option-value
+           #:vi-option-default
+           #:vi-option-type
+           #:vi-option-aliases
+           #:vi-option-getter
+           #:vi-option-set-hook
+           #:vi-option-documentation
+           #:reset-vi-option-value
+           #:toggle-vi-option-value
+           #:execute-set-command))
+(in-package #:lem-vi-mode/options)
+
+(defstruct vi-option
+  (name nil :type string)
+  %value
+  default
+  (type t :type (member t boolean number string))
+  (aliases '() :type list)
+  (getter nil :type (or function null))
+  (set-hook nil :type (or function null))
+  (documentation nil :type (or string null)))
+
+(defvar *options* (make-hash-table :test 'equal))
+(defvar *option-aliases* (make-hash-table :test 'equal))
+
+(defmacro define-vi-option (name (default &key (type t) aliases) &rest others)
+  (once-only (name default)
+    (with-gensyms (option alias)
+      `(progn
+         (dolist (,alias ',aliases)
+           (setf (gethash ,alias *option-aliases*) ,name))
+         (check-type ,default ,type)
+         (let ((,option
+                 (make-vi-option :name ,name
+                                 :%value ,default
+                                 :default ,default
+                                 :type ',type
+                                 :aliases ',aliases
+                                 :getter ,(when-let (getter-arg (find :getter others :key #'car))
+                                            `(lambda () ,@(rest getter-arg)))
+                                 :set-hook ,(when-let (set-hook-arg (find :set-hook others :key #'car))
+                                              `(lambda ,@(rest set-hook-arg)))
+                                 :documentation ,(when-let (doc-arg (find :documentation others :key #'car))
+                                                   (second doc-arg)))))
+           (setf (gethash ,name *options*) ,option))))))
+
+(defun canonical-option-name (name)
+  (or (gethash name *option-aliases*)
+      name))
+
+(defun get-option (name &optional (error-if-not-exists t))
+  (check-type name string)
+  (let ((name (canonical-option-name name)))
+    (multiple-value-bind (option exists)
+        (gethash name *options*)
+      (when (and (null exists)
+                 error-if-not-exists)
+        (error "Unknown option: ~A" name))
+      option)))
+
+(defun vi-option-value (option)
+  (values
+   (if-let (getter (vi-option-getter option))
+     (funcall getter)
+     (vi-option-%value option))
+   (vi-option-name option)))
+
+(defun (setf vi-option-value) (new-value option)
+  (with-slots (type set-hook) option
+    (unless (typep new-value type)
+      (error "Option '~A' accepts only ~S, but given ~S"
+             (vi-option-name option) type new-value))
+    (let ((old-value (vi-option-value option)))
+      (multiple-value-prog1
+          (values
+           (setf (vi-option-%value option) new-value)
+           (vi-option-name option)
+           old-value
+           t)
+        (when set-hook
+          (funcall set-hook new-value))))))
+
+(defun reset-option-value (option)
+  (setf (vi-option-value option)
+        (vi-option-default option)))
+
+(defun toggle-option-value (option)
+  (with-slots (name type) option
+    (unless (eq type 'boolean)
+      (error "Can't toggle non-boolean option: '~A' (type=~S)" name type)))
+  (setf (vi-option-value option)
+        (not (vi-option-value option))))
+
+(defun parse-option-string (option-string)
+  (coerce
+   (nth-value 1
+              (ppcre:scan-to-strings "^(no|inv)?([^?!&=:]+)(\\?|\\!|&|=|:)?(.+)?$" option-string))
+   'list))
+
+(defun execute-set-command (option-string)
+  (destructuring-bind (prefix option-name suffix new-value)
+      (parse-option-string option-string)
+    (let ((option (get-option option-name)))
+      (cond
+        ((equal suffix "?")
+         (vi-option-value option))
+        ((equal prefix "no")
+         (setf (vi-option-value option) nil))
+        ((or (equal prefix "inv")
+             (equal suffix "!"))
+         (toggle-option-value option))
+        ((equal suffix "&")
+         (reset-option-value option))
+        ((member suffix '("=" ":") :test 'equal)
+         (setf (vi-option-value option)
+               (case (vi-option-type option)
+                 (boolean
+                  (cond
+                    ((string-equal new-value "t") t)
+                    ((string-equal new-value "nil") nil)
+                    (t new-value)))
+                 (number
+                  (handler-case (parse-number new-value)
+                    (error () new-value)))
+                 (string
+                  new-value)
+                 (otherwise new-value))))
+        (t
+         (assert (and (null prefix)
+                      (null suffix)))
+         (setf (vi-option-value option) t))))))
+
+(define-vi-option "autochdir" (nil :type boolean :aliases ("acd"))
+  (:documentation "A flag on whether change the current directory to the buffer directory automatically.
+  Default: nil
+  Aliases: acd"))

--- a/extensions/vi-mode/options.lisp
+++ b/extensions/vi-mode/options.lisp
@@ -1,5 +1,7 @@
 (defpackage #:lem-vi-mode/options
   (:use #:cl)
+  (:import-from #:lem-vi-mode/core
+                #:change-directory)
   (:import-from #:parse-number
                 #:parse-number)
   (:import-from #:cl-ppcre
@@ -145,7 +147,14 @@
                       (null suffix)))
          (setf (vi-option-value option) t))))))
 
+(defun auto-change-directory (buffer)
+  (change-directory (lem:buffer-directory buffer)))
+
 (define-vi-option "autochdir" (nil :type boolean :aliases ("acd"))
   (:documentation "A flag on whether change the current directory to the buffer directory automatically.
   Default: nil
-  Aliases: acd"))
+  Aliases: acd")
+  (:set-hook (new-value)
+   (if new-value
+       (lem:add-hook lem:*find-file-hook* 'auto-change-directory)
+       (lem:remove-hook lem:*find-file-hook* 'auto-change-directory))))

--- a/extensions/vi-mode/options.lisp
+++ b/extensions/vi-mode/options.lisp
@@ -1,34 +1,34 @@
-(defpackage #:lem-vi-mode/options
-  (:use #:cl)
-  (:import-from #:lem-vi-mode/core
-                #:change-directory)
-  (:import-from #:parse-number
-                #:parse-number)
-  (:import-from #:cl-ppcre
-                #:scan-to-strings)
-  (:import-from #:alexandria
-                #:if-let
-                #:when-let
-                #:once-only
-                #:with-gensyms)
-  (:export #:define-vi-option
-           #:get-option
-           #:vi-option
-           #:vi-option-name
-           #:vi-option-value
-           #:vi-option-default
-           #:vi-option-type
-           #:vi-option-aliases
-           #:vi-option-getter
-           #:vi-option-set-hook
-           #:vi-option-documentation
-           #:reset-vi-option-value
-           #:toggle-vi-option-value
-           #:execute-set-command
+(defpackage :lem-vi-mode/options
+  (:use :cl)
+  (:import-from :lem-vi-mode/core
+                :change-directory)
+  (:import-from :parse-number
+                :parse-number)
+  (:import-from :cl-ppcre
+                :scan-to-strings)
+  (:import-from :alexandria
+                :if-let
+                :when-let
+                :once-only
+                :with-gensyms)
+  (:export :define-vi-option
+           :get-option
+           :vi-option
+           :vi-option-name
+           :vi-option-value
+           :vi-option-default
+           :vi-option-type
+           :vi-option-aliases
+           :vi-option-getter
+           :vi-option-set-hook
+           :vi-option-documentation
+           :reset-vi-option-value
+           :toggle-vi-option-value
+           :execute-set-command
 
            ;; Options
-           #:autochdir))
-(in-package #:lem-vi-mode/options)
+           :autochdir))
+(in-package :lem-vi-mode/options)
 
 (defstruct vi-option
   (name nil :type string)

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -3,8 +3,13 @@
         :lem
         :lem-vi-mode/core
         :lem-vi-mode/ex)
+  (:import-from #:lem-vi-mode/options
+                #:autochdir)
   (:export :vi-mode
            :define-vi-state
            :*command-keymap*
            :*insert-keymap*
-           :*ex-keymap*))
+           :*ex-keymap*
+
+           ;; Options
+           #:autochdir))

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -3,8 +3,8 @@
         :lem
         :lem-vi-mode/core
         :lem-vi-mode/ex)
-  (:import-from #:lem-vi-mode/options
-                #:autochdir)
+  (:import-from :lem-vi-mode/options
+                :autochdir)
   (:export :vi-mode
            :define-vi-state
            :*command-keymap*
@@ -12,4 +12,4 @@
            :*ex-keymap*
 
            ;; Options
-           #:autochdir))
+           :autochdir))


### PR DESCRIPTION
## Quick troubleshooting

### Q. Why does the `:e` command no longer complete from the directory of the file being edited?

It is to make Lem's vi-mode closer to Vim's behavior. If you prefer the previous behavior, there's 2 options to achieve:


### A1. Turn `autochdir` option on

Set `autochdir` to `t` in your `init.lisp`:

```common-lisp
(setf (lem-vi-mode:autochdir) t)
```

To change the option temporarily, just execute `:set autochdir` (and `:set noautochdir` to turn off).

### A2. Change the current directory manually

Use `:cd` command to change the directory manually:

```vim
" Move to "extensions/vi-mode"
:cd extensions/vi-mode
" `%:h` expands to the directory of the current buffer's file
:cd %:h
" `-` means the previous directory
:cd -
```

## Changes

* Add Vim's options feature
  * Currently only `autochdir` is implemented
    * Works when running `:e` (`find-file`) or switching the buffer/window
* **[Incompatible changes]** Change the base directory to find with `:e` to the **current directory**
  * You need to change the directory manually with `:cd`
    * `:cd %:h` moves to the current buffer's directory (See "filename modifiers" below)
  * Or, turn `autochdir` option on
* Add "filename modifiers" which would be expanded in `:e`, `:vs`, `:sp`, and `:cd`
  * Examples:
    * `%`: The current buffer's file path
    * `%:p`: The absolute pathname of the current buffer's file path
    * `%:h`: The current buffer's directory
    * `%:e`: The file extension of the current buffer's file
    * `%:t`: The filename of the current buffer's file
    * `%:r`: The root of the filename
* Add `:cd` for changing the current directory
  * `:cd <dir>` moves to the `<dir>`
  * `:cd` moves to the home directory
  * `:cd -` moves to the previous directory
* Add `:set` (also `:se` works)
  * Examples:
    * Turn on: `:set autochdir`, `:set acd`, `:set acd=t`
    * Turn off: `:set noautochdir`, `:set noacd`, `:set acd=nil`
    * Toggle: `:set invautochdir`, `:set autochdir!`, `:set invacd`, `:set acd!`
    * Get the current value: `:set autochdir`, `:set acd?`
    * Reset to the default: `:set autochdir&`, `:set acd&`
  * In `init.lisp`
    * `(setf (lem-vi-mode:autochdir) t)`