### PR TITLE
lem-sdl2: Make configurable modifier keycode by dynamic variable

### DIFF
--- a/frontends/sdl2/keyboard.lisp
+++ b/frontends/sdl2/keyboard.lisp
@@ -90,18 +90,23 @@
         (modifier (get-modifier keysym)))
     (make-key-event code modifier)))
 
-(defun mod-p (mod value)
-  (= value (logand value mod)))
+(defparameter *modifier-code-table*
+  `((:shift ,sdl2-ffi:+kmod-lshift+ ,sdl2-ffi:+kmod-rshift+)
+    (:ctrl ,sdl2-ffi:+kmod-lctrl+ ,sdl2-ffi:+kmod-rctrl+)
+    (:meta ,sdl2-ffi:+kmod-lalt+)
+    (:super ,sdl2-ffi:+kmod-lgui+ ,sdl2-ffi:+kmod-rgui+)))
+
+(defun mod-p (mod mod-type)
+  (some (lambda (value)
+          (= value (logand value mod)))
+        (cdr (assoc mod-type *modifier-code-table*))))
 
 (defun get-modifier (keysym)
   (let* ((mod (sdl2:mod-value keysym))
-         (shift (or (mod-p mod sdl2-ffi:+kmod-lshift+)
-                    (mod-p mod sdl2-ffi:+kmod-rshift+)))
-         (ctrl (or (mod-p mod sdl2-ffi:+kmod-lctrl+)
-                   (mod-p mod sdl2-ffi:+kmod-rctrl+)))
-         (meta (mod-p mod sdl2-ffi:+kmod-lalt+))
-         (super (or (mod-p mod sdl2-ffi:+kmod-lgui+)
-                    (mod-p mod sdl2-ffi:+kmod-rgui+))))
+         (shift (mod-p mod :shift))
+         (ctrl (mod-p mod :ctrl))
+         (meta (mod-p mod :meta))
+         (super (mod-p mod :super)))
     (make-modifier :shift shift :ctrl ctrl :meta meta :super super)))
 
 (defun update-modifier (modifier new-modifier)


### PR DESCRIPTION
On SDL2 / Linux, when the meta key is assigned separately from the alt key, the meta key is not recognized as meta but super.
Currently, it is hard-coded which modifier key is actually assigned to which modifier.
This PR introduces a dynamic variable `*modifier-code-table*` that allows modifier keys to be set.
By default, the behavior is the same as before.

The following can be written in the configuration file.
```lisp
#+lem-sdl2
(setf lem-sdl2/keyboard::*modifier-code-table*
      `((:shift ,sdl2-ffi:+kmod-lshift+ ,sdl2-ffi:+kmod-rshift+)
        (:ctrl ,sdl2-ffi:+kmod-lctrl+ ,sdl2-ffi:+kmod-rctrl+)
        (:meta ,sdl2-ffi:+kmod-lgui+ ,sdl2-ffi:+kmod-rgui+)
        (:super ,sdl2-ffi:+kmod-lalt+ ,sdl2-ffi:+kmod-ralt+)))
```