### PR TITLE
Fix an unintended column movement regarding `vi-line`

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -139,7 +139,7 @@
 
 (define-motion vi-line (&optional (n 1)) ("p")
     ()
-  (next-logical-line (1- n)))
+  (line-offset (current-point) (1- n)))
 
 (define-motion vi-next-display-line (&optional (n 1)) ("p")
     (:type :line)


### PR DESCRIPTION
Fix an unintended column movement regarding `vi-line`, which is commonly used in vi commands. It uses `next-logical-line`; however, it keeps the column position unintentionally.

For example, `^$j` goes to the beginning of the line.