### PR TITLE
Add some process helping functions

### DIFF
--- a/lib/process/process.lisp
+++ b/lib/process/process.lisp
@@ -20,6 +20,10 @@
    (output-callback
     :initarg :output-callback
     :reader process-output-callback)
+   (output-buffer
+    :initarg :output-buffer
+    :reader process-output-buffer
+    :type lem:buffer)
    (callback-type
     :initarg :output-callback-type
     :reader process-output-callback-type)))


### PR DESCRIPTION
So, the idea is to get a buffer to store all the raw information that comes from that process and output that to a helping buffer.
Given that this can create some noise on the number of buffers, maybe this can be optional, and only be trigger with a flag.

So, I don't know if I'm taking the output correctly, maybe there is another function to get the output in a better way.