### PR TITLE
Fix vi-mode text objects

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -721,21 +721,27 @@
         (fall-within-line (current-point))))))
 
 (define-text-object-command vi-a-word (count) ("p")
+    (:expand-selection t)
   (a-range-of 'word-object (current-state) count))
 
 (define-text-object-command vi-inner-word (count) ("p")
+    (:expand-selection t)
   (inner-range-of 'word-object (current-state) count))
 
 (define-text-object-command vi-a-double-quote () ()
+    ()
   (a-range-of 'double-quoted-object (current-state) 1))
 
 (define-text-object-command vi-inner-double-quote () ()
+    ()
   (inner-range-of 'double-quoted-object (current-state) 1))
 
 (define-text-object-command vi-a-paren (count) ("p")
+    (:expand-selection t)
   (a-range-of 'paren-object (current-state) count))
 
 (define-text-object-command vi-inner-paren (count) ("p")
+    (:expand-selection t)
   (inner-range-of 'paren-object (current-state) count))
 
 (define-command vi-normal () ()

--- a/extensions/vi-mode/commands/utils.lisp
+++ b/extensions/vi-mode/commands/utils.lisp
@@ -251,7 +251,7 @@
                               :keep-visual ,keep-visual
                               :restore-point ,restore-point)))
 
-(defun call-define-text-object-command (fn)
+(defun call-define-text-object-command (fn &key expand-selection)
   (flet ((expand-visual-range (range)
            (let ((p1 (range-beginning range))
                  (p2 (range-end range)))
@@ -271,11 +271,16 @@
                          (return-from call-define-text-object-command)))))
       (let ((range (funcall fn)))
         (when (visual-p)
-          (expand-visual-range range))
+          (if expand-selection
+              (expand-visual-range range)
+              (setf (visual-range)
+                    (list (range-beginning range) (range-end range)))))
         range))))
 
-(defmacro define-text-object-command (name arg-list arg-descriptors
+(defmacro define-text-object-command (name arg-list arg-descriptors (&key expand-selection)
                                       &body body)
   `(define-command (,name (:advice-classes vi-text-object)) ,arg-list
        (,(parse-arg-descriptors arg-descriptors))
-     (call-define-text-object-command (lambda () ,@body))))
+     (call-define-text-object-command
+      (lambda () ,@body)
+      :expand-selection ,expand-selection)))

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -47,6 +47,7 @@
      (:file "operator")
      (:file "visual")
      (:file "commands")
+     (:file "text-objects")
      (:file "options")))
    (:file "utils"
     :pathname "tests/utils"))

--- a/extensions/vi-mode/tests/text-objects.lisp
+++ b/extensions/vi-mode/tests/text-objects.lisp
@@ -1,0 +1,34 @@
+(defpackage :lem-vi-mode/tests/text-objects
+  (:use :cl
+        :lem
+        :rove
+        :lem-vi-mode/tests/utils)
+  (:import-from :lem-fake-interface
+                :with-fake-interface)
+  (:import-from :named-readtables
+                :in-readtable))
+(in-package :lem-vi-mode/tests/text-objects)
+
+(in-readtable :interpol-syntax)
+
+(deftest double-quoted
+  (with-fake-interface ()
+    (with-vi-buffer ("[ ]\"foo\" \"bar\"")
+      (cmd "va\"")
+      (ok (buf= " <\"foo\"[ ]>\"bar\"")))
+    (with-vi-buffer (" [\"]foo\" \"bar\"")
+      (cmd "va\"")
+      (ok (buf= " <\"foo\"[ ]>\"bar\"")))
+    (with-vi-buffer (" \"f[o]o\" \"bar\"")
+      (cmd "va\"")
+      (ok (buf= " <\"foo\"[ ]>\"bar\"")))
+    (with-vi-buffer (" \"foo[\"] \"bar\"")
+      (cmd "va\"")
+      (ok (buf= " <\"foo\"[ ]>\"bar\"")))
+    (with-vi-buffer (" \"foo\"[ ]\"bar\"")
+      (cmd "va\"")
+      ;; NOTE: This behavior is not same as Vim
+      (ok (buf= " \"foo\"< \"bar[\"]>")))
+    (with-vi-buffer (" \"foo\" \"bar[\"]")
+      (cmd "va\"")
+      (ok (buf= " \"foo\"< \"bar[\"]>")))))

--- a/extensions/vi-mode/tests/visual.lisp
+++ b/extensions/vi-mode/tests/visual.lisp
@@ -36,6 +36,9 @@
 (deftest text-objects
   (with-fake-interface ()
     (testing "vaw"
+      (with-vi-buffer (#?"  [f]oo\n")
+        (cmd "vaw")
+        (ok (buf= #?"  <fo[o]>\n")))
       (with-vi-buffer (#?"  [ ]foo bar   baz  \n")
         (cmd "vaw")
         (ok (buf= #?"<   fo[o]> bar   baz  \n")))


### PR DESCRIPTION
In some cases, `a"` doesn't work expectedly. ref #1014 