### PR TITLE
Fix `o` to indent properly.

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -799,15 +799,11 @@
   (change-state 'insert))
 
 (define-command vi-open-below () ()
-  (let* ((p (current-point))
-         (column (with-point ((p (current-point)))
-                   (point-column (or (and (line-offset p 1)
-                                          (back-to-indentation p))
-                                     (line-start p))))))
+  (let ((p (current-point)))
     (line-end p)
     (change-state 'insert)
     (insert-character p #\Newline)
-    (move-to-column p column t)))
+    (indent-line (current-point))))
 
 (define-command vi-open-above () ()
   (line-start (current-point))


### PR DESCRIPTION
It didn't indent when the next line is empty.