### PR TITLE
Add `<Leader>` key to vi-mode.

### DIFF
--- a/extensions/vi-mode/core.lisp
+++ b/extensions/vi-mode/core.lisp
@@ -42,7 +42,9 @@
            :text-object-abort
            :text-object-abort-range
            :vi-current-window
-           :with-main-window))
+           :with-main-window
+           :vi-keymap
+           :define-keymap))
 (in-package :lem-vi-mode/core)
 
 (defvar *last-repeat-keys* '())
@@ -243,3 +245,17 @@
 (defmacro with-main-window (window &body body)
   `(let ((*vi-current-window* ,window))
      ,@body))
+
+(defstruct (vi-keymap (:include keymap)
+                      (:constructor %make-vi-keymap)))
+
+(defun make-vi-keymap (&rest args &key undef-hook parent name)
+  (declare (ignore undef-hook parent name))
+  (let ((keymap (apply #'%make-vi-keymap args)))
+    (push keymap *keymaps*)
+    keymap))
+
+(defmacro define-keymap (name &key undef-hook parent)
+  `(defvar ,name (make-vi-keymap :name ',name
+                                 :undef-hook ,undef-hook
+                                 :parent ,parent)))

--- a/extensions/vi-mode/leader.lisp
+++ b/extensions/vi-mode/leader.lisp
@@ -1,0 +1,30 @@
+(defpackage :lem-vi-mode/leader
+  (:use :cl
+        :lem)
+  (:import-from :lem-vi-mode/core
+                :vi-keymap)
+  (:export :leader-key))
+(in-package :lem-vi-mode/leader)
+
+(define-named-key "Leader")
+
+(define-editor-variable leader-key "\\")
+
+(defun mapleader-key ()
+  (first (lem-core::parse-keyspec (variable-value 'leader-key))))
+
+(defun mapleader-key-p (key)
+  (eq key (mapleader-key)))
+
+(defun leader-key ()
+  (make-key :sym "Leader"))
+
+(defmethod keymap-find-keybind ((keymap vi-keymap) (key lem-core::key) cmd)
+  (if (mapleader-key-p key)
+      (call-next-method keymap (leader-key) cmd)
+      (call-next-method)))
+
+(defmethod keymap-find-keybind ((keymap vi-keymap) (key cons) cmd)
+  (if (mapleader-key-p (first key))
+      (call-next-method keymap (cons (leader-key) (rest key)) cmd)
+      (call-next-method)))

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -10,6 +10,7 @@
                "lem-lisp-mode"
                "trivial-types")
   :components ((:file "core")
+               (:file "leader" :depends-on ("core"))
                (:file "options" :depends-on ("utils"))
                (:file "word" :depends-on ("options"))
                (:file "modeline" :depends-on ("core"))

--- a/extensions/vi-mode/states.lisp
+++ b/extensions/vi-mode/states.lisp
@@ -6,7 +6,8 @@
                 :*enable-hook*
                 :*disable-hook*
                 :change-state
-                :state-enabled-hook)
+                :state-enabled-hook
+                :define-keymap)
   (:import-from :lem-vi-mode/modeline
                 :state-modeline-yellow
                 :state-modeline-aqua
@@ -34,15 +35,13 @@
 
 (defvar *emacs-keymap* *global-keymap*)
 
-(defvar *motion-keymap* (make-keymap :name '*motion-keymap*))
-(defvar *normal-keymap* (make-keymap :name '*normal-keymap*
-                                     :parent *motion-keymap*))
-(defvar *insert-keymap* (make-keymap :name '*insert-keymap*))
-(defvar *operator-keymap* (make-keymap :name '*operator-keymap*))
-(defvar *replace-state-keymap* (make-keymap :name '*replace-state-keymap*
-                                            :undef-hook 'return-last-read-char))
-(defvar *outer-text-objects-keymap* (make-keymap :name '*outer-text-objects-keymap*))
-(defvar *inner-text-objects-keymap* (make-keymap :name '*inner-text-objects-keymap*))
+(define-keymap *motion-keymap*)
+(define-keymap *normal-keymap* :parent *motion-keymap*)
+(define-keymap *insert-keymap*)
+(define-keymap *operator-keymap*)
+(define-keymap *replace-state-keymap* :undef-hook 'return-last-read-char)
+(define-keymap *outer-text-objects-keymap*)
+(define-keymap *inner-text-objects-keymap*)
 
 (defvar *inactive-keymap* (make-keymap))
 

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -5,6 +5,8 @@
         :lem-vi-mode/ex)
   (:import-from :lem-vi-mode/options
                 :option-value)
+  (:import-from :lem-vi-mode/leader
+                :leader-key)
   (:import-from :lem-vi-mode/commands
                 :vi-open-below
                 :vi-open-above)
@@ -42,7 +44,8 @@
            :normal
            :insert
            :change-state
-           :option-value))
+           :option-value
+           :leader-key))
 (in-package :lem-vi-mode)
 
 (define-command adjust-window-scroll () ()

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -59,6 +59,8 @@
    :key-sym
    :match-key
    :insertion-key-sym-p
+   :named-key-sym-p
+   :define-named-key
    :key-to-char)
   ;; macros.lisp
   (:export
@@ -361,6 +363,7 @@
    :find-keybind
    :insertion-key-p
    :lookup-keybind
+   :keymap-find-keybind
    :*abort-key*
    :abort-key-p
    :with-special-keymap

--- a/src/key.lisp
+++ b/src/key.lisp
@@ -1,11 +1,15 @@
 (in-package :lem-core)
 
-(defparameter *named-key-syms*
+(defvar *named-key-syms*
   '("Backspace" "Delete" "Down" "End" "Escape" "F0" "F1" "F10" "F11" "F12" "F2" "F3" "F4" "F5" "F6" "F7" "F8" "F9"
     "Home" "Left" "NopKey" "PageDown" "PageUp" "Return" "Right" "Space" "Tab" "Up"))
 
 (defun named-key-sym-p (key-sym)
   (find key-sym *named-key-syms* :test #'string=))
+
+(defmacro define-named-key (name)
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
+     (pushnew ,name *named-key-syms* :test 'string=)))
 
 (defparameter *key-sym-to-character-table* (make-hash-table :test 'equal))
 

--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -14,8 +14,8 @@
 (defstruct (keymap (:constructor %make-keymap))
   undef-hook
   parent
-  table
-  function-table
+  (table (make-hash-table :test 'eq))
+  (function-table (make-hash-table :test 'eq))
   name)
 
 (defmethod print-object ((object keymap) stream)
@@ -27,8 +27,6 @@
   (let ((keymap (%make-keymap
                  :undef-hook undef-hook
                  :parent parent
-                 :table (make-hash-table :test 'eq)
-                 :function-table (make-hash-table :test 'eq)
                  :name name)))
     (push keymap *keymaps*)
     keymap))
@@ -108,28 +106,29 @@
                       table)))
     (f (keymap-table keymap) nil)))
 
-(defun keymap-find-keybind (keymap key cmd)
-  (let ((table (keymap-table keymap)))
-    (labels ((f (k)
-               (let ((cmd (gethash k table)))
-                 (if (prefix-command-p cmd)
-                     (setf table cmd)
-                     cmd))))
-      (let ((parent (keymap-parent keymap)))
-        (when parent
-          (setf cmd (keymap-find-keybind parent key cmd))))
-      (or (etypecase key
-            (key
-             (f key))
-            (list
-             (let (cmd)
-               (dolist (k key)
-                 (unless (setf cmd (f k))
-                   (return)))
-               cmd)))
-          (gethash cmd (keymap-function-table keymap))
-          (keymap-undef-hook keymap)
-          cmd))))
+(defgeneric keymap-find-keybind (keymap key cmd)
+  (:method ((keymap t) key cmd)
+    (let ((table (keymap-table keymap)))
+      (labels ((f (k)
+                 (let ((cmd (gethash k table)))
+                   (if (prefix-command-p cmd)
+                       (setf table cmd)
+                       cmd))))
+        (let ((parent (keymap-parent keymap)))
+          (when parent
+            (setf cmd (keymap-find-keybind parent key cmd))))
+        (or (etypecase key
+              (key
+               (f key))
+              (list
+               (let (cmd)
+                 (dolist (k key)
+                   (unless (setf cmd (f k))
+                     (return)))
+                 cmd)))
+            (gethash cmd (keymap-function-table keymap))
+            (keymap-undef-hook keymap)
+            cmd)))))
 
 (defun insertion-key-p (key)
   (let* ((key (typecase key


### PR DESCRIPTION
Vim provides a special key `<Leader>`, which is configurable by each user.

For example, an extension provides a command mapped to `<Leader> x`, then it's invoked by `\` + `x` since `Backslash` (`\`) is the default map of `<Leader>`. If the user set `g:mapleader` to `Space`, it can be invoked by `Space x`.

## Usage

```common-lisp
(define-command say-hello () () (message "Hello!"))
(define-key lem-vi-mode:*normal-keymap* "Leader x" 'say-hello)
(setf (variable-value 'lem-vi-mode:leader-key) "Space")
```

## Lem API changes

* Add `define-named-key` to define a custom named key
* Rewrite `keymap-find-keybind` as a generic function, and export it