### PR TITLE
Add a feature to set high priority keymaps for emulation modes

### DIFF
--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -365,6 +365,7 @@
    :abort-key-p
    :with-special-keymap
    :traverse-keymap
+   :compute-keymaps
    :collect-command-keybindings)
   ;; reexport common/timer
   (:export

--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -143,11 +143,16 @@
                 (match-key key :sym sym))
            (char sym 0)))))
 
+(defgeneric compute-keymaps (global-mode)
+  (:method ((mode global-mode)) nil))
+
 (defun all-keymaps ()
-  (let ((keymaps
-          (loop :for mode :in (all-active-modes (current-buffer))
-                :when (mode-keymap mode)
-                :collect :it)))
+  (let* ((keymaps (compute-keymaps (current-global-mode)))
+         (keymaps
+           (append keymaps
+                   (loop :for mode :in (all-active-modes (current-buffer))
+                         :when (mode-keymap mode)
+                         :collect :it))))
     (when *special-keymap*
       (push *special-keymap* keymaps))
     (nreverse keymaps)))


### PR DESCRIPTION
Add a new variable `*emulation-mode-keymaps-functions*` to set keymaps that precede other major/minor modes. This is equivalent to Emacs's `emulation-mode-map-alists` for emulation mode.

ref. [Controlling Active Maps | Emacs manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Controlling-Active-Maps.html#index-emulation_002dmode_002dmap_002dalists)

For the time being, `vi-mode` is in mind. It requires switching multiple keymaps by its "state" and has to _merge_ with others to work better in other modes.

Talking about preceding lisp-mode's keybinds, and problems with directory-mode at #992 .