### PR TITLE
NeoVim-like status indicator for vi-mode

### DIFF
--- a/extensions/vi-mode/core.lisp
+++ b/extensions/vi-mode/core.lisp
@@ -43,44 +43,73 @@
 
 (defvar *modeline-element*)
 
-(define-attribute state-attribute
-  (t :reverse t))
+(define-attribute state-modeline-white
+  (t :foreground "white" :reverse t))
+
+(define-attribute state-modeline-yellow
+  (t :foreground "yellow" :reverse t))
+
+(define-attribute state-modeline-green
+  (t :foreground "#003300" :reverse t))
+
+(define-attribute state-modeline-aqua
+  (t :foreground "#33CCFF" :reverse t))
+
+(define-attribute state-modeline-orange
+  (t :foreground "orange" :reverse t))
 
 (defstruct (vi-modeline-element (:conc-name element-))
-  name)
+  name
+  attribute)
 
 (defmethod convert-modeline-element ((element vi-modeline-element) window)
-  (values (element-name element) 'state-attribute))
+  (if (or (eq (lem:current-window) window)
+          (string= (element-name element) " COMMAND "))
+      (values (element-name element)
+              (element-attribute element))
+      (values "" 'state-modeline-white)))
 
 (defun initialize-vi-modeline ()
   (setf *modeline-element* (make-vi-modeline-element))
-  (modeline-add-status-list *modeline-element*))
+  (pushnew *modeline-element* (lem:variable-value 'lem:modeline-format :global)))
 
 (defun finalize-vi-modeline ()
   (modeline-remove-status-list *modeline-element*))
 
-(defun change-element-name (name)
-  (setf (element-name *modeline-element*) name))
+(defun change-element-by-state (state)
+  (setf (element-name *modeline-element*) (format nil " ~A " (state-name state))
+        (element-attribute *modeline-element*) (state-modeline-color state)))
 
 
 (defclass vi-state ()
-  ((message
-  :initarg :message
-  :reader state-message)
-  (cursor-type 
-  :initarg :cursor-type
-  :initform :box
-  :reader state-cursor-type)
-  (keymap
-  :initarg :keymap
-  :reader state-keymap)
-  (cursor-color
-  :initarg :cursor-color
-  :accessor state-cursor-color))
+  ((name :initarg :name
+         :reader state-name)
+   (message
+    :initarg :message
+    :reader state-message)
+   (cursor-type
+    :initarg :cursor-type
+    :initform :box
+    :reader state-cursor-type)
+   (modeline-color
+    :initarg :modeline-color
+    :initform 'state-modeline-white
+    :reader state-modeline-color)
+   (keymap
+    :initarg :keymap
+    :reader state-keymap)
+   (cursor-color
+    :initarg :cursor-color
+    :accessor state-cursor-color))
   (:default-initargs
-        :message nil
-        :cursor-color nil
-        :keymap *global-keymap*))
+   :message nil
+   :cursor-color nil
+   :keymap *global-keymap*))
+
+(defmethod initialize-instance ((state vi-state) &rest initargs &key name &allow-other-keys)
+  (unless name
+    (setf (getf initargs :name) (class-name (class-of state))))
+  (apply #'call-next-method state initargs))
 
 (defvar *current-state* nil)
 
@@ -127,7 +156,7 @@
   (let ((state (ensure-state name)))
     (setf *current-state* name)
     (change-global-mode-keymap 'vi-mode (state-keymap state))
-    (change-element-name (format nil "[~A]" name))
+    (change-element-by-state state)
     (state-enabled-hook state)
     (unless *default-cursor-color*
       (setf *default-cursor-color*
@@ -148,7 +177,8 @@
 
 (define-vi-state normal () ()
   (:default-initargs
-   :keymap *command-keymap*))
+   :keymap *command-keymap*
+   :modeline-color 'state-modeline-yellow))
 
 ;; insert state
 (defvar *insert-keymap* (make-keymap :name '*insert-keymap* :parent *global-keymap*))
@@ -158,10 +188,13 @@
    :message "-- INSERT --"
    :cursor-color "IndianRed"
    :cursor-type :bar
+   :modeline-color 'state-modeline-aqua
    :keymap *insert-keymap*))
 
 (define-vi-state vi-modeline () ()
   (:default-initargs
+   :name "COMMAND"
+   :modeline-color 'state-modeline-green
    :keymap *inactive-keymap*))
 
 (defun prompt-activate-hook () (change-state 'vi-modeline))

--- a/extensions/vi-mode/visual.lisp
+++ b/extensions/vi-mode/visual.lisp
@@ -24,16 +24,21 @@
 (define-vi-state visual (vi-state) ()
   (:default-initargs
    :message "-- VISUAL --"
+   :modeline-color 'lem-vi-mode/core::state-modeline-orange
    :keymap *visual-keymap*))
 
-(define-vi-state visual-char (visual) ())
+(define-vi-state visual-char (visual)
+  ()
+  (:default-initargs :name "VISUAL"))
 
 (define-vi-state visual-line (visual) ()
   (:default-initargs
+   :name "V-LINE"
    :message "-- VISUAL LINE --"))
 
 (define-vi-state visual-block (visual) ()
   (:default-initargs
+   :name "V-BLOCK"
    :message "-- VISUAL BLOCK --"))
 
 (defmethod state-enabled-hook :after ((state visual))


### PR DESCRIPTION
I don't know if this is the appropriate way (and works in other environments) to set it up in Lem.

<img width="682" alt="Screen Shot 2023-08-20 at 1 16 05" src="https://github.com/lem-project/lem/assets/90570/ce17f9e7-edcb-455d-a904-49876b1e1b90">
<img width="682" alt="Screen Shot 2023-08-20 at 1 16 12" src="https://github.com/lem-project/lem/assets/90570/f1b1954b-bd95-4860-bee5-58364dc2aed1">
<img width="682" alt="Screen Shot 2023-08-20 at 1 16 29" src="https://github.com/lem-project/lem/assets/90570/36e6be43-13ef-4e9f-adfb-11bd59f6b190">
<img width="682" alt="Screen Shot 2023-08-20 at 1 16 49" src="https://github.com/lem-project/lem/assets/90570/b9dfa908-b08c-43a3-a0c0-e8a24c3fd644">
