### PR TITLE
Revert "Fix not to move the cursor by *isearch-search-function*."

### DIFF
--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -395,9 +395,8 @@
         (concatenate 'string
                      *isearch-string*
                      (string c)))
-  (with-point ((point (current-point)))
-    (unless (funcall *isearch-search-function* point *isearch-string*)
-      (move-point (current-point) point)))
+  (unless (funcall *isearch-search-function* (current-point) *isearch-string*)
+    (move-point (current-point) *isearch-start-point*))
   (isearch-update-display)
   t)
 


### PR DESCRIPTION
This reverts commit 006111d5db33b930bfe069f1b101bec6d5e86f68.

ref https://github.com/lem-project/lem/pull/996#discussion_r1304551049