### PR TITLE
Fix `H`, `M`, `L` not to scroll when `scrolloff` option is set.

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -19,6 +19,10 @@
                 :visual-region)
   (:import-from :lem/common/killring
                 :peek-killring-item)
+  (:import-from :lem-vi-mode/window
+                :move-to-window-top
+                :move-to-window-middle
+                :move-to-window-bottom)
   (:import-from :lem-vi-mode/utils
                 :kill-region-without-appending)
   (:import-from :lem/isearch
@@ -248,19 +252,17 @@
 (define-motion vi-move-to-window-top () ()
     (:type :line
      :jump t)
-  (move-point (current-point) (window-view-point (current-window))))
+  (move-to-window-top))
 
 (define-motion vi-move-to-window-middle () ()
     (:type :line
      :jump t)
-  (vi-move-to-window-top)
-  (next-line (floor (/ (- (window-height (current-window)) 2) 2))))
+  (move-to-window-middle))
 
 (define-motion vi-move-to-window-bottom () ()
     (:type :line
      :jump t)
-  (vi-move-to-window-top)
-  (next-line (- (window-height (current-window)) 2)))
+  (move-to-window-bottom))
 
 (define-command vi-back-to-indentation () ()
   (vi-move-to-beginning-of-line)

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -23,14 +23,15 @@
                 :pathname "commands"
                 :depends-on ("core" "jump-motions" "visual" "states")
                 :components ((:file "utils")))
-               (:file "commands" :depends-on ("core" "commands-utils" "word" "visual" "jump-motions" "states" "registers"))
+               (:file "commands" :depends-on ("core" "commands-utils" "word" "visual" "jump-motions" "states" "registers" "window"))
                (:file "ex-core" :depends-on ("visual"))
                (:file "ex-parser" :depends-on ("ex-core"))
                (:file "ex-command" :depends-on ("ex-core" "options" "utils"))
                (:file "ex" :depends-on ("core" "ex-parser" "visual" "registers"))
                (:file "binds" :depends-on ("states" "commands" "ex" "visual"))
                (:file "special-binds" :depends-on ("core"))
-               (:file "vi-mode" :depends-on ("core" "options" "ex" "commands" "states"))
+               (:file "window" :depends-on ("options"))
+               (:file "vi-mode" :depends-on ("core" "options" "ex" "commands" "states" "window"))
                (:file "utils"))
   :in-order-to ((test-op (test-op "lem-vi-mode/tests"))))
 

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -26,6 +26,8 @@
                 :*operator-keymap*)
   (:import-from :lem-vi-mode/visual
                 :*visual-keymap*)
+  (:import-from :lem-vi-mode/window
+                :adjust-window-scroll)
   (:import-from :lem/kbdmacro
                 :*macro-running-p*)
   (:import-from :alexandria
@@ -49,21 +51,6 @@
            :option-value
            :leader-key))
 (in-package :lem-vi-mode)
-
-(define-command adjust-window-scroll () ()
-  (let* ((window (lem:current-window))
-         (window-height (lem-core::window-height-without-modeline window))
-         (cursor-y (lem:window-cursor-y window))
-         (window-scroll-offset (option-value "scrolloff"))
-         (scroll-offset (min (floor (/ window-height 2)) window-scroll-offset)))
-    (cond
-      ((< cursor-y scroll-offset)
-       (lem:window-scroll window (- cursor-y scroll-offset)))
-      ((and (< (- window-height scroll-offset) cursor-y)
-            (< (- window-height cursor-y)
-               (- (lem:buffer-nlines (lem:current-buffer))
-                  (lem:line-number-at-point (lem:current-point)))))
-       (lem:window-scroll window (- cursor-y (- window-height scroll-offset)))))))
 
 (defmethod post-command-hook ((state normal))
   (when *enable-repeat-recording*

--- a/extensions/vi-mode/window.lisp
+++ b/extensions/vi-mode/window.lisp
@@ -1,0 +1,90 @@
+(defpackage :lem-vi-mode/window
+  (:use :cl
+        :lem)
+  (:import-from :lem-vi-mode/options
+                :option-value)
+  (:import-from :lem-core
+                :window-height-without-modeline)
+  (:export :move-to-window-top
+           :move-to-window-middle
+           :move-to-window-bottom
+           :adjust-window-scroll))
+(in-package :lem-vi-mode/window)
+
+(defun window-height* (&optional (window (current-window)))
+  (window-height-without-modeline window))
+
+(defun scroll-offset (&optional (window (current-window)))
+  (min (floor (/ (window-height* window) 2))
+       (option-value "scrolloff")))
+
+(defun window-start-point (&optional (window (current-window)))
+  (window-view-point window))
+
+(defun window-end-point (&optional (window (current-window)))
+  (let ((point (copy-point (window-start-point window))))
+    (move-to-next-virtual-line point (1- (window-height* window)) window)
+    point))
+
+(defun buffer-nlines-without-last-empty-line (buffer)
+  (- (lem:buffer-nlines buffer)
+     (if (string= (line-string (buffer-end-point buffer)) "")
+         1
+         0)))
+
+(defun point-last-line-p (point)
+  (let* ((buffer (point-buffer point))
+         (end-point (buffer-end-point buffer)))
+    (or (= (line-number-at-point point)
+           (line-number-at-point end-point))
+        (and (string= (line-string end-point) "")
+             (= (line-number-at-point point)
+                (1- (line-number-at-point end-point)))))))
+
+(defun window-has-following-lines-p (&optional (window (current-window)))
+  (let ((buffer (window-buffer window))
+        (end-point (window-end-point window)))
+    (and
+     (not (point-last-line-p end-point))
+     (or
+      (< (line-number-at-point end-point)
+         (buffer-nlines-without-last-empty-line buffer))
+      (< (+ (point-charpos end-point)
+            (window-width window))
+         (length (line-string end-point)))))))
+
+(defun window-has-leading-lines-p (&optional (window (current-window)))
+  (let ((start-point (window-start-point window)))
+    (or (< 1 (line-number-at-point start-point))
+        (/= 0 (point-charpos start-point)))))
+
+(defun move-to-window-top ()
+  (let ((window (current-window)))
+    (move-point (current-point) (window-start-point window))
+    (when (window-has-leading-lines-p window)
+      (next-line (scroll-offset)))))
+
+(defun move-to-window-middle ()
+  (let ((window (current-window)))
+    (move-point (current-point) (window-start-point window))
+    (move-to-next-virtual-line (current-point)
+                               (floor (/ (- (window-height* window) 2) 2))
+                               window)))
+
+(defun move-to-window-bottom ()
+  (let ((window (current-window)))
+    (move-point (current-point) (window-end-point window))
+    (when (window-has-following-lines-p window)
+      (previous-line (scroll-offset)))))
+
+(defun adjust-window-scroll ()
+  (let* ((window (current-window))
+         (window-height (window-height* window))
+         (cursor-y (window-cursor-y window))
+         (scroll-offset (scroll-offset window)))
+    (cond
+      ((< cursor-y scroll-offset)
+       (window-scroll window (- cursor-y scroll-offset)))
+      ((and (<= (- window-height scroll-offset) cursor-y)
+            (window-has-following-lines-p window))
+       (window-scroll window (1+ (- cursor-y (- window-height scroll-offset))))))))


### PR DESCRIPTION
`H`, `M`, `L` are viewpoint-oriented motion commands. When `scrolloff` is set, they should move to the line inside by the offset.