### PR TITLE
Fix `window-has-following-lines-p` to work when the last displayed line is wrapped

### DIFF
--- a/extensions/vi-mode/window.lisp
+++ b/extensions/vi-mode/window.lisp
@@ -26,32 +26,12 @@
     (move-to-next-virtual-line point (1- (window-height* window)) window)
     point))
 
-(defun buffer-nlines-without-last-empty-line (buffer)
-  (- (lem:buffer-nlines buffer)
-     (if (string= (line-string (buffer-end-point buffer)) "")
-         1
-         0)))
-
-(defun point-last-line-p (point)
-  (let* ((buffer (point-buffer point))
-         (end-point (buffer-end-point buffer)))
-    (or (= (line-number-at-point point)
-           (line-number-at-point end-point))
-        (and (string= (line-string end-point) "")
-             (= (line-number-at-point point)
-                (1- (line-number-at-point end-point)))))))
-
 (defun window-has-following-lines-p (&optional (window (current-window)))
-  (let ((buffer (window-buffer window))
-        (end-point (window-end-point window)))
-    (and
-     (not (point-last-line-p end-point))
-     (or
-      (< (line-number-at-point end-point)
-         (buffer-nlines-without-last-empty-line buffer))
-      (< (+ (point-charpos end-point)
-            (window-width window))
-         (length (line-string end-point)))))))
+  (let ((end-point (window-end-point window)))
+    (with-point ((p end-point))
+      (move-to-next-virtual-line p)
+      (and (point/= p end-point)
+           (not (string= (line-string p) ""))))))
 
 (defun window-has-leading-lines-p (&optional (window (current-window)))
   (let ((start-point (window-start-point window)))
@@ -67,9 +47,7 @@
 (defun move-to-window-middle ()
   (let ((window (current-window)))
     (move-point (current-point) (window-start-point window))
-    (move-to-next-virtual-line (current-point)
-                               (floor (/ (- (window-height* window) 2) 2))
-                               window)))
+    (next-line (floor (/ (- (window-height* window) 2) 2)))))
 
 (defun move-to-window-bottom ()
   (let ((window (current-window)))


### PR DESCRIPTION
ref #1081 