### PR TITLE
Fix unintended undef-hook invocation due to more than twice key lookup

### DIFF
--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -155,7 +155,7 @@
                          :collect :it))))
     (when *special-keymap*
       (push *special-keymap* keymaps))
-    (nreverse keymaps)))
+    (delete-duplicates (nreverse keymaps))))
 
 (defun lookup-keybind (key)
   (let (cmd)


### PR DESCRIPTION
After the merge of #1004, the completion-mode can't use `C-n` and `C-p` to choose an item.

This is because #1004 adds minor-mode keymaps to the top of the keymaps list to make them a high priority. I didn't think this caused any problems, but it invoked the undef-hook of the completion keymap by accident.

The key command will go through the list of keymaps like this: `next-line` -> `completion-next-line` -> `completion-self-insert` (by undef-hook).

Reported by @Sasanidas.