### PR TITLE
Add keyboard macro to vi-mode

### DIFF
--- a/extensions/vi-mode/binds.lisp
+++ b/extensions/vi-mode/binds.lisp
@@ -119,6 +119,7 @@
 (define-key *normal-keymap* "C-r" 'vi-redo)
 (define-key *motion-keymap* 'delete-previous-char 'vi-backward-char)
 (define-key *motion-keymap* 'self-insert 'undefined-key)
+(define-key *normal-keymap* "q" 'vi-record-macro)
 
 (define-key *insert-keymap* "Escape" 'vi-end-insert)
 (define-key *insert-keymap* "C-p" 'abbrev)

--- a/extensions/vi-mode/binds.lisp
+++ b/extensions/vi-mode/binds.lisp
@@ -120,6 +120,8 @@
 (define-key *motion-keymap* 'delete-previous-char 'vi-backward-char)
 (define-key *motion-keymap* 'self-insert 'undefined-key)
 (define-key *normal-keymap* "q" 'vi-record-macro)
+(define-key *normal-keymap* "@" 'vi-execute-macro)
+(define-key *normal-keymap* "Q" 'vi-execute-last-recorded-macro)
 
 (define-key *insert-keymap* "Escape" 'vi-end-insert)
 (define-key *insert-keymap* "C-p" 'abbrev)

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -564,7 +564,7 @@
     ((macro-register-p macro)
      (let ((keyseq (register macro)))
        (cond
-         ((consp keyseq)
+         ((listp keyseq)
           (let ((*macro-running-p* t))
             (buffer-disable-undo-boundary (lem:current-buffer))
             (unwind-protect

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -23,6 +23,8 @@
                 :kill-region-without-appending)
   (:import-from :lem/isearch
                 :*isearch-finish-hooks*)
+  (:import-from :lem/kbdmacro
+                :*macro-running-p*)
   (:import-from :alexandria
                 :when-let
                 :last-elt)
@@ -563,8 +565,12 @@
      (let ((keyseq (register macro)))
        (cond
          ((consp keyseq)
-          (dotimes (i n)
-            (execute-key-sequence keyseq)))
+          (let ((*macro-running-p* t))
+            (buffer-disable-undo-boundary (lem:current-buffer))
+            (unwind-protect
+                 (dotimes (i n)
+                   (execute-key-sequence keyseq))
+              (buffer-enable-undo-boundary (lem:current-buffer)))))
          (t
           (editor-error "No macro is recorded at the register '~A'" macro)))))
     (t

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -52,6 +52,7 @@
      (:file "commands")
      (:file "text-objects")
      (:file "registers")
+     (:file "kbdmacro")
      (:file "options")))
    (:file "utils"
     :pathname "tests/utils"))

--- a/extensions/vi-mode/registers.lisp
+++ b/extensions/vi-mode/registers.lisp
@@ -17,6 +17,8 @@
   (:export :register
            :named-register-p
            :numbered-register-p
+           :macro-register-p
+           :downcase-char
            :yank-region
            :delete-region))
 (in-package :lem-vi-mode/registers)
@@ -80,6 +82,11 @@
 (defun numbered-register-p (name)
   (declare (type character name))
   (char<= #\0 name #\9))
+
+(defun macro-register-p (name)
+  (or (named-register-p name)
+      (numbered-register-p name)
+      (char= name #\")))
 
 (defun values-register-item (item)
   (etypecase item

--- a/extensions/vi-mode/registers.lisp
+++ b/extensions/vi-mode/registers.lisp
@@ -15,6 +15,8 @@
   (:import-from :trivial-types
                 :proper-list)
   (:export :register
+           :named-register-p
+           :numbered-register-p
            :yank-region
            :delete-region))
 (in-package :lem-vi-mode/registers)

--- a/extensions/vi-mode/tests/kbdmacro.lisp
+++ b/extensions/vi-mode/tests/kbdmacro.lisp
@@ -55,7 +55,9 @@
       (cmd "Q")
       (ok (buf= #?"set-command\nde[f]ine-command\ndefine-command\n"))
       (cmd "2Q")
-      (ok (buf= #?"set-command\nset-command\nset-command\n[]")))
+      (ok (buf= #?"set-command\nset-command\nset-command\n[]"))
+      (cmd "u")
+      (ok (text= #?"set-command\ndefine-command\ndefine-command\n")))
     (with-vi-buffer (#?"[d]efine-command\ndefine-command\ndefine-command\n")
       (handler-case
           (cmd "10@a")

--- a/extensions/vi-mode/tests/kbdmacro.lisp
+++ b/extensions/vi-mode/tests/kbdmacro.lisp
@@ -1,0 +1,63 @@
+(defpackage :lem-vi-mode/tests/kbdmacro
+  (:use :cl
+        :lem
+        :rove
+        :lem-vi-mode/tests/utils)
+  (:import-from :lem-vi-mode/commands
+                :*kbdmacro-recording-register*
+                :*last-recorded-macro*)
+  (:import-from :lem-vi-mode/registers
+                :register)
+  (:import-from :lem-fake-interface
+                :with-fake-interface)
+  (:import-from :named-readtables
+                :in-readtable))
+(in-package :lem-vi-mode/tests/kbdmacro)
+
+(in-readtable :interpol-syntax)
+
+(deftest vi-record-macro
+  (with-fake-interface ()
+    (with-vi-buffer ("")
+      (ok (signals (cmd "q<C-g>") 'editor-abort))
+      (ok (not *kbdmacro-recording-register*))
+      (ok (signals (cmd "q<Escape>") 'editor-abort))
+      (ok (not *kbdmacro-recording-register*))
+      (ok (signals (cmd "q#") 'editor-error))
+      (cmd "qa")
+      (ok (char= *kbdmacro-recording-register* #\a))
+      (cmd "q")
+      (ok (null *kbdmacro-recording-register*))
+      (ok (char= *last-recorded-macro* #\a))
+      (cmd "qA")
+      (ok (char= *kbdmacro-recording-register* #\A))
+      (cmd "q")
+      (ok (char= *last-recorded-macro* #\a))
+      (cmd "q1")
+      (ok (char= *kbdmacro-recording-register* #\1))
+      (cmd "q")
+      (ok (char= *last-recorded-macro* #\1)))
+    (with-vi-buffer (#?"[d]efine-command\ndefine-command\ndefine-command\n")
+      (setf (register #\a) nil)
+      (cmd "qa")
+      (cmd "^dt-")
+      (cmd "q")
+      (ok (= 4 (length (register #\a))))
+      (ok (buf= #?"[-]command\ndefine-command\ndefine-command\n"))
+      (cmd "qA")
+      (cmd "iset<Escape>j")
+      (cmd "q")
+      (ok (= 10 (length (register #\a))))
+      (ok (buf= #?"set-command\nde[f]ine-command\ndefine-command\n"))
+      (cmd "@a")
+      (ok (buf= #?"set-command\nset-command\nde[f]ine-command\n")))
+    (with-vi-buffer (#?"[d]efine-command\ndefine-command\ndefine-command\n")
+      (cmd "Q")
+      (ok (buf= #?"set-command\nde[f]ine-command\ndefine-command\n"))
+      (cmd "2Q")
+      (ok (buf= #?"set-command\nset-command\nset-command\n[]")))
+    (with-vi-buffer (#?"[d]efine-command\ndefine-command\ndefine-command\n")
+      (handler-case
+          (cmd "10@a")
+        (end-of-buffer ()))
+      (ok (buf= #?"set-command\nset-command\nset-command\nset[]")))))

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -84,8 +84,9 @@
   (when *enable-repeat-recording*
     (setf *last-repeat-keys* nil))
   (unless *macro-running-p*
-    (buffer-undo-boundary))
-  (buffer-disable-undo-boundary (lem:current-buffer)))
+    (buffer-undo-boundary)
+    (buffer-disable-undo-boundary (lem:current-buffer))))
 
 (defmethod state-disabled-hook ((state insert))
-  (buffer-enable-undo-boundary (lem:current-buffer)))
+  (unless *macro-running-p*
+    (buffer-enable-undo-boundary (lem:current-buffer))))

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -24,6 +24,8 @@
                 :*operator-keymap*)
   (:import-from :lem-vi-mode/visual
                 :*visual-keymap*)
+  (:import-from :lem/kbdmacro
+                :*macro-running-p*)
   (:import-from :alexandria
                 :appendf)
   (:export :vi-mode
@@ -81,7 +83,8 @@
 (defmethod state-enabled-hook ((state insert))
   (when *enable-repeat-recording*
     (setf *last-repeat-keys* nil))
-  (buffer-undo-boundary)
+  (unless *macro-running-p*
+    (buffer-undo-boundary))
   (buffer-disable-undo-boundary (lem:current-buffer)))
 
 (defmethod state-disabled-hook ((state insert))


### PR DESCRIPTION
- `q{a-zA-Z0-9"}` to record a new macro
- `q` to finish recording
- `@{a-zA-Z0-9"}` to execute a macro
- `Q` to execute the last recorded macro