### PR TITLE
Fix project-switch issue when It doesn't exists projects

### DIFF
--- a/src/commands/project.lisp
+++ b/src/commands/project.lisp
@@ -282,7 +282,7 @@
          "Project: "
          :completion-function (lambda (x) (completion-strings x candidates))
          :test-function (lambda (name) (member name candidates :test #'string=)))
-        (show-message "No projects." :timeout 5))))
+        (progn (show-message "No projects." :timeout 5) nil))))
 
 (define-command project-switch () ()
   "Prompt for a saved project and find a file in this project."

--- a/src/commands/project.lisp
+++ b/src/commands/project.lisp
@@ -282,7 +282,7 @@
          "Project: "
          :completion-function (lambda (x) (completion-strings x candidates))
          :test-function (lambda (name) (member name candidates :test #'string=)))
-        (progn (show-message "No projects." :timeout 5) nil))))
+        (editor-error "No projects."))))
 
 (define-command project-switch () ()
   "Prompt for a saved project and find a file in this project."


### PR DESCRIPTION
Hi there
The `prompt-for-project` method returns `(show-message "No projects." :timeout 5)` if there aren't any `candidates`. 
I think the `show-message` function doesn't return nil and and that's why `project-switch` method fails.
This is the error message:
```
The value
  #<LEM/POPUP-WINDOW::POPUP-WINDOW {1004B65343}>
is not of type
  (OR STRING PATHNAME SYNONYM-STREAM FILE-STREAM NULL)
when binding :DEFAULTS
Backtrace for: #<SB-THREAD:THREAD "editor" RUNNING {100401DA73}>
0: (MAKE-PATHNAME :HOST NIL :DEVICE NIL :DIRECTORY NIL :NAME NIL :TYPE NIL :VERSION NIL :DEFAULTS #<LEM/POPUP-WINDOW::POPUP-WINDOW {1004B65343}> :CASE :LOCAL)
1: (UIOP/FILESYSTEM:CALL-WITH-CURRENT-DIRECTORY #<LEM/POPUP-WINDOW::POPUP-WINDOW {1004B65343}> #<FUNCTION (LAMBDA NIL :IN LEM-CORE/COMMANDS/PROJECT::PROJECT-SWITCH) {52C7FE7B}>)
2: (LEM-CORE:CALL-COMMAND LEM-CORE/COMMANDS/PROJECT::PROJECT-SWITCH NIL)
3: (LEM-CORE::COMMAND-LOOP-BODY)
4: (LEM-CORE:COMMAND-LOOP)
5: (LEM-CORE::TOPLEVEL-COMMAND-LOOP #<FUNCTION (LAMBDA NIL :IN LEM-CORE::RUN-EDITOR-THREAD) {1004B5BB4B}>)
6: ((LAMBDA NIL :IN LEM-CORE::RUN-EDITOR-THREAD))
7: ((LAMBDA NIL :IN LEM-CORE::RUN-EDITOR-THREAD))
8: ((LABELS BORDEAUX-THREADS::%BINDING-DEFAULT-SPECIALS-WRAPPER :IN BORDEAUX-THREADS::BINDING-DEFAULT-SPECIALS))
9: ((FLET SB-UNIX::BODY :IN SB-THREAD::RUN))
10: ((FLET "WITHOUT-INTERRUPTS-BODY-173" :IN SB-THREAD::RUN))
11: ((FLET SB-UNIX::BODY :IN SB-THREAD::RUN))
12: ((FLET "WITHOUT-INTERRUPTS-BODY-166" :IN SB-THREAD::RUN))
13: (SB-THREAD::RUN)
14: ("foreign function: call_into_lisp_")
15: ("foreign function: funcall1")
```
