### PR TITLE
Add `lem:this-command-keys` and `lem:universal-argument-of-this-command`

### DIFF
--- a/src/command.lisp
+++ b/src/command.lisp
@@ -11,7 +11,7 @@
 (defvar *this-command-keys* '()
   "List containing the key sequence that invoked the present command.")
 
-(defvar *current-prefix-arg* nil
+(defvar *universal-argument* nil
   "The raw prefix argument for the current command.")
 
 (defun this-command ()
@@ -27,7 +27,7 @@
 (defun call-command (this-command universal-argument)
   "Call first argument as the command, passing remaining arguments to it."
   (let ((*this-command* (ensure-command this-command))
-        (*current-prefix-arg* universal-argument))
+        (*universal-argument* universal-argument))
     (unless *this-command*
       (editor-error "~A: command not found" this-command))
     (run-hooks *pre-command-hook*)

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -8,6 +8,9 @@
 (defvar *this-command*
   "The command now being executed.")
 
+(defvar *current-prefix-arg* nil
+  "The raw prefix argument for the current command.")
+
 (defun this-command ()
   "Return the command now being executed."
   *this-command*)
@@ -16,7 +19,8 @@
 
 (defun call-command (this-command universal-argument)
   "Call first argument as the command, passing remaining arguments to it."
-  (let ((*this-command* (ensure-command this-command)))
+  (let ((*this-command* (ensure-command this-command))
+        (*current-prefix-arg* universal-argument))
     (unless *this-command*
       (editor-error "~A: command not found" this-command))
     (run-hooks *pre-command-hook*)

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -8,12 +8,19 @@
 (defvar *this-command*
   "The command now being executed.")
 
+(defvar *this-command-keys* '()
+  "List containing the key sequence that invoked the present command.")
+
 (defvar *current-prefix-arg* nil
   "The raw prefix argument for the current command.")
 
 (defun this-command ()
   "Return the command now being executed."
   *this-command*)
+
+(defun this-command-keys ()
+  "Return the list of key sequence that invoked the present command."
+  (reverse *this-command-keys*))
 
 (defgeneric execute (mode command argument))
 

--- a/src/command.lisp
+++ b/src/command.lisp
@@ -22,6 +22,10 @@
   "Return the list of key sequence that invoked the present command."
   (reverse *this-command-keys*))
 
+(defun universal-argument-of-this-command ()
+  "Return the universal argument of this command now being executed."
+  *universal-argument*)
+
 (defgeneric execute (mode command argument))
 
 (defun call-command (this-command universal-argument)

--- a/src/input.lisp
+++ b/src/input.lisp
@@ -66,6 +66,7 @@
 (defun unread-key (key)
   (when *key-recording-p*
     (pop *record-keys*))
+  (pop *this-command-keys*)
   (push key *unread-keys*))
 
 (defun read-command ()
@@ -91,7 +92,9 @@
   (last-read-key-sequence))
 
 (defun unread-key-sequence (kseq)
-  (setf *unread-keys* (nconc *unread-keys* kseq)))
+  (prog1 (setf *unread-keys* (nconc *unread-keys* kseq))
+    (setf *this-command-keys*
+          (nthcdr (length kseq) *this-command-keys*))))
 
 (defun execute-key-sequence (key-sequence)
   (let ((*unread-keys* key-sequence))

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -315,10 +315,10 @@
   (:export
    :*pre-command-hook*
    :*post-command-hook*
-   :*universal-argument*
    :command-name
    :this-command
    :this-command-keys
+   :universal-argument-of-this-command
    :execute
    :call-command
    :all-command-names)

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -315,7 +315,7 @@
   (:export
    :*pre-command-hook*
    :*post-command-hook*
-   :*current-prefix-arg*
+   :*universal-argument*
    :command-name
    :this-command
    :this-command-keys

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -318,6 +318,7 @@
    :*current-prefix-arg*
    :command-name
    :this-command
+   :this-command-keys
    :execute
    :call-command
    :all-command-names)

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -315,6 +315,7 @@
   (:export
    :*pre-command-hook*
    :*post-command-hook*
+   :*current-prefix-arg*
    :command-name
    :this-command
    :execute

--- a/src/interp.lisp
+++ b/src/interp.lisp
@@ -94,7 +94,8 @@
                          #'editor-abort-handler)
                        (editor-condition
                          #'editor-condition-handler))
-          (read-command-and-call))
+          (let ((*this-command-keys* '()))
+            (read-command-and-call)))
       (editor-condition (c)
         (restart-case (error c)
           (lem-restart:message ()

--- a/src/lem.lisp
+++ b/src/lem.lisp
@@ -77,7 +77,10 @@ Options:
                 5000)
       (add-hook (variable-value 'before-save-hook :global)
                 (lambda (buffer)
-                  (process-file buffer))))))
+                  (process-file buffer)))
+      (add-hook *input-hook*
+                (lambda (event)
+                  (push event *this-command-keys*))))))
 
 (defun teardown ()
   (teardown-frames))


### PR DESCRIPTION
This PR adds the following symbols:

* `lem:this-command-keys`: A function to get a key sequence that invokes the current command.
* `lem:universal-argument-of-this-command`: A function to get the universal argument of the current command.

These are equivalent to Emacs's `this-command-keys` and `current-prefix-arg`.

ref https://www.gnu.org/software/emacs/manual/html_node/elisp/Command-Loop-Info.html#index-this_002dcommand_002dkeys

Originally, I was making these changes to implement vi-mode's `.`, an operator to repeat the last operation, however, I split them as an individual PR to hear other's thoughts.