### PR TITLE
Add "number" option to show line numbers in vi-mode.

### DIFF
--- a/extensions/vi-mode/README.md
+++ b/extensions/vi-mode/README.md
@@ -1,8 +1,40 @@
 # vi-mode
 
+## Usage
 
-To enable,add `~/.lem/init.lisp`
+To enable, add the following code to `~/.lem/init.lisp`:
 
-```
+```common-lisp
 (lem-vi-mode:vi-mode)
 ```
+
+## Defining keymaps
+
+```common-lisp
+;; NORMAL mode
+(define-key lem-vi-mode:*command-keymap* "q" 'quit-window)
+(define-key lem-vi-mode:*command-keymap* "Space @" 'paredit-splice)
+
+;; INSERT mode
+(define-key lem-vi-mode:*insert-keymap* "(" 'paredit-insert-paren)
+(define-key lem-vi-mode:*insert-keymap* ")" 'paredit-close-parenthesis)
+```
+
+## Options
+
+Vi-mode options are global settings, similarly to Vim.
+
+They can be set with `:set` command, or a function `vi-option-value` in `~/.lem/init.lisp`, like:
+
+```common-lisp
+(setf (lem-vi-mode:vi-option-value "autochdir") t)
+```
+
+Here's a list of all options currently implemented:
+
+* `autochdir`: Boolean to change the current directory to the buffer's directory automatically.
+  * Default: `nil` (don't change the current directory)
+  * Aliases: `acd`
+* `number`: Boolean to show the line number.
+  * Default: `nil` (don't show)
+  * Aliases: `nu`

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -4,12 +4,10 @@
         :lem-vi-mode/core
         :lem-vi-mode/ex)
   (:import-from :lem-vi-mode/options
-                :autochdir)
+                :vi-option-value)
   (:export :vi-mode
            :define-vi-state
            :*command-keymap*
            :*insert-keymap*
            :*ex-keymap*
-
-           ;; Options
-           :autochdir))
+           :vi-option-value))


### PR DESCRIPTION
Also, stop defining functions for each option, because `number` conflicts with the common-lisp package. (ref #908)