### PR TITLE
Fix vi-mode's visual rectangle region 

### DIFF
--- a/extensions/vi-mode/tests/visual.lisp
+++ b/extensions/vi-mode/tests/visual.lisp
@@ -92,3 +92,22 @@
       (with-vi-buffer (#?' "f[o]o" ')
         (cmd "vi\"")
         (ok (buf= #?' "<fo[o]>" '))))))
+
+(deftest visual-block
+  (with-fake-interface ()
+    (testing "right-bottom"
+      (with-vi-buffer (#?"apple\nor[a]nge\ngrape\n")
+        (cmd "<C-v>jl")
+        (ok (buf= #?"apple\nor<an>ge\ngr<a[p]>e\n"))))
+    (testing "right-top"
+      (with-vi-buffer (#?"apple\nor[a]nge\ngrape\n")
+        (cmd "<C-v>kl")
+        (ok (buf= #?"ap<p[l]>e\nor<an>ge\ngrape\n"))))
+    (testing "left-top"
+      (with-vi-buffer (#?"apple\nor[a]nge\ngrape\n")
+        (cmd "<C-v>kh")
+        (ok (buf= #?"a<[p]p>le\no<ra>nge\ngrape\n"))))
+    (testing "left-bottom"
+      (with-vi-buffer (#?"apple\nor[a]nge\ngrape\n")
+        (cmd "<C-v>jh")
+        (ok (buf= #?"apple\no<ra>nge\ng<[r]a>pe\n"))))))

--- a/extensions/vi-mode/visual.lisp
+++ b/extensions/vi-mode/visual.lisp
@@ -95,13 +95,17 @@
 (defmethod state-setup ((state visual-block))
   (with-point ((start *start-point*)
                (end (current-point)))
-    (when (point< end start)
-      (rotatef start end))
-    (character-offset end 1)
     (let ((start-column (point-column start))
           (end-column (point-column end)))
-      (unless (< start-column end-column)
-        (rotatef start-column end-column))
+      (if (< end-column start-column)
+          ;; left-top or left-bottom
+          (progn
+            (character-offset start 1)
+            (incf start-column))
+          ;; right-top or right-bottom
+          (progn
+            (character-offset end 1)
+            (incf end-column)))
       (apply-region-lines start end
                           (lambda (p)
                             (with-point ((s p) (e p))


### PR DESCRIPTION
Fix the vi-mode's visual block region when the cursor moves to right-top or left-bottom.