### PR TITLE
Delete a dependency of lem-paredit-mode

### DIFF
--- a/extensions/paredit-mode/lem-paredit-mode.asd
+++ b/extensions/paredit-mode/lem-paredit-mode.asd
@@ -1,4 +1,3 @@
 (defsystem "lem-paredit-mode"
-  :depends-on ("lem" "lem-vi-mode")
-  :serial t
+  :depends-on ("lem")
   :components ((:file "paredit-mode")))

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -4,8 +4,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 
 (defpackage :lem-paredit-mode
   (:use :cl
-        :lem
-        :lem-vi-mode/word)
+        :lem)
   (:export :paredit-mode
            :paredit-forward
            :paredit-backward


### PR DESCRIPTION
Since it doesn't depend on vi-mode anymore.