### PR TITLE
Add test detection with detective and some handy lisp commands to run the test on the REPL

### DIFF
--- a/extensions/lisp-mode/detective.lisp
+++ b/extensions/lisp-mode/detective.lisp
@@ -6,7 +6,7 @@
 
 (defun %default-capture (class position)
   (let* ((line (str:split #\Space (line-string position)))
-         (name (second line)))
+         (name (str:replace-all ")" ""  (second line))))
     (make-instance class
                    :reference-name name
                    :reference-point position)))
@@ -29,4 +29,14 @@
 
 (defmethod capture-reference ((position lem:point) (class (eql :package-reference)))
   (%default-capture 'lem/detective:package-reference position))
+
+(defmethod capture-reference ((position lem:point) (class (eql :misc-reference)))
+  (let* ((line (str:split #\Space (line-string position)))
+         (type (str:replace-all "(" "" (first line)))
+         (name (second line)))
+    (make-instance 'lem/detective:misc-reference
+                   :misc-custom-type type
+                   :reference-name name
+                   :reference-point position)))
+
 

--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -60,6 +60,10 @@
                        :variable-regex
                        (lem/detective:make-capture-regex
                         :regex "^(?:\\(defvar |\\(defparameter )"
+                        :function #'lem-lisp-mode/detective:capture-reference)
+                       :misc-regex
+                       (lem/detective:make-capture-regex
+                        :regex "^\\(deftest "
                         :function #'lem-lisp-mode/detective:capture-reference)))
   (set-syntax-parser lem-lisp-syntax:*syntax-table*
                      (make-tmlanguage-lisp))

--- a/extensions/lisp-mode/misc-commands.lisp
+++ b/extensions/lisp-mode/misc-commands.lisp
@@ -55,6 +55,7 @@
 
 
 (defparameter *run-test-function-name* "rove:run-test")
+(defparameter *run-suite-test-function-name* "rove:run-suite")
 
 (defun %send-test-reference (package test)
   (lem-lisp-mode/internal::lisp-switch-to-repl-buffer)
@@ -65,6 +66,16 @@
            *run-test-function-name*
            (str:replace-all ":" "" (lem/detective:reference-name package))
            (lem/detective:reference-name test)))
+  (lem/listener-mode:listener-return))
+
+(defun %send-test-suite (suite-package)
+  (lem-lisp-mode/internal::lisp-switch-to-repl-buffer)
+  (buffer-end (current-point))
+  (insert-string
+   (current-point)
+   (format nil "(~A ~A)"
+           *run-suite-test-function-name*
+           (lem/detective:reference-name suite-package)))
   (lem/listener-mode:listener-return))
 
 (define-command lisp-test-run-buffer () ()
@@ -95,3 +106,10 @@
                         "deftest"))
         (%send-test-reference package reference)
         (message "Current reference is not a test."))))
+
+(define-command lisp-test-run-suite () ()
+  (lem/detective::check-change)
+  (let* ((buffer-references (lem/detective:buffer-references
+                             (current-buffer)))
+         (package (car (gethash "packages" buffer-references))))
+    (%send-test-suite package)))

--- a/extensions/lisp-mode/misc-commands.lisp
+++ b/extensions/lisp-mode/misc-commands.lisp
@@ -54,29 +54,44 @@
   (lem-lisp-syntax:defstruct-to-defclass (current-point)))
 
 
-(defun move-to-deftest-toplevel-form (point)
-  (or (looking-at point "\\(deftest\\s")
-      (progn (lisp-beginning-of-defun point 1)
-             (looking-at point "\\(deftest\\s"))))
-
-(defun get-deftest-name (point)
-  (with-point ((point point))
-    (when (and (move-to-deftest-toplevel-form point)
-               (scan-lists point 1 -1 t)
-               (form-offset point 1)
-               (skip-whitespace-forward point))
-      (with-point ((start point)
-                   (end point))
-        (form-offset end 1)
-        (points-to-string start end)))))
-
 (defparameter *run-test-function-name* "rove:run-test")
 
-(define-command lisp-run-test () ()
-  (let* ((package-name (buffer-package (current-buffer)))
-         (test-name (get-deftest-name (current-point)))
-         (form-string (format nil "(~A '~A::~A)" *run-test-function-name* package-name test-name)))
-    (start-lisp-repl)
-    (buffer-end (current-point))
-    (insert-string (current-point) form-string)
-    (lem/listener-mode:listener-return)))
+(defun %send-test-reference (package test)
+  (lem-lisp-mode/internal::lisp-switch-to-repl-buffer)
+  (buffer-end (current-point))
+  (insert-string
+   (current-point)
+   (format nil "(~A '~A::~A)"
+           *run-test-function-name*
+           (str:replace-all ":" "" (lem/detective:reference-name package))
+           (lem/detective:reference-name test)))
+  (lem/listener-mode:listener-return))
+
+(define-command lisp-test-run-buffer () ()
+  (lem/detective::check-change :force t)
+  (alexandria:when-let*
+      ((buffer-references (lem/detective:buffer-references
+                           (current-buffer)))
+       (package (car (gethash "packages" buffer-references)))
+       (test-references
+        (remove-if-not #'(lambda (x)
+                           (string-equal "deftest" x))
+                       (gethash "misc" buffer-references)
+                       :key #'lem/detective:misc-custom-type))
+       (selected-test
+        (lem/detective::%get-reference test-references
+                                       :prompt "Test: ")))
+    (%send-test-reference package selected-test)))
+
+(define-command lisp-test-run-current () ()
+  (lem/detective::check-change :force t)
+  (let* ((buffer-references (lem/detective:buffer-references
+                             (current-buffer)))
+         (package (car (gethash "packages" buffer-references)))
+         (reference (lem/detective::current-reference)))
+    ;;TODO: Make a regex for the test posiblities
+    (if (and (typep reference 'lem/detective:misc-reference)
+          (string-equal (lem/detective:misc-custom-type reference)
+                        "deftest"))
+        (%send-test-reference package reference)
+        (message "Current reference is not a test."))))

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -201,10 +201,13 @@
 (defmethod move-to-reference (reference)
   (message "Not reference available in current buffer."))
 
-(defun check-change ()
-  (cond 
+(defun check-change (&key (force nil))
+  (cond
+   (force
+    (search-references
+     (variable-value 'lem/language-mode:detective-search :buffer)))
    ((null (buffer-references (current-buffer)))
-    (search-references 
+    (search-references
      (variable-value 'lem/language-mode:detective-search :buffer)))
 
    ((not (eql (buffer-value (current-buffer) 'prev-tick)

--- a/src/ext/detective.lisp
+++ b/src/ext/detective.lisp
@@ -172,10 +172,10 @@
 
 (defgeneric capture-reference (point class))
 
-(defun %get-reference (references)
+(defun %get-reference (references &key (prompt "Navigate: "))
   (alexandria:when-let* ((name-references (mapcar #'reference-name references))
                          (item
-                          (prompt-for-string "Navigate: "
+                          (prompt-for-string prompt
                                              :completion-function (lambda (x) (completion-strings x name-references))
 
                                              :test-function (lambda (name)


### PR DESCRIPTION
- Add the detective ability to get misc references (only tests for now)
- Add a few convenience options to detective, so it's more flexible
- Add two commands to run tests:  `lisp-test-run-buffer` and `lisp-test-run-current`