### PR TITLE
Revise vi-mode's jumplist

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -632,7 +632,7 @@
 (define-command vi-search-forward () ()
   (setf *last-search-direction* :forward)
   (add-hook *isearch-finish-hooks* 'vi-isearch-finish-hook)
-  (with-jump-motion
+  (with-jumplist
     (lem/isearch::isearch-start "/"
                                 (lambda (point string)
                                   (alexandria:when-let (p (lem/isearch::search-forward-regexp
@@ -647,13 +647,13 @@
 (define-command vi-search-backward () ()
   (setf *last-search-direction* :backward)
   (add-hook *isearch-finish-hooks* 'vi-isearch-finish-hook)
-  (with-jump-motion
+  (with-jumplist
     (lem/isearch:isearch-backward-regexp "?")))
 
 (defun vi-search-repeat-forward (n)
   (when-let ((query (register #\/)))
     (lem/isearch::change-previous-string query)
-    (with-jump-motion
+    (with-jumplist
       (with-point ((p (current-point)))
         (vi-forward-char (length lem/isearch::*isearch-string*))
         (loop repeat n
@@ -667,7 +667,7 @@
 (defun vi-search-repeat-backward (n)
   (when-let ((query (register #\/)))
     (lem/isearch::change-previous-string query)
-    (with-jump-motion
+    (with-jumplist
       (dotimes (i n) (lem/isearch:isearch-prev)))))
 
 (define-command vi-search-next (n) ("p")
@@ -681,7 +681,7 @@
     (:backward (vi-search-repeat-forward n))))
 
 (define-command vi-search-forward-symbol-at-point () ()
-  (with-jump-motion
+  (with-jumplist
     (lem/isearch:isearch-forward-symbol-at-point)
     (lem/isearch:isearch-finish)
     (lem/isearch:isearch-next)))

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -6,7 +6,7 @@
         :lem-vi-mode/core
         :lem-vi-mode/word
         :lem-vi-mode/visual
-        :lem-vi-mode/jump-motions
+        :lem-vi-mode/jumplist
         :lem-vi-mode/registers
         :lem-vi-mode/text-objects
         :lem-vi-mode/commands/utils)

--- a/extensions/vi-mode/commands/utils.lisp
+++ b/extensions/vi-mode/commands/utils.lisp
@@ -22,7 +22,8 @@
   (:import-from :lem-vi-mode/states
                 :operator)
   (:import-from :lem-vi-mode/jumplist
-                :with-jump-motion)
+                :with-jump-motion
+                :without-jump-motion)
   (:import-from :lem-vi-mode/visual
                 :visual-p
                 :visual-line-p
@@ -213,12 +214,13 @@
 
 (defun call-define-operator (fn &key keep-visual restore-point)
   (with-point ((*vi-origin-point* (current-point)))
-    (unwind-protect (funcall fn)
-      (when restore-point
-        (move-point (current-point) *vi-origin-point*))
-      (unless keep-visual
-        (when (visual-p)
-          (vi-visual-end))))))
+    (without-jump-motion
+      (unwind-protect (funcall fn)
+        (when restore-point
+          (move-point (current-point) *vi-origin-point*))
+        (unless keep-visual
+          (when (visual-p)
+            (vi-visual-end)))))))
 
 (defun parse-arg-descriptors (arg-descriptors &key motion move-point)
   `(values-list

--- a/extensions/vi-mode/commands/utils.lisp
+++ b/extensions/vi-mode/commands/utils.lisp
@@ -22,8 +22,8 @@
   (:import-from :lem-vi-mode/states
                 :operator)
   (:import-from :lem-vi-mode/jumplist
-                :with-jump-motion
-                :without-jump-motion)
+                :with-jumplist
+                :without-jumplist)
   (:import-from :lem-vi-mode/visual
                 :visual-p
                 :visual-line-p
@@ -109,7 +109,7 @@
                            :default-n-arg ,default-n-arg))
        ,arg-list ,arg-descriptors
      (with-point ((*vi-origin-point* (current-point)))
-       (,(if jump 'with-jump-motion 'progn)
+       (,(if jump 'with-jumplist 'progn)
         ,@body))))
 
 (defun call-motion-command (command n)
@@ -214,7 +214,7 @@
 
 (defun call-define-operator (fn &key keep-visual restore-point)
   (with-point ((*vi-origin-point* (current-point)))
-    (without-jump-motion
+    (without-jumplist
       (unwind-protect (funcall fn)
         (when restore-point
           (move-point (current-point) *vi-origin-point*))

--- a/extensions/vi-mode/commands/utils.lisp
+++ b/extensions/vi-mode/commands/utils.lisp
@@ -21,7 +21,7 @@
                 :text-object-abort-range)
   (:import-from :lem-vi-mode/states
                 :operator)
-  (:import-from :lem-vi-mode/jump-motions
+  (:import-from :lem-vi-mode/jumplist
                 :with-jump-motion)
   (:import-from :lem-vi-mode/visual
                 :visual-p

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -27,7 +27,8 @@
 
 (define-ex-command "^e$" (range filename)
   (declare (ignore range))
-  (lem:find-file (merge-pathnames (expand-filename-modifiers filename) (uiop:getcwd))))
+  (with-jump-motion
+    (lem:find-file (merge-pathnames (expand-filename-modifiers filename) (uiop:getcwd)))))
 
 (define-ex-command "^(w|write)$" (range filename)
   (ex-write range filename t))

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -2,7 +2,10 @@
   (:use :cl
         :lem-vi-mode/ex-core)
   (:import-from :lem-vi-mode/jumplist
-                :with-jumplist)
+                :with-jumplist
+                :window-jumplist
+                :current-jumplist
+                :copy-jumplist)
   (:import-from :lem-vi-mode/options
                 :execute-set-command)
   (:import-from :lem-vi-mode/utils
@@ -73,15 +76,24 @@
 (define-ex-command "^(x|xit)!$" (range filename)
   (ex-write-quit range filename t nil))
 
+(defun copy-current-jumplist-to-next-window ()
+  (let* ((window-list
+           (lem:compute-window-list (lem:current-window)))
+         (new-window (lem:get-next-window (lem:current-window) window-list)))
+    (setf (window-jumplist new-window)
+          (copy-jumplist (current-jumplist)))))
+
 (define-ex-command "^(sp|split)$" (range filename)
   (declare (ignore range))
   (lem:split-active-window-vertically)
+  (copy-current-jumplist-to-next-window)
   (unless (string= filename "")
     (lem:find-file (merge-pathnames (expand-filename-modifiers filename) (uiop:getcwd)))))
 
 (define-ex-command "^(vs|vsplit)$" (range filename)
   (declare (ignore range))
   (lem:split-active-window-horizontally)
+  (copy-current-jumplist-to-next-window)
   (lem:next-window)
   (unless (string= filename "")
     (lem:find-file (merge-pathnames (expand-filename-modifiers filename) (uiop:getcwd)))))

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -150,7 +150,8 @@
 
 (define-ex-command "^(b|buffer)$" (range buffer-name)
   (declare (ignore range))
-  (lem:select-buffer buffer-name))
+  (with-jump-motion
+    (lem:select-buffer buffer-name)))
 
 (define-ex-command "^bd(?:elete)?$" (range buffer-name)
   (declare (ignore range))

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -1,7 +1,7 @@
 (defpackage :lem-vi-mode/ex-command
   (:use :cl
         :lem-vi-mode/ex-core)
-  (:import-from :lem-vi-mode/jump-motions
+  (:import-from :lem-vi-mode/jumplist
                 :with-jump-motion)
   (:import-from :lem-vi-mode/options
                 :execute-set-command)

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -2,7 +2,7 @@
   (:use :cl
         :lem-vi-mode/ex-core)
   (:import-from :lem-vi-mode/jumplist
-                :with-jump-motion)
+                :with-jumplist)
   (:import-from :lem-vi-mode/options
                 :execute-set-command)
   (:import-from :lem-vi-mode/utils
@@ -27,7 +27,7 @@
 
 (define-ex-command "^e$" (range filename)
   (declare (ignore range))
-  (with-jump-motion
+  (with-jumplist
     (lem:find-file (merge-pathnames (expand-filename-modifiers filename) (uiop:getcwd)))))
 
 (define-ex-command "^(w|write)$" (range filename)
@@ -87,7 +87,7 @@
     (lem:find-file (merge-pathnames (expand-filename-modifiers filename) (uiop:getcwd)))))
 
 (define-ex-command "^(s|substitute)$" (range argument)
-  (with-jump-motion
+  (with-jumplist
     (let (start end)
       (case (length range)
         ((0)
@@ -150,7 +150,7 @@
 
 (define-ex-command "^(b|buffer)$" (range buffer-name)
   (declare (ignore range))
-  (with-jump-motion
+  (with-jumplist
     (lem:select-buffer buffer-name)))
 
 (define-ex-command "^bd(?:elete)?$" (range buffer-name)

--- a/extensions/vi-mode/jump-motions.lisp
+++ b/extensions/vi-mode/jump-motions.lisp
@@ -1,42 +1,162 @@
-(defpackage #:lem-vi-mode/jump-motions
-  (:use #:cl
-        #:lem)
-  (:export #:with-jump-motion
-           #:jump-back
-           #:jump-next))
-(in-package #:lem-vi-mode/jump-motions)
+(defpackage :lem-vi-mode/jump-motions
+  (:use :cl
+        :lem)
+  (:export :with-jump-motion
+           :jump-back
+           :jump-next
+           :window-jumplist))
+(in-package :lem-vi-mode/jump-motions)
 
-(defvar *prev-jump-points* '())
-(defvar *current-point* nil)
-(defvar *next-jump-points* '())
+(defvar *max-jumplist-size* 100)
+
+(defstruct jumplist
+  (history nil :type list)
+  (index 0 :type (integer 0))
+  (current nil :type (or null point)))
+
+(defmethod print-object ((object jumplist) stream)
+  (print-unreadable-object (object stream :type t)
+    (with-slots (history index current)
+        object
+      (format stream ":HISTORY (~A items) :INDEX ~A"
+              (+ (length history)
+                 (if current 1 0))
+              index))))
+
+(define-condition jumplist-invalid-index (error)
+  ((jumplist :initarg :jumplist)
+   (index :initarg :index))
+  (:report (lambda (condition stream)
+             (with-slots (jumplist index) condition
+               (format stream "Invalid index ~A for ~A"
+                       index
+                       jumplist)))))
+
+(defun jumplist-ref (jumplist index)
+  (check-type index integer)
+  (cond
+    ((= index 0)
+     (jumplist-current jumplist))
+    ((< 0 index)
+     (or (nth (1- index)
+              (jumplist-history jumplist))
+         (error 'jumplist-invalid-index
+                :jumplist jumplist
+                :index index)))
+    (t
+     (error 'jumplist-invalid-index
+            :jumplist jumplist
+            :index index))))
+
+(defun delete-exceeded-elements (list count)
+  (let ((last-cdr (nthcdr (- count 1) list)))
+    (when last-cdr
+      (setf (cdr last-cdr) nil))
+    list))
+
+(defun jumplist-push (jumplist point)
+  (with-slots (history index current) jumplist
+    ;; Delete the newer history
+    (when (< 0 index)
+      (setf history (nthcdr index history))
+      (setf index 0
+            current nil))
+    (setf history
+          (cons point
+                ;; Remove points at the same line in the history
+                (remove (line-number-at-point point)
+                        history
+                        :key #'line-number-at-point
+                        :test #'=
+                        :count 1)))
+    ;; Keep only *max-jumplist-size* points (including `current`)
+    (delete-exceeded-elements history (1- *max-jumplist-size*))
+    point))
+
+(defun jumplist-history-back (jumplist)
+  (with-slots (index current) jumplist
+    (when (zerop index)
+      (setf current (copy-point (current-point))))
+    (handler-case
+        (prog1 (jumplist-ref jumplist (1+ index))
+          (incf index))
+      (jumplist-invalid-index () nil))))
+
+(defun jumplist-history-next (jumplist)
+  (with-slots (index current) jumplist
+    (when (<= 0 (1- index))
+      (decf index)
+      (prog1 (jumplist-ref jumplist index)
+        (when (zerop index)
+          (setf current nil))))))
+
+(defun window-jumplist (&optional (window (current-window)))
+  (or (window-parameter window :vi-mode-jumplist)
+      (setf (window-parameter window :vi-mode-jumplist)
+            (make-jumplist))))
+
+(defun jumplist-table (&optional (jumplist (window-jumplist)))
+  (flet ((buffer-identifier (buffer)
+           (if (buffer-filename buffer)
+               (enough-namestring (buffer-filename buffer))
+               (buffer-name buffer))))
+    (with-slots (index current) jumplist
+      (loop with results = (list (list (= 0 index)
+                                       (abs (- 0 index))
+                                       (and current
+                                            (line-number-at-point current))
+                                       (and current
+                                            (point-column current))
+                                       (and current
+                                            (buffer-identifier (point-buffer current)))))
+            for point in (jumplist-history jumplist)
+            for i from 1
+            ;; current-p index line column file/buffer-name
+            do (push (list
+                      (= i index)
+                      (abs (- i index))
+                      (line-number-at-point point)
+                      (point-column point)
+                      (buffer-identifier (point-buffer point)))
+                     results)
+            finally (return results)))))
+
+(defun print-jumplist (&optional (jumplist (window-jumplist)))
+  (let ((table (jumplist-table jumplist)))
+    (message
+     (with-output-to-string (s)
+       (dolist (row table)
+         (destructuring-bind (current-p index line column file)
+             row
+           (format s "~:[  ~;> ~]~A: ~A~%"
+                   current-p
+                   index
+                   (and line column file
+                        (format nil "(~A, ~A)  ~A" line column file)))))))))
 
 (defvar *jump-motion-recursive* nil)
+(defun call-with-jump-motion (fn)
+  (let ((*jump-motion-recursive* t)
+        (p (copy-point (current-point))))
+    (prog1 (funcall fn)
+      (unless (point= p (current-point))
+        (jumplist-push (window-jumplist) p)))))
+
 (defmacro with-jump-motion (&body body)
-  (let ((p (gensym "P")))
-    `(if *jump-motion-recursive*
-         (progn ,@body)
-         (let ((*jump-motion-recursive* t)
-               (,p (copy-point (current-point)) ; leak?
-                   ))
-           (prog1 (progn ,@body)
-             (unless (point= ,p (current-point))
-               (push ,p *prev-jump-points*))
-             (setf *current-point* nil))))))
+  `(if *jump-motion-recursive*
+       (progn ,@body)
+       (call-with-jump-motion
+        (lambda () ,@body))))
 
 (defun jump-back ()
-  (push (or *current-point*
-            (copy-point (current-point))) ; leak?
-        *next-jump-points*)
-  (setf *current-point* (pop *prev-jump-points*))
-  (when *current-point*
-    (switch-to-buffer (point-buffer *current-point*))
-    (move-point (current-point) *current-point*)))
+  (let ((point (jumplist-history-back (window-jumplist))))
+    (when point
+      (switch-to-buffer (point-buffer point))
+      (move-point (current-point) point)
+      point)))
 
 (defun jump-next ()
-  (when *current-point*
-    (push *current-point* *prev-jump-points*))
-  (let ((p (pop *next-jump-points*)))
-    (setf *current-point* p)
-    (when *current-point*
-      (switch-to-buffer (point-buffer *current-point*))
-      (move-point (current-point) p))))
+  (let ((point (jumplist-history-next (window-jumplist))))
+    (when point
+      (switch-to-buffer (point-buffer point))
+      (move-point (current-point) point))))

--- a/extensions/vi-mode/jumplist.lisp
+++ b/extensions/vi-mode/jumplist.lisp
@@ -6,8 +6,8 @@
   (:import-from :alexandria
                 :when-let
                 :ignore-some-conditions)
-  (:export :with-jump-motion
-           :without-jump-motion
+  (:export :with-jumplist
+           :without-jumplist
            :jump-back
            :jump-next
            :window-jumplist))
@@ -174,7 +174,7 @@
 
 (defvar *disable-jumplist* nil)
 
-(defun call-with-jump-motion (fn)
+(defun call-with-jumplist (fn)
   (with-point ((p (current-point)))
     (let ((*disable-jumplist* t))
       (prog1 (funcall fn)
@@ -183,13 +183,13 @@
                      (point= p (current-point)))
           (jumplist-history-push (window-jumplist) p))))))
 
-(defmacro with-jump-motion (&body body)
+(defmacro with-jumplist (&body body)
   `(if *disable-jumplist*
        (progn ,@body)
-       (call-with-jump-motion
+       (call-with-jumplist
         (lambda () ,@body))))
 
-(defmacro without-jump-motion (&body body)
+(defmacro without-jumplist (&body body)
   `(let ((*disable-jumplist* t))
      ,@body))
 

--- a/extensions/vi-mode/jumplist.lisp
+++ b/extensions/vi-mode/jumplist.lisp
@@ -54,7 +54,7 @@
       (setf (cdr last-cdr) nil))
     list))
 
-(defun jumplist-push (jumplist point)
+(defun jumplist-history-push (jumplist point)
   (with-slots (history index current) jumplist
     ;; Delete the newer history
     (when (< 0 index)
@@ -140,7 +140,7 @@
         (p (copy-point (current-point))))
     (prog1 (funcall fn)
       (unless (point= p (current-point))
-        (jumplist-push (window-jumplist) p)))))
+        (jumplist-history-push (window-jumplist) p)))))
 
 (defmacro with-jump-motion (&body body)
   `(if *jump-motion-recursive*

--- a/extensions/vi-mode/jumplist.lisp
+++ b/extensions/vi-mode/jumplist.lisp
@@ -149,7 +149,9 @@
   (with-point ((p (current-point)))
     (let ((*jump-motion-recursive* t))
       (prog1 (funcall fn)
-        (unless (point= p (current-point))
+        (unless (and (eq (point-buffer p)
+                         (current-buffer))
+                     (point= p (current-point)))
           (jumplist-history-push (window-jumplist) p))))))
 
 (defmacro with-jump-motion (&body body)

--- a/extensions/vi-mode/jumplist.lisp
+++ b/extensions/vi-mode/jumplist.lisp
@@ -1,6 +1,11 @@
 (defpackage :lem-vi-mode/jumplist
   (:use :cl
         :lem)
+  (:import-from :lem-base
+                :alive-point-p)
+  (:import-from :alexandria
+                :when-let
+                :ignore-some-conditions)
   (:export :with-jump-motion
            :jump-back
            :jump-next
@@ -48,12 +53,25 @@
             :jumplist jumplist
             :index index))))
 
+(defun jumplist-find-backward (jumplist from-index)
+  (loop for i from from-index below *max-jumplist-size*
+        for point = (jumplist-ref jumplist i)
+        until (or (null point)
+                  (alive-point-p point))
+        finally (return (values point i))))
+
+(defun jumplist-find-forward (jumplist from-index)
+  (loop for i downfrom from-index
+        for point = (jumplist-ref jumplist i)
+        until (or (null point)
+                  (alive-point-p point))
+        finally (return (values point i))))
+
 (defun delete-exceeded-elements (list count)
-  (let ((last-cdr (nthcdr (- count 1) list)))
-    (when last-cdr
-      (mapc #'delete-point (cdr last-cdr))
-      (setf (cdr last-cdr) nil))
-    list))
+  (when-let ((last-cdr (nthcdr (- count 1) list)))
+    (mapc #'delete-point (cdr last-cdr))
+    (setf (cdr last-cdr) nil))
+  list)
 
 (defun jumplist-history-push (jumplist point)
   (with-slots (history index current) jumplist
@@ -88,19 +106,23 @@
   (with-slots (index current) jumplist
     (when (zerop index)
       (setf current (copy-point (current-point) :left-inserting)))
-    (handler-case
-        (prog1 (jumplist-ref jumplist (1+ index))
-          (incf index))
-      (jumplist-invalid-index () nil))))
+    (ignore-some-conditions (jumplist-invalid-index)
+      (multiple-value-bind (point new-index)
+          (jumplist-find-backward jumplist (1+ index))
+        (setf index new-index)
+        point))))
 
 (defun jumplist-history-next (jumplist)
   (with-slots (index current) jumplist
     (when (<= 0 (1- index))
-      (decf index)
-      (prog1 (jumplist-ref jumplist index)
-        (when (zerop index)
-          (delete-point current)
-          (setf current nil))))))
+      (ignore-some-conditions (jumplist-invalid-index)
+        (multiple-value-bind (point new-index)
+            (jumplist-find-forward jumplist (1- index))
+          (setf index new-index)
+          (when (zerop index)
+            (delete-point current)
+            (setf current nil))
+          point)))))
 
 (defun window-jumplist (&optional (window (current-window)))
   (or (window-parameter window :vi-mode-jumplist)
@@ -113,24 +135,29 @@
                (enough-namestring (buffer-filename buffer))
                (buffer-name buffer))))
     (with-slots (index current) jumplist
-      (loop with results = (list (list (= 0 index)
-                                       (abs (- 0 index))
-                                       (and current
-                                            (line-number-at-point current))
-                                       (and current
-                                            (point-column current))
-                                       (and current
-                                            (buffer-identifier (point-buffer current)))))
+      (loop with results = (list (if (and current
+                                          (alive-point-p current))
+                                     (list (= 0 index)
+                                           (abs (- 0 index))
+                                           (line-number-at-point current)
+                                           (point-column current)
+                                           (buffer-identifier (point-buffer current)))
+                                     (list (= 0 index)
+                                           (abs (- 0 index))
+                                           nil nil nil)))
+            with dead-count = 0
             for point in (jumplist-history jumplist)
             for i from 1
+            if (alive-point-p point)
             ;; current-p index line column file/buffer-name
             do (push (list
-                      (= i index)
-                      (abs (- i index))
+                      (= (- i dead-count) index)
+                      (abs (- (- i dead-count) index))
                       (line-number-at-point point)
                       (point-column point)
                       (buffer-identifier (point-buffer point)))
                      results)
+            else do (incf dead-count)
             finally (return results)))))
 
 (defun print-jumplist (jumplist &optional (stream *standard-output*))
@@ -161,14 +188,12 @@
         (lambda () ,@body))))
 
 (defun jump-back ()
-  (let ((point (jumplist-history-back (window-jumplist))))
-    (when point
-      (switch-to-buffer (point-buffer point))
-      (move-point (current-point) point)
-      point)))
+  (when-let ((point (jumplist-history-back (window-jumplist))))
+    (switch-to-buffer (point-buffer point))
+    (move-point (current-point) point)
+    point))
 
 (defun jump-next ()
-  (let ((point (jumplist-history-next (window-jumplist))))
-    (when point
-      (switch-to-buffer (point-buffer point))
-      (move-point (current-point) point))))
+  (when-let ((point (jumplist-history-next (window-jumplist))))
+    (switch-to-buffer (point-buffer point))
+    (move-point (current-point) point)))

--- a/extensions/vi-mode/jumplist.lisp
+++ b/extensions/vi-mode/jumplist.lisp
@@ -1,11 +1,11 @@
-(defpackage :lem-vi-mode/jump-motions
+(defpackage :lem-vi-mode/jumplist
   (:use :cl
         :lem)
   (:export :with-jump-motion
            :jump-back
            :jump-next
            :window-jumplist))
-(in-package :lem-vi-mode/jump-motions)
+(in-package :lem-vi-mode/jumplist)
 
 (defvar *max-jumplist-size* 100)
 

--- a/extensions/vi-mode/jumplist.lisp
+++ b/extensions/vi-mode/jumplist.lisp
@@ -136,8 +136,12 @@
 
 (defun window-jumplist (window)
   (or (window-parameter window :vi-mode-jumplist)
-      (setf (window-parameter window :vi-mode-jumplist)
-            (make-jumplist))))
+      (let ((jumplist (make-jumplist)))
+        (setf (window-parameter window :vi-mode-jumplist)
+              jumplist)
+        (push (lambda () (delete-jumplist jumplist))
+              (window-delete-hook window))
+        jumplist)))
 
 (defun (setf window-jumplist) (jumplist window)
   (check-type jumplist jumplist)

--- a/extensions/vi-mode/jumplist.lisp
+++ b/extensions/vi-mode/jumplist.lisp
@@ -7,6 +7,7 @@
                 :when-let
                 :ignore-some-conditions)
   (:export :with-jump-motion
+           :without-jump-motion
            :jump-back
            :jump-next
            :window-jumplist))
@@ -171,10 +172,11 @@
                 (and line column
                      (format nil "(~A, ~A)  ~A" line column file)))))))
 
-(defvar *jump-motion-recursive* nil)
+(defvar *disable-jumplist* nil)
+
 (defun call-with-jump-motion (fn)
   (with-point ((p (current-point)))
-    (let ((*jump-motion-recursive* t))
+    (let ((*disable-jumplist* t))
       (prog1 (funcall fn)
         (unless (and (eq (point-buffer p)
                          (current-buffer))
@@ -182,10 +184,14 @@
           (jumplist-history-push (window-jumplist) p))))))
 
 (defmacro with-jump-motion (&body body)
-  `(if *jump-motion-recursive*
+  `(if *disable-jumplist*
        (progn ,@body)
        (call-with-jump-motion
         (lambda () ,@body))))
+
+(defmacro without-jump-motion (&body body)
+  `(let ((*disable-jumplist* t))
+     ,@body))
 
 (defun jump-back ()
   (when-let ((point (jumplist-history-back (window-jumplist))))

--- a/extensions/vi-mode/jumplist.lisp
+++ b/extensions/vi-mode/jumplist.lisp
@@ -203,7 +203,8 @@
       (prog1 (funcall fn)
         (unless (and (eq (point-buffer p)
                          (current-buffer))
-                     (point= p (current-point)))
+                     (= (line-number-at-point p)
+                        (line-number-at-point (current-point))))
           (jumplist-history-push (current-jumplist) p))))))
 
 (defmacro with-jumplist (&body body)

--- a/extensions/vi-mode/jumplist.lisp
+++ b/extensions/vi-mode/jumplist.lisp
@@ -70,10 +70,13 @@
     (setf history
           (cons (copy-point point :left-inserting)
                 ;; Remove points at the same line in the history
-                (remove (line-number-at-point point)
+                (remove point
                         history
-                        :test (lambda (linum point)
-                                (when (= linum (line-number-at-point point))
+                        :test (lambda (new-point point)
+                                (when (and (eq (point-buffer new-point)
+                                               (point-buffer point))
+                                           (= (line-number-at-point new-point)
+                                              (line-number-at-point point)))
                                   (delete-point point)
                                   t))
                         :count 1)))

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -18,12 +18,12 @@
                (:file "visual" :depends-on ("core" "states"))
                (:file "text-objects" :depends-on ("core" "visual" "word"))
                (:file "registers" :depends-on ("core"))
-               (:file "jump-motions")
+               (:file "jumplist")
                (:module "commands-utils"
                 :pathname "commands"
-                :depends-on ("core" "jump-motions" "visual" "states")
+                :depends-on ("core" "jumplist" "visual" "states")
                 :components ((:file "utils")))
-               (:file "commands" :depends-on ("core" "commands-utils" "word" "visual" "jump-motions" "states" "registers" "window"))
+               (:file "commands" :depends-on ("core" "commands-utils" "word" "visual" "jumplist" "states" "registers" "window"))
                (:file "ex-core" :depends-on ("visual"))
                (:file "ex-parser" :depends-on ("ex-core"))
                (:file "ex-command" :depends-on ("ex-core" "options" "utils"))

--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -56,6 +56,7 @@
      (:file "text-objects")
      (:file "registers")
      (:file "kbdmacro")
+     (:file "jumplist")
      (:file "options")))
    (:file "utils"
     :pathname "tests/utils"))

--- a/extensions/vi-mode/tests/jumplist.lisp
+++ b/extensions/vi-mode/tests/jumplist.lisp
@@ -4,7 +4,7 @@
         :rove
         :lem-vi-mode/tests/utils)
   (:import-from :lem-vi-mode/jumplist
-                :window-jumplist
+                :current-jumplist
                 :jumplist-history-back
                 :jumplist-history-next
                 :jumplist-history-push
@@ -21,7 +21,7 @@
 (deftest jumplist-go-back-and-forth
   (with-fake-interface ()
     (with-vi-buffer (#?"[a]bc\ndef\nghi\njkl\n")
-      (let ((jumplist (window-jumplist)))
+      (let ((jumplist (current-jumplist)))
         (ok (not (signals (jumplist-history-next jumplist))))
         (jumplist-history-push jumplist (copy-point (current-point)))
         (cmd "j")
@@ -89,7 +89,7 @@
 (deftest jumplist-delete-newer-history
   (with-fake-interface ()
     (with-vi-buffer (#?"[a]bc\ndef\nghi\njkl\nmno\n")
-      (let ((jumplist (window-jumplist)))
+      (let ((jumplist (current-jumplist)))
         (jumplist-history-push jumplist (copy-point (current-point)))
         (cmd "j")
         (jumplist-history-push jumplist (copy-point (current-point)))
@@ -115,7 +115,7 @@
 (deftest jumplist-remove-same-line-points
   (with-fake-interface ()
     (with-vi-buffer (#?"[a]bc\ndef\nghi\njkl\nmno\n")
-      (let ((jumplist (window-jumplist)))
+      (let ((jumplist (current-jumplist)))
         (jumplist-history-push jumplist (copy-point (current-point)))
         (cmd "j")
         (jumplist-history-push jumplist (copy-point (current-point)))
@@ -131,7 +131,7 @@
   (with-fake-interface ()
     (let ((*max-jumplist-size* 3))
       (with-vi-buffer (#?"[a]bc\ndef\nghi\njkl\n")
-        (let ((jumplist (window-jumplist)))
+        (let ((jumplist (current-jumplist)))
           (jumplist-history-push jumplist (copy-point (current-point)))
           (cmd "j")
           (jumplist-history-push jumplist (copy-point (current-point)))

--- a/extensions/vi-mode/tests/jumplist.lisp
+++ b/extensions/vi-mode/tests/jumplist.lisp
@@ -1,0 +1,149 @@
+(defpackage :lem-vi-mode/tests/jumplist
+  (:use :cl
+        :lem
+        :rove
+        :lem-vi-mode/tests/utils)
+  (:import-from :lem-vi-mode/jumplist
+                :window-jumplist
+                :jumplist-history-back
+                :jumplist-history-next
+                :jumplist-history-push
+                :print-jumplist
+                :*max-jumplist-size*)
+  (:import-from :lem-fake-interface
+                :with-fake-interface)
+  (:import-from :named-readtables
+                :in-readtable))
+(in-package :lem-vi-mode/tests/jumplist)
+
+(in-readtable :interpol-syntax)
+
+(deftest jumplist-go-back-and-forth
+  (with-fake-interface ()
+    (with-vi-buffer (#?"[a]bc\ndef\nghi\njkl\n")
+      (let ((jumplist (window-jumplist)))
+        (ok (not (signals (jumplist-history-next jumplist))))
+        (jumplist-history-push jumplist (copy-point (current-point)))
+        (cmd "j")
+        (jumplist-history-push jumplist (copy-point (current-point)))
+        (cmd "j")
+        (jumplist-history-push jumplist (copy-point (current-point)))
+        (cmd "j")
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  3: (1, 0)  NIL"
+                          "  2: (2, 0)  NIL"
+                          "  1: (3, 0)  NIL"
+                          "> 0: NIL")))
+        (jumplist-history-back jumplist)
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  2: (1, 0)  NIL"
+                          "  1: (2, 0)  NIL"
+                          "> 0: (3, 0)  NIL"
+                          "  1: (4, 0)  NIL")))
+        (jumplist-history-back jumplist)
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  1: (1, 0)  NIL"
+                          "> 0: (2, 0)  NIL"
+                          "  1: (3, 0)  NIL"
+                          "  2: (4, 0)  NIL")))
+        (jumplist-history-back jumplist)
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "> 0: (1, 0)  NIL"
+                          "  1: (2, 0)  NIL"
+                          "  2: (3, 0)  NIL"
+                          "  3: (4, 0)  NIL")))
+        (ok (not (signals (jumplist-history-back jumplist))))
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "> 0: (1, 0)  NIL"
+                          "  1: (2, 0)  NIL"
+                          "  2: (3, 0)  NIL"
+                          "  3: (4, 0)  NIL")))
+        (jumplist-history-next jumplist)
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  1: (1, 0)  NIL"
+                          "> 0: (2, 0)  NIL"
+                          "  1: (3, 0)  NIL"
+                          "  2: (4, 0)  NIL")))
+        (jumplist-history-next jumplist)
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  2: (1, 0)  NIL"
+                          "  1: (2, 0)  NIL"
+                          "> 0: (3, 0)  NIL"
+                          "  1: (4, 0)  NIL")))
+        (jumplist-history-next jumplist)
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  3: (1, 0)  NIL"
+                          "  2: (2, 0)  NIL"
+                          "  1: (3, 0)  NIL"
+                          "> 0: NIL")))
+        (ok (not (signals (jumplist-history-next jumplist))))))))
+
+(deftest jumplist-delete-newer-history
+  (with-fake-interface ()
+    (with-vi-buffer (#?"[a]bc\ndef\nghi\njkl\nmno\n")
+      (let ((jumplist (window-jumplist)))
+        (jumplist-history-push jumplist (copy-point (current-point)))
+        (cmd "j")
+        (jumplist-history-push jumplist (copy-point (current-point)))
+        (cmd "j")
+        (jumplist-history-push jumplist (copy-point (current-point)))
+        (cmd "j")
+        (jumplist-history-back jumplist)
+        (jumplist-history-back jumplist)
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  1: (1, 0)  NIL"
+                          "> 0: (2, 0)  NIL"
+                          "  1: (3, 0)  NIL"
+                          "  2: (4, 0)  NIL")))
+        (jumplist-history-push jumplist (copy-point (buffer-end-point (current-buffer))))
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  3: (1, 0)  NIL"
+                          "  2: (2, 0)  NIL"
+                          "  1: (6, 0)  NIL"
+                          "> 0: NIL")))))))
+
+(deftest jumplist-remove-same-line-points
+  (with-fake-interface ()
+    (with-vi-buffer (#?"[a]bc\ndef\nghi\njkl\nmno\n")
+      (let ((jumplist (window-jumplist)))
+        (jumplist-history-push jumplist (copy-point (current-point)))
+        (cmd "j")
+        (jumplist-history-push jumplist (copy-point (current-point)))
+        (cmd "kl")
+        (jumplist-history-push jumplist (copy-point (current-point)))
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  2: (2, 0)  NIL"
+                          "  1: (1, 1)  NIL"
+                          "> 0: NIL")))))))
+
+(deftest jumplist-max-size
+  (with-fake-interface ()
+    (let ((*max-jumplist-size* 3))
+      (with-vi-buffer (#?"[a]bc\ndef\nghi\njkl\n")
+        (let ((jumplist (window-jumplist)))
+          (jumplist-history-push jumplist (copy-point (current-point)))
+          (cmd "j")
+          (jumplist-history-push jumplist (copy-point (current-point)))
+          (ok (equal (with-output-to-string (s)
+                       (print-jumplist jumplist s))
+                     (lines "  2: (1, 0)  NIL"
+                            "  1: (2, 0)  NIL"
+                            "> 0: NIL")))
+          (cmd "j")
+          (jumplist-history-push jumplist (copy-point (current-point)))
+          (ok (equal (with-output-to-string (s)
+                       (print-jumplist jumplist s))
+                     (lines "  2: (2, 0)  NIL"
+                            "  1: (3, 0)  NIL"
+                            "> 0: NIL"))))))))

--- a/extensions/vi-mode/tests/utils.lisp
+++ b/extensions/vi-mode/tests/utils.lisp
@@ -39,7 +39,8 @@
            :text=
            :state=
            :visual=
-           :buf=))
+           :buf=
+           :lines))
 (in-package :lem-vi-mode/tests/utils)
 
 (defun state-to-keyword (state)
@@ -394,3 +395,6 @@
           negative
           (first values)
           (ignore-errors (state-to-keyword (current-state)))))
+
+(defun lines (&rest lines)
+  (format nil "~{~A~%~}" lines))


### PR DESCRIPTION
* Make jumplist window-local
* Keep only 100 points in a single jumplist
* Remove points on the same line when pushing a new point in a jumplist history
* Remove newer history when pushing a new point after going back the history
* Don't save on the same line motion
* Don't save on operator execution (like `dG`, `d%`)
* Save the current point on `:e` and `:b`
* Copy a current jumplist when splitting the current window