### PR TITLE
Reorganize packages of vi-mode

### DIFF
--- a/extensions/vi-mode/binds.lisp
+++ b/extensions/vi-mode/binds.lisp
@@ -3,7 +3,7 @@
         :lem
         :lem/universal-argument
         :lem/abbrev
-        :lem-vi-mode/core
+        :lem-vi-mode/states
         :lem-vi-mode/commands
         :lem-vi-mode/ex
         :lem-vi-mode/visual))

--- a/extensions/vi-mode/commands/utils.lisp
+++ b/extensions/vi-mode/commands/utils.lisp
@@ -2,7 +2,11 @@
   (:use :cl
         :lem)
   (:import-from :lem-vi-mode/core
-                :*command-keymap*)
+                :*this-motion-command*
+                :vi-command
+                :vi-motion
+                :vi-motion-type
+                :vi-operator)
   (:import-from :lem-vi-mode/jump-motions
                 :with-jump-motion)
   (:import-from :lem-vi-mode/visual
@@ -22,21 +26,14 @@
            :goto-eol
            :fall-within-line
            :operator-pending-mode-p
-           :this-motion-command
            :read-universal-argument
            :*cursor-offset*
-           :vi-command
-           :vi-motion
-           :vi-motion-type
-           :vi-operator
            :define-vi-motion
-           :define-vi-operator
-           :extract-count-keys))
+           :define-vi-operator))
 (in-package :lem-vi-mode/commands/utils)
 
 (defvar *cursor-offset* -1)
 (defvar *operator-pending-mode* nil)
-(defvar *this-motion-command* nil)
 
 (defun bolp (point)
   "Return t if POINT is at the beginning of a line."
@@ -62,9 +59,6 @@
 (defun operator-pending-mode-p ()
   *operator-pending-mode*)
 
-(defun this-motion-command ()
-  *this-motion-command*)
-
 (defun read-universal-argument ()
   (loop :for key := (read-key)
         :for char := (key-to-char key)
@@ -74,26 +68,6 @@
                  (return-from read-universal-argument
                    (and digits
                         (parse-integer (format nil "~{~D~}" digits))))))
-
-(deftype repeat-type () '(member t nil :motion))
-
-(defclass vi-command ()
-  ((repeat :type repeat-type
-           :initarg :repeat
-           :initform nil
-           :accessor vi-command-repeat)))
-
-(defclass vi-motion (vi-command)
-  ((type :type keyword
-         :initarg :type
-         :initform :exclusive
-         :accessor vi-motion-type)
-   (default-n-arg :type (or null integer)
-                  :initarg :default-n-arg
-                  :initform 1
-                  :accessor vi-motion-default-n-arg)))
-
-(defclass vi-operator (vi-command) ())
 
 (defmethod execute :around (mode (command vi-operator) uarg)
   (declare (ignore mode uarg))
@@ -249,19 +223,3 @@
      (call-define-vi-operator (lambda () ,@body)
                               :keep-visual ,keep-visual
                               :restore-point ,restore-point)))
-
-(defun extract-count-keys (keys)
-  (loop for key in keys
-        for cmd = (lem-core::keymap-find-keybind *command-keymap* key nil)
-        unless (member cmd '(lem/universal-argument:universal-argument-0
-                             lem/universal-argument:universal-argument-1
-                             lem/universal-argument:universal-argument-2
-                             lem/universal-argument:universal-argument-3
-                             lem/universal-argument:universal-argument-4
-                             lem/universal-argument:universal-argument-5
-                             lem/universal-argument:universal-argument-6
-                             lem/universal-argument:universal-argument-7
-                             lem/universal-argument:universal-argument-8
-                             lem/universal-argument:universal-argument-9)
-                       :test 'eq)
-        collect key))

--- a/extensions/vi-mode/core.lisp
+++ b/extensions/vi-mode/core.lisp
@@ -4,8 +4,11 @@
         :lem/universal-argument)
   (:import-from :cl-package-locks)
   (:import-from :cl-ppcre)
+  (:import-from :alexandria
+                :with-gensyms)
   (:export :*enable-hook*
            :*disable-hook*
+           :*default-cursor-color*
            :*last-repeat-keys*
            :*enable-repeat-recording*
            :vi-state
@@ -15,28 +18,29 @@
            :state=
            :change-state
            :with-state
-           :*command-keymap*
-           :*insert-keymap*
-           :*inactive-keymap*
            :pre-command-hook
            :post-command-hook
            :state-enabled-hook
            :state-disabled-hook
-           :normal
-           :insert
-           :change-directory
-           :expand-filename-modifiers
-           :kill-region-without-appending
-           :vi-this-command-keys))
+           :vi-this-command-keys
+           :this-motion-command
+           :vi-command
+           :vi-command-repeat
+           :vi-motion
+           :vi-motion-type
+           :vi-operator))
 (in-package :lem-vi-mode/core)
 
 (defvar *last-repeat-keys* '())
+
 (defvar *default-cursor-color* nil)
 
 (defvar *enable-hook* '())
 (defvar *disable-hook* '())
 
 (defvar *enable-repeat-recording* t)
+
+(defvar *this-motion-command* nil)
 
 (defun enable-hook ()
   (run-hooks *enable-hook*))
@@ -50,56 +54,13 @@
    :disable-hook #'disable-hook))
 
 
-(defvar *modeline-element*)
-
-(define-attribute state-modeline-white
-  (t :foreground "white" :reverse t))
-
-(define-attribute state-modeline-yellow
-  (t :foreground "yellow" :reverse t))
-
-(define-attribute state-modeline-green
-  (t :foreground "#003300" :reverse t))
-
-(define-attribute state-modeline-aqua
-  (t :foreground "#33CCFF" :reverse t))
-
-(define-attribute state-modeline-orange
-  (t :foreground "orange" :reverse t))
-
-(defstruct (vi-modeline-element (:conc-name element-))
-  name
-  attribute)
-
-(defmethod convert-modeline-element ((element vi-modeline-element) window)
-  (if (or (eq (lem:current-window) window)
-          (string= (element-name element) " COMMAND "))
-      (values (element-name element)
-              (element-attribute element))
-      (values "" 'state-modeline-white)))
-
-(defun initialize-vi-modeline ()
-  (setf *modeline-element* (make-vi-modeline-element))
-  (pushnew *modeline-element* (lem:variable-value 'lem:modeline-format :global)))
-
-(defun finalize-vi-modeline ()
-  (setf (lem:variable-value 'lem:modeline-format :global)
-        (remove-if #'vi-modeline-element-p
-                   (lem:variable-value 'lem:modeline-format :global)))
-  (modeline-remove-status-list *modeline-element*)
-  (set-attribute 'cursor :background *default-cursor-color*)
-  (lem-if:update-cursor-shape (lem-core:implementation) :box))
-
-(defun change-element-by-state (state)
-  (setf (element-name *modeline-element*) (format nil " ~A " (state-name state))
-        (element-attribute *modeline-element*) (state-modeline-color state)))
-
 
 (defclass vi-state ()
   ((name :initarg :name
          :reader state-name)
    (message
     :initarg :message
+    :initform nil
     :reader state-message)
    (cursor-type
     :initarg :cursor-type
@@ -111,14 +72,15 @@
     :reader state-modeline-color)
    (keymap
     :initarg :keymap
+    :initform *global-keymap*
     :reader state-keymap)
    (cursor-color
     :initarg :cursor-color
-    :accessor state-cursor-color))
-  (:default-initargs
-   :message nil
-   :cursor-color nil
-   :keymap *global-keymap*))
+    :initform nil)))
+
+(defun state-cursor-color (state)
+  (or (slot-value state 'cursor-color)
+      *default-cursor-color*))
 
 (defmethod initialize-instance ((state vi-state) &rest initargs &key name &allow-other-keys)
   (unless name
@@ -173,53 +135,19 @@
 
 (defun change-state (name)
   (and *current-state*
-       (state-disabled-hook (ensure-state *current-state*))) 
+       (state-disabled-hook (ensure-state *current-state*)))
   (let ((state (ensure-state name)))
     (setf *current-state* name)
     (change-global-mode-keymap 'vi-mode (state-keymap state))
-    (change-element-by-state state)
     (state-enabled-hook state)
-    (unless *default-cursor-color*
-      (setf *default-cursor-color*
-            (attribute-background (ensure-attribute 'cursor nil))))
-    (set-attribute 'cursor :background (or (state-cursor-color state) *default-cursor-color*))))
+    (set-attribute 'cursor :background (state-cursor-color state))))
 
 (defmacro with-state (state &body body)
-  (alexandria:with-gensyms (old-state)
+  (with-gensyms (old-state)
     `(let ((,old-state (current-state)))
        (change-state ,state)
        (unwind-protect (progn ,@body)
          (change-state ,old-state)))))
-
-
-(defvar *command-keymap* (make-keymap :name '*command-keymap*
-                                      :parent *global-keymap*))
-(defvar *inactive-keymap* (make-keymap :parent *global-keymap*))
-
-(define-vi-state normal () ()
-  (:default-initargs
-   :keymap *command-keymap*
-   :modeline-color 'state-modeline-yellow))
-
-;; insert state
-(defvar *insert-keymap* (make-keymap :name '*insert-keymap* :parent *global-keymap*))
-
-(define-vi-state insert () ()
-  (:default-initargs
-   :message "-- INSERT --"
-   :cursor-color "IndianRed"
-   :cursor-type :bar
-   :modeline-color 'state-modeline-aqua
-   :keymap *insert-keymap*))
-
-(define-vi-state vi-modeline () ()
-  (:default-initargs
-   :name "COMMAND"
-   :modeline-color 'state-modeline-green
-   :keymap *inactive-keymap*))
-
-(defun prompt-activate-hook () (change-state 'vi-modeline))
-(defun prompt-deactivate-hook () (change-state 'normal))
 
 (defun vi-pre-command-hook ()
   (when (mode-active-p (current-buffer) 'vi-mode)
@@ -232,79 +160,9 @@
 (add-hook *pre-command-hook* 'vi-pre-command-hook)
 (add-hook *post-command-hook* 'vi-post-command-hook)
 
-(add-hook *enable-hook*
-          (lambda ()
-            (initialize-vi-modeline)
-            (change-state 'normal)
-            (add-hook *prompt-activate-hook* 'prompt-activate-hook)
-            (add-hook *prompt-deactivate-hook* 'prompt-deactivate-hook)))
-
-(add-hook *disable-hook*
-          (lambda ()
-            (finalize-vi-modeline)
-            (remove-hook *prompt-activate-hook* 'prompt-activate-hook)
-            (remove-hook *prompt-deactivate-hook* 'prompt-deactivate-hook)))
-
 (defmethod state-enabled-hook :after (state)
-  (lem-if:update-cursor-shape (lem-core:implementation)
+  (lem-if:update-cursor-shape (lem:implementation)
                               (state-cursor-type state)))
-
-(defvar *previous-cwd* nil)
-
-(defun change-directory (new-directory)
-  (check-type new-directory (or string pathname))
-  (let* ((previous-directory (uiop:getcwd))
-         (new-directory (cond
-                          ((equal new-directory "")
-                           (user-homedir-pathname))
-                          ((equal new-directory "-")
-                           (or *previous-cwd* previous-directory))
-                          (t
-                           (truename
-                            (merge-pathnames (uiop:ensure-directory-pathname new-directory) previous-directory))))))
-    (assert (uiop:absolute-pathname-p new-directory))
-    (uiop:chdir new-directory)
-    (unless (uiop:pathname-equal *previous-cwd* previous-directory)
-      (setf *previous-cwd* previous-directory))
-    new-directory))
-
-(defun expand-filename-modifiers (string &optional (base-filename (lem:buffer-filename)))
-  (ppcre:regex-replace-all "%(?::[a-z])*"
-                           string
-                           (lambda (match &rest registers)
-                             (declare (ignore registers))
-                             (let ((result (enough-namestring (or base-filename
-                                                                  (lem:buffer-filename)
-                                                                  (uiop:getcwd))
-                                                              (uiop:getcwd))))
-                               (ppcre:do-matches-as-strings (flag "(?<=:)([a-z])" match result)
-                                 (setf result
-                                       (ecase (aref flag 0)
-                                         (#\p (namestring
-                                               (uiop:ensure-absolute-pathname result (uiop:getcwd))))
-                                         (#\h
-                                          (namestring
-                                           (if (uiop:directory-pathname-p result)
-                                               (uiop:pathname-parent-directory-pathname result)
-                                               (uiop:pathname-directory-pathname result))))
-                                         (#\t
-                                          (let ((result-path (pathname result)))
-                                            (namestring
-                                             (make-pathname :name (pathname-name result-path)
-                                                            :type (pathname-type result-path)))))
-                                         (#\r
-                                          (make-pathname :defaults (pathname result)
-                                                         :type nil))
-                                         (#\e (or (pathname-type (pathname result))
-                                                  "")))))))
-                           :simple-calls t))
-
-(defun kill-region-without-appending (start end)
-  "Same as lem:kill-region except this won't append to the existing killring"
-  (when (point< end start)
-    (rotatef start end))
-  (let ((killed-string (delete-character start (count-characters start end))))
-    (copy-to-clipboard-with-killring killed-string)))
 
 (defun vi-this-command-keys ()
   (append
@@ -312,3 +170,26 @@
         (map 'list (lambda (char) (lem:make-key :sym (string char)))
              (princ-to-string (universal-argument-of-this-command))))
    (this-command-keys)))
+
+(defun this-motion-command ()
+  *this-motion-command*)
+
+(deftype repeat-type () '(member t nil :motion))
+
+(defclass vi-command ()
+  ((repeat :type repeat-type
+           :initarg :repeat
+           :initform nil
+           :accessor vi-command-repeat)))
+
+(defclass vi-motion (vi-command)
+  ((type :type keyword
+         :initarg :type
+         :initform :exclusive
+         :accessor vi-motion-type)
+   (default-n-arg :type (or null integer)
+     :initarg :default-n-arg
+     :initform 1
+     :accessor vi-motion-default-n-arg)))
+
+(defclass vi-operator (vi-command) ())

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -1,13 +1,13 @@
 (defpackage :lem-vi-mode/ex-command
-  (:use :cl :lem-vi-mode/ex-core)
-  (:import-from :lem-vi-mode/core
-                :expand-filename-modifiers)
+  (:use :cl
+        :lem-vi-mode/ex-core)
   (:import-from :lem-vi-mode/jump-motions
                 :with-jump-motion)
   (:import-from :lem-vi-mode/options
                 :execute-set-command)
-  (:import-from :lem-vi-mode/core
-                :change-directory))
+  (:import-from :lem-vi-mode/utils
+                :change-directory
+                :expand-filename-modifiers))
 (in-package :lem-vi-mode/ex-command)
 
 (defun ex-write (range filename touch)

--- a/extensions/vi-mode/ex.lisp
+++ b/extensions/vi-mode/ex.lisp
@@ -3,6 +3,8 @@
         :lem
         :lem-vi-mode/core
         :lem-vi-mode/ex-parser)
+  (:import-from :lem-vi-mode/utils
+                :expand-filename-modifiers)
   (:export :vi-ex))
 (in-package :lem-vi-mode/ex)
 

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -7,23 +7,25 @@
                "cl-package-locks"
                "alexandria"
                "split-sequence")
-  :serial t
   :components ((:file "core")
-               (:file "options")
-               (:file "word")
-               (:file "visual")
+               (:file "options" :depends-on ("utils"))
+               (:file "word" :depends-on ("options"))
+               (:file "modeline" :depends-on ("core"))
+               (:file "states" :depends-on ("core" "modeline"))
+               (:file "visual" :depends-on ("core" "states"))
                (:file "jump-motions")
-               (:module "commands-dir"
+               (:module "commands-utils"
                 :pathname "commands"
-                :components
-                ((:file "utils")))
-               (:file "commands")
+                :depends-on ("core" "jump-motions" "visual" "states")
+                :components ((:file "utils")))
+               (:file "commands" :depends-on ("core" "commands-utils" "word" "visual" "jump-motions" "states"))
                (:file "ex-core")
-               (:file "ex-parser")
-               (:file "ex-command")
-               (:file "ex")
-               (:file "binds")
-               (:file "vi-mode"))
+               (:file "ex-parser" :depends-on ("ex-core"))
+               (:file "ex-command" :depends-on ("ex-core" "options" "utils"))
+               (:file "ex" :depends-on ("core" "ex-parser"))
+               (:file "binds" :depends-on ("states" "commands" "ex" "visual"))
+               (:file "vi-mode" :depends-on ("core" "options" "ex" "commands" "states"))
+               (:file "utils"))
   :in-order-to ((test-op (test-op "lem-vi-mode/tests"))))
 
 (defsystem "lem-vi-mode/tests"

--- a/extensions/vi-mode/modeline.lisp
+++ b/extensions/vi-mode/modeline.lisp
@@ -1,0 +1,64 @@
+(defpackage :lem-vi-mode/modeline
+  (:use :cl
+        :lem)
+  (:import-from :lem-vi-mode/core
+                :state-name
+                :state-modeline-color
+                :*default-cursor-color*
+                :*enable-hook*
+                :*disable-hook*)
+  (:import-from :lem-interface)
+  (:export :state-modeline-white
+           :state-modeline-yellow
+           :state-modeline-green
+           :state-modeline-aqua
+           :state-modeline-orange
+           :change-element-by-state))
+(in-package :lem-vi-mode/modeline)
+
+(defvar *modeline-element*)
+
+(define-attribute state-modeline-white
+  (t :foreground "white" :reverse t))
+
+(define-attribute state-modeline-yellow
+  (t :foreground "yellow" :reverse t))
+
+(define-attribute state-modeline-green
+  (t :foreground "#003300" :reverse t))
+
+(define-attribute state-modeline-aqua
+  (t :foreground "#33CCFF" :reverse t))
+
+(define-attribute state-modeline-orange
+  (t :foreground "orange" :reverse t))
+
+(defstruct (vi-modeline-element (:conc-name element-))
+  name
+  attribute)
+
+(defmethod lem:convert-modeline-element ((element vi-modeline-element) window)
+  (if (or (eq (lem:current-window) window)
+          (string= (element-name element) "COMMAND"))
+      (values (format nil " ~A " (element-name element))
+              (element-attribute element))
+      (values "" 'state-modeline-white)))
+
+(defun initialize-vi-modeline ()
+  (setf *modeline-element* (make-vi-modeline-element))
+  (pushnew *modeline-element* (lem:variable-value 'lem:modeline-format :global)))
+
+(defun finalize-vi-modeline ()
+  (setf (lem:variable-value 'lem:modeline-format :global)
+        (remove-if #'vi-modeline-element-p
+                   (lem:variable-value 'lem:modeline-format :global)))
+  (lem:modeline-remove-status-list *modeline-element*)
+  (set-attribute 'cursor :background *default-cursor-color*)
+  (lem-if:update-cursor-shape (lem:implementation) :box))
+
+(defun change-element-by-state (state)
+  (setf (element-name *modeline-element*) (state-name state)
+        (element-attribute *modeline-element*) (state-modeline-color state)))
+
+(add-hook *enable-hook* 'initialize-vi-modeline 10)
+(add-hook *disable-hook* 'finalize-vi-modeline)

--- a/extensions/vi-mode/options.lisp
+++ b/extensions/vi-mode/options.lisp
@@ -2,7 +2,7 @@
   (:use :cl
         :lem
         :split-sequence)
-  (:import-from :lem-vi-mode/core
+  (:import-from :lem-vi-mode/utils
                 :change-directory)
   (:import-from :parse-number
                 :parse-number)

--- a/extensions/vi-mode/states.lisp
+++ b/extensions/vi-mode/states.lisp
@@ -1,0 +1,82 @@
+(defpackage :lem-vi-mode/states
+  (:use :cl
+        :lem)
+  (:import-from :lem-vi-mode/core
+                :define-vi-state
+                :*enable-hook*
+                :*disable-hook*
+                :change-state
+                :state-enabled-hook)
+  (:import-from :lem-vi-mode/modeline
+                :state-modeline-yellow
+                :state-modeline-aqua
+                :state-modeline-green
+                :change-element-by-state)
+  (:export :*command-keymap*
+           :*insert-keymap*
+           :*inactive-keymap*
+           :normal
+           :insert))
+(in-package :lem-vi-mode/states)
+
+(defmethod state-enabled-hook :after (state)
+  (change-element-by-state state))
+
+;;
+;; Keymaps
+
+(defvar *command-keymap* (make-keymap :name '*command-keymap*
+                                      :parent *global-keymap*))
+
+(defvar *inactive-keymap* (make-keymap :parent *global-keymap*))
+
+(defvar *insert-keymap* (make-keymap :name '*insert-keymap*
+                                     :parent *global-keymap*))
+
+;;
+;; Normal state
+
+(define-vi-state normal () ()
+  (:default-initargs
+   :keymap *command-keymap*
+   :modeline-color 'state-modeline-yellow))
+
+;;
+;; Insert state
+
+(define-vi-state insert () ()
+  (:default-initargs
+   :message "-- INSERT --"
+   :cursor-color "IndianRed"
+   :cursor-type :bar
+   :modeline-color 'state-modeline-aqua
+   :keymap *insert-keymap*))
+
+;;
+;; Ex state
+
+(define-vi-state vi-modeline () ()
+  (:default-initargs
+   :name "COMMAND"
+   :modeline-color 'state-modeline-green
+   :keymap *inactive-keymap*))
+
+;;
+;; Setup hooks
+
+(defun enable-normal-state ()
+  (change-state 'normal))
+(defun enable-vi-modeline-state ()
+  (change-state 'vi-modeline))
+
+(defun vi-enable-hook ()
+  (change-state 'normal)
+  (add-hook *prompt-activate-hook* 'enable-vi-modeline-state)
+  (add-hook *prompt-deactivate-hook* 'enable-normal-state))
+
+(defun vi-disable-hook ()
+  (remove-hook *prompt-activate-hook* 'enable-vi-modeline-state)
+  (remove-hook *prompt-deactivate-hook* 'enable-normal-state))
+
+(add-hook *enable-hook* 'vi-enable-hook)
+(add-hook *disable-hook* 'vi-disable-hook)

--- a/extensions/vi-mode/tests/utils.lisp
+++ b/extensions/vi-mode/tests/utils.lisp
@@ -10,13 +10,13 @@
   (:import-from :lem-core
                 :*this-command-keys*
                 :*input-hook*)
-  (:import-from :lem-vi-mode
-                :vi-mode)
   (:import-from :lem-vi-mode/core
-                :normal
-                :insert
+                :vi-mode
                 :current-state
                 :ensure-state)
+  (:import-from :lem-vi-mode/states
+                :normal
+                :insert)
   (:import-from :lem-vi-mode/visual
                 :visual-line
                 :visual-block

--- a/extensions/vi-mode/utils.lisp
+++ b/extensions/vi-mode/utils.lisp
@@ -1,0 +1,65 @@
+(defpackage :lem-vi-mode/utils
+  (:use :cl
+        :lem)
+  (:import-from :cl-ppcre)
+  (:export :change-directory
+           :expand-filename-modifiers
+           :kill-region-without-appending))
+(in-package :lem-vi-mode/utils)
+
+(defvar *previous-cwd* nil)
+
+(defun change-directory (new-directory)
+  (check-type new-directory (or string pathname))
+  (let* ((previous-directory (uiop:getcwd))
+         (new-directory (cond
+                          ((equal new-directory "")
+                           (user-homedir-pathname))
+                          ((equal new-directory "-")
+                           (or *previous-cwd* previous-directory))
+                          (t
+                           (truename
+                            (merge-pathnames (uiop:ensure-directory-pathname new-directory) previous-directory))))))
+    (assert (uiop:absolute-pathname-p new-directory))
+    (uiop:chdir new-directory)
+    (unless (uiop:pathname-equal *previous-cwd* previous-directory)
+      (setf *previous-cwd* previous-directory))
+    new-directory))
+
+(defun expand-filename-modifiers (string &optional (base-filename (buffer-filename)))
+  (ppcre:regex-replace-all "%(?::[a-z])*"
+                           string
+                           (lambda (match &rest registers)
+                             (declare (ignore registers))
+                             (let ((result (enough-namestring (or base-filename
+                                                                  (buffer-filename)
+                                                                  (uiop:getcwd))
+                                                              (uiop:getcwd))))
+                               (ppcre:do-matches-as-strings (flag "(?<=:)([a-z])" match result)
+                                 (setf result
+                                       (ecase (aref flag 0)
+                                         (#\p (namestring
+                                               (uiop:ensure-absolute-pathname result (uiop:getcwd))))
+                                         (#\h
+                                          (namestring
+                                           (if (uiop:directory-pathname-p result)
+                                               (uiop:pathname-parent-directory-pathname result)
+                                               (uiop:pathname-directory-pathname result))))
+                                         (#\t
+                                          (let ((result-path (pathname result)))
+                                            (namestring
+                                             (make-pathname :name (pathname-name result-path)
+                                                            :type (pathname-type result-path)))))
+                                         (#\r
+                                          (make-pathname :defaults (pathname result)
+                                                         :type nil))
+                                         (#\e (or (pathname-type (pathname result))
+                                                  "")))))))
+                           :simple-calls t))
+
+(defun kill-region-without-appending (start end)
+  "Same as lem:kill-region except this won't append to the existing killring"
+  (when (point< end start)
+    (rotatef start end))
+  (let ((killed-string (delete-character start (count-characters start end))))
+    (copy-to-clipboard-with-killring killed-string)))

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -8,9 +8,11 @@
   (:import-from :lem-vi-mode/commands
                 :vi-open-below
                 :vi-open-above)
-  (:import-from :lem-vi-mode/commands/utils
-                :vi-command
-                :vi-command-repeat)
+  (:import-from :lem-vi-mode/states
+                :normal
+                :insert
+                :*command-keymap*
+                :*insert-keymap*)
   (:import-from :alexandria
                 :appendf)
   (:export :vi-mode

--- a/extensions/vi-mode/visual.lisp
+++ b/extensions/vi-mode/visual.lisp
@@ -4,6 +4,11 @@
         :lem-vi-mode/core)
   (:import-from :lem-vi-mode/core
                 :ensure-state)
+  (:import-from :lem-vi-mode/states
+                :*command-keymap*
+                :normal)
+  (:import-from :lem-vi-mode/modeline
+                :state-modeline-orange)
   (:import-from :lem-base
                 :alive-point-p)
   (:export :*visual-keymap*
@@ -31,7 +36,7 @@
 (define-vi-state visual (vi-state) ()
   (:default-initargs
    :message "-- VISUAL --"
-   :modeline-color 'lem-vi-mode/core::state-modeline-orange
+   :modeline-color 'state-modeline-orange
    :keymap *visual-keymap*))
 
 (define-vi-state visual-char (visual)


### PR DESCRIPTION
Move some code in `lem-vi-mode/core` into `states`, `modeline`, and `utils`.