### PR TITLE
Add lem-if:update-cursor-shape to change the cursor's shape for lem-ncurses

### DIFF
--- a/extensions/vi-mode/core.lisp
+++ b/extensions/vi-mode/core.lisp
@@ -66,6 +66,7 @@
   :reader state-message)
   (cursor-type 
   :initarg :cursor-type
+  :initform :box
   :reader state-cursor-type)
   (keymap
   :initarg :keymap
@@ -149,13 +150,14 @@
 ;; insert state
 (defvar *insert-keymap* (make-keymap :name '*insert-keymap* :parent *global-keymap*))
 
-(define-vi-state insert () () 
+(define-vi-state insert () ()
   (:default-initargs
    :message "-- INSERT --"
    :cursor-color "IndianRed"
+   :cursor-type :bar
    :keymap *insert-keymap*))
 
-(define-vi-state vi-modeline () () 
+(define-vi-state vi-modeline () ()
   (:default-initargs
    :keymap *inactive-keymap*))
 
@@ -180,3 +182,7 @@
             (finalize-vi-modeline)
             (remove-hook *prompt-activate-hook* 'prompt-activate-hook)
             (remove-hook *prompt-deactivate-hook* 'prompt-deactivate-hook)))
+
+(defmethod state-enabled-hook :after (state)
+  (lem-if:update-cursor-shape (lem-core:implementation)
+                              (state-cursor-type state)))

--- a/frontends/ncurses/ncurses.lisp
+++ b/frontends/ncurses/ncurses.lisp
@@ -273,7 +273,7 @@
   (uiop:run-program `("printf"
                       ,(format nil "~C[~D q"
                                #\Esc
-                               (typecase cursor-type
+                               (case cursor-type
                                  (:box 2)
                                  (:bar 5)
                                  (:underline 4)

--- a/frontends/ncurses/ncurses.lisp
+++ b/frontends/ncurses/ncurses.lisp
@@ -269,6 +269,18 @@
 (defmethod lem-if:update-foreground ((implementation ncurses) color-name)
   (lem.term:term-set-foreground color-name))
 
+(defmethod lem-if:update-cursor-shape ((implementation ncurses) cursor-type)
+  (uiop:run-program `("printf"
+                      ,(format nil "~C[~D q"
+                               #\Esc
+                               (typecase cursor-type
+                                 (:box 2)
+                                 (:bar 5)
+                                 (:underline 4)
+                                 (otherwise 2))))
+                    :output :interactive
+                    :ignore-error-status t))
+
 (defmethod lem-if:update-background ((implementation ncurses) color-name)
   (lem.term:term-set-background color-name))
 

--- a/src/interface.lisp
+++ b/src/interface.lisp
@@ -38,6 +38,8 @@
 (defgeneric lem-if:get-background-color (implementation))
 (defgeneric lem-if:update-foreground (implementation color-name))
 (defgeneric lem-if:update-background (implementation color-name))
+(defgeneric lem-if:update-cursor-shape (implementation cursor-type)
+  (:method (implementation cursor-type)))
 (defgeneric lem-if:display-width (implementation))
 (defgeneric lem-if:display-height (implementation))
 (defgeneric lem-if:display-title (implementation))

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -518,6 +518,7 @@
    :get-background-color
    :update-foreground
    :update-background
+   :update-cursor-shape
    :display-width
    :display-height
    :display-title


### PR DESCRIPTION
**This also affects other than vi-mode.**. 
Please review changes if this doesn't break other Lem's features or frontends.

Adds `lem-if:update-cursor-shape` to change the cursor's shape, like a box, a vertical bar, or an underline.  
It works only on ncurses frontend for now.

In vi-mode, the cursor will be changed to 'vertial bar' on INSERT mode.