### PR TITLE
Fix new bugs of vi-mode introduced by #952

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -447,12 +447,12 @@
   (redo n)
   (fall-within-line (current-point)))
 
-(defun vi-forward-matching-paren (window point &optional (offset *cursor-offset*))
-  (declare (ignore window offset))
+(defun vi-forward-matching-paren (window point &optional (offset -1))
+  (declare (ignore window))
   (with-point ((point point))
     (when (syntax-open-paren-char-p (character-at point))
       (when (scan-lists point 1 0 t)
-        (character-offset point *cursor-offset*)))))
+        (character-offset point offset)))))
 
 (defun vi-backward-matching-paren (window point &optional (offset -1))
   (declare (ignore window offset))
@@ -463,7 +463,7 @@
     (:type :inclusive
      :jump t)
   (alexandria:when-let ((p (or (vi-backward-matching-paren (current-window) (current-point))
-                               (vi-forward-matching-paren (current-window) (current-point) *cursor-offset*))))
+                               (vi-forward-matching-paren (current-window) (current-point)))))
     (move-point (current-point) p)))
 
 (let ((old-forward-matching-paren)

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -287,7 +287,9 @@
 
 (define-vi-operator vi-delete (start end type) ()
   (let ((pos (point-charpos (current-point))))
-    (with-killring-context (:options (when (eq type :line) :vi-line))
+    (with-killring-context (:options (when (eq type :line) :vi-line)
+                            :appending (when (eq type :block)
+                                         (continue-flag :kill)))
       (kill-region start end))
     (when (and (eq type :line)
                (eq 'vi-delete (command-name (this-command))))

--- a/extensions/vi-mode/commands/utils.lisp
+++ b/extensions/vi-mode/commands/utils.lisp
@@ -173,7 +173,9 @@
                  (:line (unless (visual-p)
                           (line-start start)
                           (line-end end)))
-                 (:inclusive (character-offset end 1))
+                 (:inclusive
+                  (unless (point= start end)
+                    (character-offset end 1)))
                  (:exclusive))
                (let ((*vi-operator-arguments* (list start end type)))
                  (funcall fn start end type))))


### PR DESCRIPTION
## Bug fixed

* Fix `d%` to work regardless of whether the direction is forward or backward
* Fix `df<char>` and `dt<char>` not to delete if the search failed
* Support visual block mode to make `d` & `y` work with a rectangle region

ref #952 