### PR TITLE
site-init: use lem-home instead of user's home directory

### DIFF
--- a/src/config.lisp
+++ b/src/config.lisp
@@ -5,7 +5,7 @@
 	(dot-lem (merge-pathnames ".lem/" (user-homedir-pathname))))
     (or (uiop:getenv "LEM_HOME")
 	(and (probe-file dot-lem) dot-lem)
-	  xdg-lem)))
+	xdg-lem)))
 
 (defun lem-logdir-pathname ()
   (merge-pathnames "logs/" (lem-home)))

--- a/src/site-init.lisp
+++ b/src/site-init.lisp
@@ -4,9 +4,9 @@
 (defvar *site-init-comment ";; don't edit !!!")
 
 (defun site-init-path ()
-  (let ((path (merge-pathnames (format nil ".lem/~A.asd"
+  (let ((path (merge-pathnames (format nil "~A.asd"
                                        *site-init-name*)
-                               (user-homedir-pathname))))
+                               (lem-home))))
     (with-open-file (out (ensure-directories-exist path)
                          :direction :output
                          :if-exists nil)


### PR DESCRIPTION
Currently this drops lem-site-init.asd into ~/.lem which causes lem-home to always use ~/.lem instead of XDG_CONFIG_HOME + lem

small whitespace fix in config.lisp #434
