### PR TITLE
Add a feature to disable undo boundary temporarily

### DIFF
--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -60,22 +60,13 @@
                        (eq (vi-command-repeat command) nil))
                   (eq (command-name (this-command)) 'vi-end-insert))
         (appendf *last-repeat-keys*
-                 (vi-this-command-keys))))
-    (when (and (member (command-name command)
-                       '(self-insert
-                         ;; XXX: lem:call-command always adds a undo boundary
-                         ;;  Delete the last boundary after these commands executed.
-                         vi-open-below
-                         vi-open-above)
-                       :test 'eq)
-               (eq :separator (lem-base::last-edit-history (current-buffer))))
-      (vector-pop (lem-base::buffer-edit-history (current-buffer))))))
+                 (vi-this-command-keys))))))
 
 (defmethod state-enabled-hook ((state insert))
   (when *enable-repeat-recording*
     (setf *last-repeat-keys* nil))
-  (buffer-undo-boundary))
+  (buffer-undo-boundary)
+  (buffer-disable-undo-boundary (lem:current-buffer)))
 
 (defmethod state-disabled-hook ((state insert))
-  (unless (eq :separator (lem-base::last-edit-history (current-buffer)))
-    (buffer-undo-boundary)))
+  (buffer-enable-undo-boundary (lem:current-buffer)))

--- a/src/base/buffer.lisp
+++ b/src/base/buffer.lisp
@@ -31,6 +31,10 @@
     :initarg :%enable-undo-p
     :accessor buffer-%enable-undo-p
     :type boolean)
+   (%enable-undo-boundary-p
+    :initarg :%enable-undo-boundary-p
+    :initform t
+    :accessor buffer-%enable-undo-boundary-p)
    (read-only-p
     :initarg :read-only-p
     :accessor buffer-read-only-p
@@ -194,6 +198,17 @@ Options that can be specified by arguments are ignored if `temporary` is NIL and
   (setf (buffer-redo-stack buffer) nil)
   nil)
 
+(defun buffer-enable-undo-boundary-p (&optional (buffer (current-buffer)))
+  (buffer-%enable-undo-boundary-p buffer))
+
+(defun buffer-enable-undo-boundary (buffer)
+  (setf (buffer-%enable-undo-boundary-p buffer) t)
+  nil)
+
+(defun buffer-disable-undo-boundary (buffer)
+  (setf (buffer-%enable-undo-boundary-p buffer) nil)
+  nil)
+
 (defmethod print-object ((buffer buffer) stream)
   (print-unreadable-object (buffer stream :identity t :type t)
     (format stream "~A ~A"
@@ -339,8 +354,9 @@ Options that can be specified by arguments are ignored if `temporary` is NIL and
       result0)))
 
 (defun buffer-undo-boundary (&optional (buffer (current-buffer)))
-  (unless (eq :separator (last-edit-history buffer))
-    (vector-push-extend :separator (buffer-edit-history buffer))))
+  (when (buffer-enable-undo-boundary-p)
+    (unless (eq :separator (last-edit-history buffer))
+      (vector-push-extend :separator (buffer-edit-history buffer)))))
 
 (defun buffer-value (buffer name &optional default)
   "`buffer`のバッファ変数`name`に束縛されている値を返します。

--- a/src/base/package.lisp
+++ b/src/base/package.lisp
@@ -109,6 +109,8 @@
    :buffer-undo
    :buffer-redo
    :buffer-undo-boundary
+   :buffer-enable-undo-boundary
+   :buffer-disable-undo-boundary
    :buffer-value
    :buffer-unbound
    :clear-buffer-variables)


### PR DESCRIPTION
This PR allows users to enable/disable auto undo boundary addition temporarily.

This feature is required in vi-mode to take all modifications done while in INSERT mode as a single undo stack.

I made it in a *hacky* way in vi-mode (ref #991), but it's not perfect since Lem automatically adds an undo boundary after every command invocation. For example, Lem adds a boundary even after completion.

Take this as a feature request with a code. I'm fine if the feature is done in a different way. Any advice is welcome.