### PR TITLE
Implement Vim's register for vi-mode

### DIFF
--- a/extensions/vi-mode/ex.lisp
+++ b/extensions/vi-mode/ex.lisp
@@ -6,6 +6,8 @@
   (:import-from :lem-vi-mode/visual
                 :visual-p
                 :vi-visual-end)
+  (:import-from :lem-vi-mode/registers
+                :*last-ex-command*)
   (:import-from :lem-vi-mode/utils
                 :expand-filename-modifiers)
   (:export :vi-ex
@@ -80,4 +82,5 @@
 (defun execute-ex (string)
   (let ((lem-vi-mode/ex-core:*point* (current-point)))
     (prog1 (eval (parse-ex string))
+      (setf *last-ex-command* string)
       (vi-visual-end))))

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -51,6 +51,7 @@
      (:file "visual")
      (:file "commands")
      (:file "text-objects")
+     (:file "registers")
      (:file "options")))
    (:file "utils"
     :pathname "tests/utils"))

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -7,7 +7,8 @@
                "cl-package-locks"
                "alexandria"
                "split-sequence"
-               "lem-lisp-mode")
+               "lem-lisp-mode"
+               "trivial-types")
   :components ((:file "core")
                (:file "options" :depends-on ("utils"))
                (:file "word" :depends-on ("options"))
@@ -15,16 +16,17 @@
                (:file "states" :depends-on ("core" "modeline"))
                (:file "visual" :depends-on ("core" "states"))
                (:file "text-objects" :depends-on ("core" "visual" "word"))
+               (:file "registers" :depends-on ("core"))
                (:file "jump-motions")
                (:module "commands-utils"
                 :pathname "commands"
                 :depends-on ("core" "jump-motions" "visual" "states")
                 :components ((:file "utils")))
-               (:file "commands" :depends-on ("core" "commands-utils" "word" "visual" "jump-motions" "states"))
+               (:file "commands" :depends-on ("core" "commands-utils" "word" "visual" "jump-motions" "states" "registers"))
                (:file "ex-core")
                (:file "ex-parser" :depends-on ("ex-core"))
                (:file "ex-command" :depends-on ("ex-core" "options" "utils"))
-               (:file "ex" :depends-on ("core" "ex-parser" "visual"))
+               (:file "ex" :depends-on ("core" "ex-parser" "visual" "registers"))
                (:file "binds" :depends-on ("states" "commands" "ex" "visual"))
                (:file "special-binds" :depends-on ("core"))
                (:file "vi-mode" :depends-on ("core" "options" "ex" "commands" "states"))

--- a/extensions/vi-mode/registers.lisp
+++ b/extensions/vi-mode/registers.lisp
@@ -173,12 +173,17 @@
   (setf *unnamed-register* #\0)
   (values))
 
+(defun small-deletion-p (start end type)
+  (and (= (line-number-at-point start)
+          (line-number-at-point end))
+       (not (eq type :line))))
+
 (defun delete-region (start end &key type)
   (with-killring-context (:options (when (eq type :line) :vi-line)
                           :appending (when (eq type :block)
                                        (continue-flag :vi-delete-block)))
-    (let* ((string (lem:delete-between-points start end))
-           (small (member type '(:exclusive :inclusive)))
+    (let* ((small (small-deletion-p start end type))
+           (string (lem:delete-between-points start end))
            (yank (make-yank string
                             (case type
                               (:line :line)

--- a/extensions/vi-mode/registers.lisp
+++ b/extensions/vi-mode/registers.lisp
@@ -1,0 +1,269 @@
+(defpackage :lem-vi-mode/registers
+  (:use :cl
+        :lem)
+  (:shadow :yank)
+  (:import-from :lem-vi-mode/core
+                :vi-current-window)
+  (:import-from :lem/common/killring
+                :make-item)
+  (:import-from :lem/common/ring
+                :make-ring
+                :ring-ref
+                :ring-empty-p
+                :ring-push
+                :invalid-index-error)
+  (:import-from :trivial-types
+                :proper-list)
+  (:export :register
+           :yank-region
+           :delete-region))
+(in-package :lem-vi-mode/registers)
+
+(deftype key-sequence ()
+  '(trivial-types:proper-list lem-core::key))
+
+(deftype register () 'character)
+
+(deftype register-designator () '(or character (string 1)))
+
+(defstruct (yank (:constructor make-yank (text &optional (type :char))))
+  (text nil :type string)
+  (type :char :type (member :char :line)))
+
+(defun append-yank (text1 text2)
+  (if (or (eq (yank-type text1) :line)
+          (eq (yank-type text2) :line))
+      (make-yank
+       (with-output-to-string (s)
+         (write-string (yank-text text1) s)
+         (fresh-line s)
+         (write-string (yank-text text2) s)
+         (fresh-line s))
+       :line)
+      (make-yank
+       (format nil "~A~A" (yank-text text1) (yank-text text2)))))
+
+(declaim (type hash-table *named-registers*))
+(defvar *named-registers* (make-hash-table))
+
+(defvar *yank-text* nil)
+(defvar *deletion-history* (make-ring 9))
+
+(defvar *unnamed-register* nil)
+(defvar *small-deletion-register* nil)
+
+(defvar *last-ex-command* nil)
+(defvar *last-search-query* nil)
+
+(defun downcase-char (char)
+  (declare (type character char))
+  (cond
+    ((char<= #\A char #\Z)
+     (code-char
+      (+ (char-code char)
+         #.(- (char-code #\a) (char-code #\A)))))
+    (t char)))
+
+(defun ensure-char (name)
+  (check-type name register-designator)
+  (if (stringp name)
+      (aref name 0)
+      name))
+
+(defun named-register-p (name)
+  (declare (type character name))
+  (or (char<= #\a name #\z)
+      (char<= #\A name #\Z)))
+
+(defun numbered-register-p (name)
+  (declare (type character name))
+  (char<= #\0 name #\9))
+
+(defun values-register-item (item)
+  (etypecase item
+    (null (values nil nil))
+    (yank (values (yank-text item)
+                  (yank-type item)))
+    (key-sequence (values item :key-sequence))))
+
+(defgeneric append-register-item (item1 item2)
+  (:method ((item1 t) (item2 t))
+    (error "Unmatched type: '~A' and '~A'"
+           (type-of item1)
+           (type-of item2))))
+
+(defmethod append-register-item ((item1 list) (item2 list))
+  (append item1 item2))
+
+(defmethod append-register-item ((item1 yank) (item2 yank))
+  (append-yank item1 item2))
+
+(defmethod append-register-item ((item1 null) item2)
+  item2)
+
+(defun killring-item-to-yank (item)
+  (destructuring-bind (text &optional options)
+      item
+    (make-yank text (if (member :vi-line options)
+                        :line
+                        :char))))
+
+(defun yank-to-killring-item (yank)
+  (make-item :string (yank-text yank)
+             :options (if (eq (yank-type yank) :line)
+                          '(:vi-line)
+                          nil)))
+
+(defun get-named-register (name)
+  (assert (char<= #\a name #\z))
+  (gethash name *named-registers*))
+
+(defun set-named-register (name item &key append)
+  (assert (char<= #\a name #\z))
+  (check-type item (or yank key-sequence))
+  (setf (gethash name *named-registers*)
+        (if append
+            (let ((existing-item (gethash name *named-registers*)))
+              (append-register-item existing-item item))
+            item)))
+
+(defun get-numbered-register (name)
+  (assert (char<= #\0 name #\9))
+  (case name
+    (#\0 *yank-text*)
+    (otherwise
+     (if (ring-empty-p *deletion-history*)
+         nil
+         (let ((n (- (char-code name) #.(char-code #\1))))
+           (handler-case (ring-ref *deletion-history* n)
+             (invalid-index-error ()
+               nil)))))))
+
+(defun set-numbered-register (name item &key append)
+  (assert (char<= #\0 name #\9))
+  (check-type item (or yank key-sequence))
+  (case name
+    (#\0
+     (setf *yank-text*
+           (if append
+               (append-register-item *yank-text* item)
+               item)))
+    (otherwise
+     (let ((n (- (char-code name) #.(char-code #\1))))
+       (setf (ring-ref *deletion-history* n)
+             (if append
+                 (let ((existing-item (ring-ref *deletion-history* n)))
+                   (append-register-item existing-item item))
+                 item)))))
+  (values))
+
+(defun yank-region (start end &key type append)
+  (with-killring-context (:options (when (eq type :line) :vi-line)
+                          :appending (when (eq type :block)
+                                       (continue-flag :vi-yank-block)))
+    (copy-region start end))
+  (let ((item (make-yank (points-to-string start end)
+                         (case type
+                           (:line :line)
+                           (otherwise :char)))))
+    (setf *yank-text*
+          (if append
+              (append-register-item *yank-text* item)
+              item)))
+  (setf *unnamed-register* #\0)
+  (values))
+
+(defun delete-region (start end &key type)
+  (with-killring-context (:options (when (eq type :line) :vi-line)
+                          :appending (when (eq type :block)
+                                       (continue-flag :vi-delete-block)))
+    (let* ((string (lem:delete-between-points start end))
+           (small (member type '(:exclusive :inclusive)))
+           (yank (make-yank string
+                            (case type
+                              (:line :line)
+                              (otherwise :char)))))
+      (copy-to-clipboard-with-killring string)
+      (unless small
+        (ring-push *deletion-history* yank))
+      (if small
+          (setf *small-deletion-register* yank
+                *unnamed-register* #\-)
+          (setf *unnamed-register* #\1))))
+  (values))
+
+(defun register (name)
+  (let ((name (ensure-char name)))
+    (declare (type register name))
+    (cond
+      ((named-register-p name)
+       (values-register-item
+        (get-named-register (downcase-char name))))
+      ((numbered-register-p name)
+       (values-register-item
+        (get-numbered-register name)))
+      (t
+       (ecase name
+         ;; Unnamed register
+         (#\"
+          (typecase *unnamed-register*
+            (register (register *unnamed-register*))
+            (otherwise
+             (values-register-item *unnamed-register*))))
+         ;; Small delete register
+         (#\-
+          (values-register-item
+           *small-deletion-register*))
+         ;; Most recent Ex command (read-only)
+         (#\:
+          *last-ex-command*)
+         ;; Last inserted text (read-only)
+         ;(#\.)
+         ;; Current file name (read-only)
+         (#\%
+          (buffer-filename (current-buffer)))
+         ;; Alternate file name register
+         (#\#
+          (buffer-filename (window-buffer (vi-current-window))))
+         ;; Expression register
+         ;(#\=)
+         ;; Selection register
+         ;((#\* #\+))
+         ;; Blackhole register
+         (#\_
+          nil)
+         ;; Last search register
+         (#\/
+          *last-search-query*))))))
+
+(defun (setf register) (value name)
+  (flet ((value-to-item (value)
+           (etypecase value
+             (string (make-yank value))
+             (key-sequence value))))
+    (let ((name (ensure-char name)))
+      (declare (type character name))
+      (cond
+        ((named-register-p name)
+         (let ((lower-name (downcase-char name)))
+           (set-named-register lower-name
+                               (value-to-item value)
+                               :append (char<= #\A name #\Z))))
+        ((numbered-register-p name)
+         (set-numbered-register name
+                                (value-to-item value)))
+        ((char= name #\")
+         (setf *unnamed-register* (value-to-item value)))
+        (t
+         (check-type value string)
+         (ecase name
+           (#\-
+            (setf *small-deletion-register* (make-yank value)))
+           ((#\: #\. #\% #\#)
+            (editor-error "Register '\"~A' is read-only." name))
+           ;(#\=)
+           ;((#\* #\+))
+           (#\_ nil)
+           (#\/
+            (setf *last-search-query* value)))))))
+  (values))

--- a/extensions/vi-mode/tests/registers.lisp
+++ b/extensions/vi-mode/tests/registers.lisp
@@ -1,0 +1,122 @@
+(defpackage :lem-vi-mode/tests/registers
+  (:use :cl
+        :lem
+        :rove
+        :lem-vi-mode/tests/utils)
+  (:import-from :lem-vi-mode/registers
+                :named-register-p
+                :numbered-register-p
+                :get-named-register
+                :set-named-register
+                :get-numbered-register
+                :set-numbered-register
+                :make-yank
+                :yank-text
+                :yank-type
+                :*small-deletion-register*
+                :*unnamed-register*
+                :register)
+  (:shadowing-import-from :lem-vi-mode/registers
+                          :yank)
+  (:import-from :lem-fake-interface
+                :with-fake-interface)
+  (:import-from :named-readtables
+                :in-readtable))
+(in-package :lem-vi-mode/tests/registers)
+
+(in-readtable :interpol-syntax)
+
+(deftest named-register-p
+  (ok (named-register-p #\a))
+  (ok (named-register-p #\A))
+  (ok (not (named-register-p #\1)))
+  (ok (not (named-register-p #\")))
+  (ok (signals (named-register-p "a")
+               'type-error))
+  (ok (signals (named-register-p 1)
+               'type-error)))
+
+(deftest numbered-register-p
+  (ok (numbered-register-p #\1))
+  (ok (numbered-register-p #\0))
+  (ok (not (numbered-register-p #\a)))
+  (ok (not (numbered-register-p #\/)))
+  (ok (signals (named-register-p "1")
+               'type-error))
+  (ok (signals (named-register-p 1)
+               'type-error)))
+
+(deftest named-register
+  (ok (null (get-named-register #\a)))
+  (set-named-register #\a (make-yank "hello"))
+  (let ((item (get-named-register #\a)))
+    (ok (typep item 'yank))
+    (ok (equal (yank-text item) "hello"))
+    (ok (eq (yank-type item) :char)))
+  (set-named-register #\a (make-yank #?"world\n" :line) :append t)
+  (let ((item (get-named-register #\a)))
+    (ok (typep item 'yank))
+    (ok (equal (yank-text item) #?"hello\nworld\n"))
+    (ok (eq (yank-type item) :line))))
+
+(deftest numbered-register
+  (with-fake-interface ()
+    (with-vi-buffer (#?"[a]bc\ndef\nghi\njkl\n")
+      (cmd "yy")
+      (ok (equal (yank-text (get-numbered-register #\0)) "abc"))
+      (ok (equal (yank-type (get-numbered-register #\0)) :line))
+      (ok (eql *unnamed-register* #\0))
+      (cmd "jdd")
+      (ok (equal (yank-text (get-numbered-register #\0)) "abc"))
+      (ok (equal (yank-text (get-numbered-register #\1)) "def"))
+      (ok (eql *unnamed-register* #\1))
+      (cmd "dl")
+      (ok (equal (yank-text (get-numbered-register #\0)) "abc"))
+      (ok (equal (yank-text (get-numbered-register #\1)) "def"))
+      (ok (equal (yank-text *small-deletion-register*) "g"))
+      (ok (eql *unnamed-register* #\-))
+      (cmd "dd")
+      (ok (equal (yank-text (get-numbered-register #\0)) "abc"))
+      (ok (equal (yank-text (get-numbered-register #\1)) "hi"))
+      (ok (equal (yank-text (get-numbered-register #\2)) "def"))
+      (ok (eql *unnamed-register* #\1))
+      (cmd "yl")
+      (ok (equal (yank-text (get-numbered-register #\0)) "j"))
+      (ok (equal (yank-text (get-numbered-register #\1)) "hi"))
+      (ok (equal (yank-text (get-numbered-register #\2)) "def"))
+      (ok (eql *unnamed-register* #\0)))))
+
+(deftest register
+  (with-fake-interface ()
+    (with-vi-buffer (#?"[a]bc\ndef\nghi\njkl\n")
+      (cmd "yy")
+      (ok (equal (multiple-value-list (register #\0))
+                 '("abc" :line)))
+      (ok (equal (multiple-value-list (register #\"))
+                 '("abc" :line)))
+      (cmd "dl")
+      (ok (equal (multiple-value-list (register #\-))
+                 '("a" :char)))
+
+      (setf (register #\Z) "hi")
+      (ok (equal (register #\Z) "hi"))
+      (setf (register #\Z) ", ghost")
+      (ok (equal (register #\Z) "hi, ghost"))
+      (ok (equal (register #\z) "hi, ghost"))
+
+      (ok (signals (setf (register #\x) 123)
+                   'type-error))
+      (ok (signals (setf (register #\x) #(123))
+                   'type-error))
+      (setf (register #\x) (list (make-key :sym "x")
+                                 (make-key :sym "y")
+                                 (make-key :sym "z")))
+      (setf (register #\X) (list (make-key :ctrl t :sym "o")))
+      (ok (equal (register #\x)
+                 (list (make-key :sym "x")
+                       (make-key :sym "y")
+                       (make-key :sym "z")
+                       (make-key :ctrl t :sym "o"))))
+
+      (cmd "/def<Return>")
+      (ok (equal (register #\/) "def")))))

--- a/extensions/vi-mode/visual.lisp
+++ b/extensions/vi-mode/visual.lisp
@@ -25,8 +25,6 @@
            :visual-block-p
            :visual-range
            :apply-visual-range
-           :visual-yank
-           :visual-kill
            :vi-visual-insert
            :vi-visual-append
            :vi-visual-swap-points
@@ -212,18 +210,6 @@
         (funcall function
                  (overlay-start ov)
                  (overlay-end ov)))))
-
-(defun visual-yank ()
-  (with-killring-context (:options (when (visual-line-p) :vi-line))
-    (apply-visual-range
-     (lambda (start end)
-       (copy-region start end)))))
-
-(defun visual-kill ()
-  (with-killring-context (:options (when (visual-line-p) :vi-line))
-    (apply-visual-range
-     (lambda (start end)
-       (kill-region start end)))))
 
 (defun string-without-escape ()
   (concatenate 'string

--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -1,6 +1,7 @@
 (defpackage :lem/isearch
   (:use :cl :lem)
   (:export :*isearch-keymap*
+           :*isearch-finish-hooks*
            :isearch-mode
            :isearch-highlight-attribute
            :isearch-highlight-active-attribute
@@ -42,6 +43,7 @@
 (defvar *isearch-search-forward-function*)
 (defvar *isearch-search-backward-function*)
 (defvar *isearch-popup-message* nil)
+(defvar *isearch-finish-hooks* '())
 
 (define-attribute isearch-highlight-attribute
   (t :foreground :base00 :background :base05))
@@ -339,6 +341,7 @@
   (setf (buffer-value (current-buffer) 'isearch-redisplay-string) *isearch-string*)
   (change-previous-string *isearch-string*)
   (isearch-add-hooks)
+  (run-hooks *isearch-finish-hooks* *isearch-string*)
   (isearch-redisplay-inactive (current-buffer))
   (isearch-mode nil))
 


### PR DESCRIPTION
This doesn't affect the existing features, but it's required for adding Vim's keyboard macro.

Added a new hook `*isearch-finish-hooks*` to Lem's isearch, which is invoked when `isearch-finish` is called.