### PR TITLE
Fix linewise vi-change to keep an empty line

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -323,14 +323,23 @@
 
 (define-operator vi-change (beg end type) ("<R>")
     ()
-  (vi-delete beg end type)
-  (indent-line (current-point))
+  (let ((end-with-newline (char= (character-at end -1) #\Newline)))
+    (vi-delete beg end type)
+    (when (eq type :line)
+      (cond
+        (end-with-newline
+         (insert-character (current-point) #\Newline)
+         (character-offset (current-point) -1))
+        (t
+         (insert-character (current-point) #\Newline)))
+      (indent-line (current-point))))
   (change-state 'insert))
 
 (define-operator vi-change-whole-line (beg end) ("<r>")
     (:motion vi-line)
   (line-start beg)
-  (line-end end)
+  (or (line-offset end 1 0)
+      (line-end end))
   (vi-change beg end :line))
 
 (define-operator vi-change-line (beg end type) ("<R>")

--- a/extensions/vi-mode/tests/operator.lisp
+++ b/extensions/vi-mode/tests/operator.lisp
@@ -91,6 +91,20 @@
         (cmd "di\"")
         (ok (buf= " \"[\"]  "))))))
 
+(deftest vi-change
+  (with-fake-interface ()
+    (testing "change linewise"
+      (with-vi-buffer (#?"a[b]c\ndef\n")
+        (cmd "cc")
+        (ok (buf= #?"[]\ndef\n")))
+      (with-vi-buffer (#?"abc\nd[e]f")
+        (cmd "cc")
+        (ok (buf= #?"abc\n[]"))))
+    (testing "change charwise"
+      (with-vi-buffer (#?"a[b]c\ndef\n")
+        (cmd "cl")
+        (ok (buf= #?"a[]c\ndef\n"))))))
+
 (deftest vi-change-whole-line
   (with-fake-interface ()
     (with-vi-buffer (#?"a[b]c\ndef\n")


### PR DESCRIPTION
Fix a bug that `cc` and `S` don't keep a single empty line after deletion. Introduced by a recent change of #1055 .