### PR TITLE
Fix error in start-loading-spinner

### DIFF
--- a/src/ext/loading-spinner.lisp
+++ b/src/ext/loading-spinner.lisp
@@ -115,7 +115,8 @@
   (let* ((spinner)
          (timer (start-timer (make-timer 
                               (lambda ()
-                                (update-line-spinner spinner)))
+                                (when spinner
+                                  (update-line-spinner spinner))))
                              +loading-interval+
                              t))
          (overlay (make-overlay-line-endings

--- a/src/overlay.lisp
+++ b/src/overlay.lisp
@@ -65,14 +65,16 @@
                                   &key (start-point-kind :right-inserting)
                                        (end-point-kind :left-inserting)
                                        (text (alexandria:required-argument :text))
-                                       (offset 0))
+                                       (offset 0)
+                                       temporary)
   (make-instance 'overlay-line-endings
                  :start (copy-point start start-point-kind)
                  :end (copy-point end end-point-kind)
                  :attribute attribute
                  :buffer (point-buffer start)
                  :text text
-                 :offset offset))
+                 :offset offset
+                 :temporary temporary))
 
 (defun make-overlay-line (point attribute &key (temporary nil))
   (with-point ((point point))


### PR DESCRIPTION
Fix for https://github.com/lem-project/lem/issues/987

- nil is passed to `update-line-spinner`
- The `temporary` slot of `overlay-line-endings` is unbound, causing an error in initialize-instance