### PR TITLE
Add "iskeyword" option

### DIFF
--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -153,12 +153,22 @@
 
 (define-ex-command "^set?$" (range option-string)
   (declare (ignore range))
-  (multiple-value-bind (option-value option-name old-value isset)
-      (execute-set-command option-string)
-    (if (and isset
-             (not (equal option-value old-value)))
-        (lem:show-message (format nil "~A: ~S => ~S" option-name old-value option-value) :timeout 10)
-        (lem:show-message (format nil "~A: ~S" option-name option-value) :timeout 10))))
+  (flet ((encode-value (value)
+           (typecase value
+             (list (format nil "~{~A~^,~}" value))
+             (otherwise value))))
+    (multiple-value-bind (option-value option-name old-value isset)
+        (execute-set-command option-string)
+      (let ((*print-case* :downcase))
+        (if (and isset
+                 (not (equal option-value old-value)))
+            (lem:show-message (format nil "~A: ~S => ~S"
+                                      option-name
+                                      (encode-value old-value)
+                                      (encode-value option-value))
+                              :timeout 10)
+            (lem:show-message (format nil "~A: ~S" option-name (encode-value option-value))
+                              :timeout 10))))))
 
 (define-ex-command "^cd$" (range new-directory)
   (declare (ignore range))

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -9,6 +9,7 @@
                "split-sequence")
   :serial t
   :components ((:file "core")
+               (:file "options")
                (:file "word")
                (:file "visual")
                (:file "jump-motions")
@@ -17,7 +18,6 @@
                 :components
                 ((:file "utils")))
                (:file "commands")
-               (:file "options")
                (:file "ex-core")
                (:file "ex-parser")
                (:file "ex-command")

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -5,7 +5,8 @@
                "cl-ppcre"
                "parse-number"
                "cl-package-locks"
-               "alexandria")
+               "alexandria"
+               "split-sequence")
   :serial t
   :components ((:file "core")
                (:file "word")

--- a/extensions/vi-mode/options.lisp
+++ b/extensions/vi-mode/options.lisp
@@ -20,6 +20,7 @@
            :vi-option
            :vi-option-name
            :vi-option-value
+           :vi-option-raw-value
            :vi-option-default
            :vi-option-type
            :vi-option-aliases
@@ -79,12 +80,15 @@
     (vi-option name-or-option)
     (string (get-option name-or-option error-if-not-exists))))
 
+(defun vi-option-raw-value (option)
+  (vi-option-%value (ensure-option option)))
+
 (defun vi-option-value (option)
   (let ((option (ensure-option option)))
     (values
      (if-let (getter (vi-option-getter option))
        (funcall getter option)
-       (vi-option-%value option))
+       (vi-option-raw-value option))
      (vi-option-name option))))
 
 (defun (setf vi-option-value) (new-value option)
@@ -320,7 +324,7 @@
   Default: @,48-57,_,192-255
   Aliases: isk")
   (:getter (option)
-   (car (vi-option-%value option)))
+   (car (vi-option-raw-value option)))
   (:setter (new-value option)
    (setf (vi-option-%value option)
          (cons new-value


### PR DESCRIPTION
## Description

Add "iskeyword" of vi-mode option, which is used to specify a character set to be treated as a `word` by vi-mode.

* Type: a list of strings
* Default: `@,48-57,_,192-255`
* Alias: `isk`

## Usage

It can be set in ex mode, like `:set iskeyword=@,_`. Be sure it must be a comma-separated string in ex mode.

In this PR, several set operations like `+=`, `-=`, `^=` are also added, which can be used like `:set iskeyword+=@-@` to add a new value.

To set in `init.lisp`, a function `vi-option-value` is available:

```common-lisp
(import 'lem-vi-mode:vi-option-value)
(setf (vi-option-value "iskeyword") '("@" "_"))
```