### PR TITLE
Add command to toggle line wrap in the buffer

### DIFF
--- a/src/commands/window.lisp
+++ b/src/commands/window.lisp
@@ -301,3 +301,7 @@
                      (not (eql c1 c2)))
           :while (and (character-offset p1 1)
                       (character-offset p2 1)))))
+
+(define-command toggle-line-wrap () ()
+  "Toggle line wrap in the buffer."
+  (setf (variable-value 'line-wrap) (not (variable-value 'line-wrap))))


### PR DESCRIPTION
Addresses the issue: #827

Toggles line wrap in buffer only, unsure if should be global or not