### PR TITLE
Enable syntax highlighting in the listener as well

### DIFF
--- a/extensions/lisp-mode/repl.lisp
+++ b/extensions/lisp-mode/repl.lisp
@@ -13,6 +13,7 @@
      :mode-hook *lisp-repl-mode-hook*)
   (cond
     ((eq (repl-buffer) (current-buffer))
+     (setf (variable-value 'enable-syntax-highlight) t)
      (repl-reset-input)
      (lem/listener-mode:start-listener-mode (merge-pathnames "history/lisp-repl" (lem-home)))
      (setf (variable-value 'completion-spec) 'repl-completion)

--- a/src/base/line.lisp
+++ b/src/base/line.lisp
@@ -229,7 +229,8 @@
 
 (defun line-string/attributes (line)
   (cons (line-str line)
-        (getf (line-plist line) :attribute)))
+        (append (getf (line-plist line) :sticky-attribute)
+                (getf (line-plist line) :attribute))))
 
 (defun line-free (line)
   (when (line-prev line)

--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -61,7 +61,6 @@
 
 (defun start-listener-mode (&optional history-pathname)
   (listener-mode t)
-  (setf (variable-value 'enable-syntax-highlight) nil)
   (unless (listener-history (current-buffer))
     (setf (listener-history (current-buffer))
           (lem/common/history:make-history :pathname history-pathname))
@@ -113,7 +112,7 @@
       (line-start s)
       (let ((attribute (variable-value 'listener-prompt-attribute :default buffer)))
         (when attribute
-          (put-text-property s point :attribute attribute)))
+          (put-text-property s point :sticky-attribute attribute)))
       (put-text-property s point :read-only t)
       (put-text-property s point :field t))))
 
@@ -231,7 +230,7 @@
               (with-point ((start point)
                            (end point))
                 (character-offset end 1)
-                (put-text-property start end :attribute attribute)))
+                (put-text-property start end :sticky-attribute attribute)))
     (buffer-start point)
     buffer))
 


### PR DESCRIPTION
lem is including color information in the attribute property of the buffer, when syntax highlighting is enabled, this value is overwritten, so when a listener sets an attribute to a prompt, it is erased.
In this PR, sticky-attribute is newly added separately from attribute.
The listener now sets this to the prompt.