### PR TITLE
Fix vi-mode's keyboard macro in case that the recording is accidentally stopped

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -541,13 +541,14 @@
       (t
        (lem-core:key-to-char key)))))
 
-(define-command vi-record-macro (register) ((or *kbdmacro-recording-register*
+(define-command vi-record-macro (register) ((if (key-recording-p)
+                                                *kbdmacro-recording-register*
                                                 (read-register)))
   (cond
     ((macro-register-p register)
      (cond
        ;; When recording
-       (*kbdmacro-recording-register*
+       ((key-recording-p)
         ;; Finish recording
         (lem/kbdmacro:kbdmacro-end)
         (setf (register register)


### PR DESCRIPTION
Lem's keyboard macro stops when an error occurs (such as command-not-found) while recording.

https://github.com/lem-project/lem/blob/68823d61b7783ebb01a21a20b24c1691911d862f/src/interp.lisp#L87

Ignoring it should be fine for vi-mode, but for now, fix it to work even in the case.