### PR TITLE
Show vi modeline status only for the "main" window in Ex mode.

### DIFF
--- a/extensions/vi-mode/core.lisp
+++ b/extensions/vi-mode/core.lisp
@@ -39,7 +39,9 @@
            :range-type
            :operator-abort
            :text-object-abort
-           :text-object-abort-range))
+           :text-object-abort-range
+           :vi-current-window
+           :with-main-window))
 (in-package :lem-vi-mode/core)
 
 (defvar *last-repeat-keys* '())
@@ -221,3 +223,13 @@
 (define-condition text-object-abort (operator-abort)
   ((range :initarg :range
           :reader text-object-abort-range)))
+
+(defvar *vi-current-window* nil)
+
+(defun vi-current-window ()
+  (or *vi-current-window*
+      (lem:current-window)))
+
+(defmacro with-main-window (window &body body)
+  `(let ((*vi-current-window* ,window))
+     ,@body))

--- a/extensions/vi-mode/ex.lisp
+++ b/extensions/vi-mode/ex.lisp
@@ -18,57 +18,58 @@
   (let* ((directory (uiop:getcwd))
          (buffer-filename (lem:buffer-filename)))
     (with-state 'ex
-      (execute-ex
-       (prompt-for-string
-        ":"
-        :completion-function
-        (lambda (str)
-          (cond
-            ((ppcre:scan "^(?:(?:e|vs|sp)[ \\.]|cd )" str)
-             (let* ((comp-str (ppcre:regex-replace "^(e|vs|sp|cd)\\s*" str ""))
-                    (expanded-comp-str (expand-filename-modifiers comp-str (or buffer-filename directory)))
-                    (prefix-len (- (length str) (length comp-str))))
-               (cond
-                 ((string= comp-str ".")
-                  (list (format nil "~A/" str)))
-                 ((equal comp-str expanded-comp-str)
-                  ;; Almost same as prompt-file-complete in lem-core/completion-file.lisp
-                  ;; except item's :start offsets which will be used when selecting a completion item.
-                  (mapcar (lambda (filename)
-                            (let ((label (enough-namestring filename directory)))
-                              (with-point ((s (lem/prompt-window::current-prompt-start-point))
-                                           (e (lem/prompt-window::current-prompt-start-point)))
-                                (lem/completion-mode:make-completion-item
-                                 :label label
-                                 :start (character-offset s prefix-len)
-                                 :end (line-end e)))))
-                          (lem/completion-mode::completion-file
-                           expanded-comp-str
-                           directory
-                           :directory-only (and (ppcre:scan "^cd " str) t))))
-                 (t
-                  (list (with-point ((s (lem/prompt-window::current-prompt-start-point))
-                                     (e (lem/prompt-window::current-prompt-start-point)))
-                          (lem/completion-mode:make-completion-item
-                           :label expanded-comp-str
-                           :start (character-offset s prefix-len)
-                           :end (line-end e))))))))
-            ((ppcre:scan "^(?:b(?:uffer)?|bd(?:elete)?) " str)
-             (let ((comp-str (ppcre:regex-replace "^(?:b(?:uffer)?|bd(?:elete)?)\\s+" str "")))
-               (mapcar (lambda (buffer)
-                         (let ((prefix-len (- (length str) (length comp-str))))
-                           (with-point ((s (lem/prompt-window::current-prompt-start-point))
-                                        (e (lem/prompt-window::current-prompt-start-point)))
-                             (lem/completion-mode:make-completion-item
-                              :label (buffer-name buffer)
-                              :detail (let ((filename (buffer-filename buffer)))
-                                        (when filename
-                                          (enough-namestring filename (probe-file "./"))))
-                              :start (character-offset s prefix-len)
-                              :end (line-end e)))))
-                       (lem/completion-mode::completion-buffer
-                        comp-str))))))
-        :history-symbol 'vi-ex)))))
+      (with-main-window (lem:current-window)
+        (execute-ex
+         (prompt-for-string
+          ":"
+          :completion-function
+          (lambda (str)
+            (cond
+              ((ppcre:scan "^(?:(?:e|vs|sp)[ \\.]|cd )" str)
+               (let* ((comp-str (ppcre:regex-replace "^(e|vs|sp|cd)\\s*" str ""))
+                      (expanded-comp-str (expand-filename-modifiers comp-str (or buffer-filename directory)))
+                      (prefix-len (- (length str) (length comp-str))))
+                 (cond
+                   ((string= comp-str ".")
+                    (list (format nil "~A/" str)))
+                   ((equal comp-str expanded-comp-str)
+                    ;; Almost same as prompt-file-complete in lem-core/completion-file.lisp
+                    ;; except item's :start offsets which will be used when selecting a completion item.
+                    (mapcar (lambda (filename)
+                              (let ((label (enough-namestring filename directory)))
+                                (with-point ((s (lem/prompt-window::current-prompt-start-point))
+                                             (e (lem/prompt-window::current-prompt-start-point)))
+                                  (lem/completion-mode:make-completion-item
+                                   :label label
+                                   :start (character-offset s prefix-len)
+                                   :end (line-end e)))))
+                            (lem/completion-mode::completion-file
+                             expanded-comp-str
+                             directory
+                             :directory-only (and (ppcre:scan "^cd " str) t))))
+                   (t
+                    (list (with-point ((s (lem/prompt-window::current-prompt-start-point))
+                                       (e (lem/prompt-window::current-prompt-start-point)))
+                            (lem/completion-mode:make-completion-item
+                             :label expanded-comp-str
+                             :start (character-offset s prefix-len)
+                             :end (line-end e))))))))
+              ((ppcre:scan "^(?:b(?:uffer)?|bd(?:elete)?) " str)
+               (let ((comp-str (ppcre:regex-replace "^(?:b(?:uffer)?|bd(?:elete)?)\\s+" str "")))
+                 (mapcar (lambda (buffer)
+                           (let ((prefix-len (- (length str) (length comp-str))))
+                             (with-point ((s (lem/prompt-window::current-prompt-start-point))
+                                          (e (lem/prompt-window::current-prompt-start-point)))
+                               (lem/completion-mode:make-completion-item
+                                :label (buffer-name buffer)
+                                :detail (let ((filename (buffer-filename buffer)))
+                                          (when filename
+                                            (enough-namestring filename (probe-file "./"))))
+                                :start (character-offset s prefix-len)
+                                :end (line-end e)))))
+                         (lem/completion-mode::completion-buffer
+                          comp-str))))))
+          :history-symbol 'vi-ex))))))
 
 (defun execute-ex (string)
   (let ((lem-vi-mode/ex-core:*point* (current-point)))

--- a/extensions/vi-mode/modeline.lisp
+++ b/extensions/vi-mode/modeline.lisp
@@ -6,7 +6,8 @@
                 :state-modeline-color
                 :*default-cursor-color*
                 :*enable-hook*
-                :*disable-hook*)
+                :*disable-hook*
+                :vi-current-window)
   (:import-from :lem-interface)
   (:export :state-modeline-white
            :state-modeline-yellow
@@ -39,8 +40,7 @@
 
 (defmethod lem:convert-modeline-element ((element vi-modeline-element) window)
   (if (and (element-name element)
-           (or (eq (lem:current-window) window)
-               (string= (element-name element) "COMMAND")))
+           (eq (vi-current-window) window))
       (values (format nil " ~A " (element-name element))
               (element-attribute element))
       (values "" 'state-modeline-white)))


### PR DESCRIPTION
Currently, it shows "COMMAND" for all windows while in Ex mode, but it's lame.