### PR TITLE
Ensure to reset the universal arguments even when error occurs

### DIFF
--- a/src/ext/universal-argument.lisp
+++ b/src/ext/universal-argument.lisp
@@ -73,8 +73,9 @@
          (*universal-argument* n))
     (universal-argument-mode nil)
     (unread-key-sequence key)
-    (call-command (read-command) n)
-    (reset-argument)))
+    (unwind-protect
+         (call-command (read-command) n)
+      (reset-argument))))
 
 (define-command universal-argument-abort () ()
   (universal-argument-mode nil)


### PR DESCRIPTION
The universal argument isn't reset when some error occurs in the command called in `universal-argument-default`.

This happens quite often with vi-mode for errors like `end-of-buffer`. For example, `10000j` ends with an `end-of-error`, and can see the remaining universal argument with `1j`.