### PR TITLE
Allow to install Lem via Roswell.

### DIFF
--- a/lem.asd
+++ b/lem.asd
@@ -1,13 +1,12 @@
 #+ros.installing
-(progn
-  (unless (uiop:directory-exists-p (asdf:system-relative-pathname :lem #P".qlot/"))
+(let ((project-dir (uiop:pathname-directory-pathname *load-truename*)))
+  (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
     (asdf:load-system :qlot)
-    (uiop:symbol-call :qlot :install
-                      (uiop:pathanme-directory-pathname *load-truename*)))
+    (uiop:symbol-call :qlot :install project-dir))
   #+quicklisp
   (setf ql:*quicklisp-home*
-          (asdf:system-relative-pathname :lem #P".qlot/"))
-  (load (asdf:system-relative-pathname :lem #P".qlot/setup.lisp")))
+        (merge-pathnames #P".qlot/" project-dir))
+  (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
 
 (defsystem "lem"
   :version "2.1.0"

--- a/lem.asd
+++ b/lem.asd
@@ -3,10 +3,9 @@
   (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
     (asdf:load-system :qlot)
     (uiop:symbol-call :qlot :install project-dir))
-  #+quicklisp
-  (setf ql:*quicklisp-home*
-        (merge-pathnames #P".qlot/" project-dir))
-  (let ((local-project-dir roswell:*local-project-directories*))
+  (let (#+quicklisp
+        (ql:*quicklisp-home* (merge-pathnames #P".qlot/" project-dir))
+        (local-project-dir roswell:*local-project-directories*))
     (load (merge-pathnames #P".qlot/setup.lisp" project-dir))
     ;; XXX: Not to modify the local project directories to install ros scripts in ~/.roswell/bin
     ;;   ref. https://github.com/roswell/roswell/blob/5b267381a66d36a514e2eee7283543f828541a63/lisp/util-install-quicklisp.lisp#L146

--- a/lem.asd
+++ b/lem.asd
@@ -1,14 +1,16 @@
 #+ros.installing
-(let ((project-dir (uiop:pathname-directory-pathname *load-truename*)))
-  (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
-    (asdf:load-system :qlot)
-    (uiop:symbol-call :qlot :install project-dir))
+(let ((*default-pathname-defaults* (uiop:pathname-directory-pathname *load-truename*)))
+  (uiop:chdir *default-pathname-defaults*)
+  (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/"))
+    (setf (uiop:getenv "SBCL_HOME") "")
+    (uiop:run-program '("qlot" "install" "--no-deps")
+                      :output t
+                      :error-output t))
   #+quicklisp
-  (setf ql:*quicklisp-home*
-        (merge-pathnames #P".qlot/" project-dir))
-  (let ((local-project-dir (or #+quicklisp (copy-list ql:*local-project-directories*)
-                               roswell:*local-project-directories*)))
-    (load (merge-pathnames #P".qlot/setup.lisp" project-dir))
+  (setf ql:*quicklisp-home* (merge-pathnames #P".qlot/"))
+  (let ((local-project-dir (or roswell:*local-project-directories*
+                               #+quicklisp (copy-list ql:*local-project-directories*))))
+    (load (merge-pathnames #P".qlot/setup.lisp"))
     ;; XXX: Not to modify the local project directories to install ros scripts in ~/.roswell/bin
     ;;   ref. https://github.com/roswell/roswell/blob/5b267381a66d36a514e2eee7283543f828541a63/lisp/util-install-quicklisp.lisp#L146
     (set (intern (string :*local-project-directories*) :ql) local-project-dir)))

--- a/lem.asd
+++ b/lem.asd
@@ -3,9 +3,10 @@
   (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
     (asdf:load-system :qlot)
     (uiop:symbol-call :qlot :install project-dir))
-  (let (#+quicklisp
-        (ql:*quicklisp-home* (merge-pathnames #P".qlot/" project-dir))
-        (local-project-dir roswell:*local-project-directories*))
+  #+quicklisp
+  (setf ql:*quicklisp-home*
+        (merge-pathnames #P".qlot/" project-dir))
+  (let ((local-project-dir roswell:*local-project-directories*))
     (load (merge-pathnames #P".qlot/setup.lisp" project-dir))
     ;; XXX: Not to modify the local project directories to install ros scripts in ~/.roswell/bin
     ;;   ref. https://github.com/roswell/roswell/blob/5b267381a66d36a514e2eee7283543f828541a63/lisp/util-install-quicklisp.lisp#L146

--- a/lem.asd
+++ b/lem.asd
@@ -6,11 +6,12 @@
   #+quicklisp
   (setf ql:*quicklisp-home*
         (merge-pathnames #P".qlot/" project-dir))
-  (let ((local-project-dir roswell:*local-project-directories*))
+  (let ((local-project-dir (or #+quicklisp (copy-list ql:*local-project-directories*)
+                               roswell:*local-project-directories*)))
     (load (merge-pathnames #P".qlot/setup.lisp" project-dir))
     ;; XXX: Not to modify the local project directories to install ros scripts in ~/.roswell/bin
     ;;   ref. https://github.com/roswell/roswell/blob/5b267381a66d36a514e2eee7283543f828541a63/lisp/util-install-quicklisp.lisp#L146
-    (setf roswell:*local-project-directories* local-project-dir)))
+    (set (intern (string :*local-project-directories*) :ql) local-project-dir)))
 
 (defsystem "lem"
   :version "2.1.0"

--- a/lem.asd
+++ b/lem.asd
@@ -1,3 +1,14 @@
+#+ros.installing
+(progn
+  (unless (uiop:directory-exists-p (asdf:system-relative-pathname :lem #P".qlot/"))
+    (asdf:load-system :qlot)
+    (uiop:symbol-call :qlot :install
+                      (uiop:pathanme-directory-pathname *load-truename*)))
+  #+quicklisp
+  (setf ql:*quicklisp-home*
+          (asdf:system-relative-pathname :lem #P".qlot/"))
+  (load (asdf:system-relative-pathname :lem #P".qlot/setup.lisp")))
+
 (defsystem "lem"
   :version "2.1.0"
   :depends-on ("alexandria"

--- a/lem.asd
+++ b/lem.asd
@@ -6,7 +6,11 @@
   #+quicklisp
   (setf ql:*quicklisp-home*
         (merge-pathnames #P".qlot/" project-dir))
-  (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
+  (let ((local-project-dir roswell:*local-project-directories*))
+    (load (merge-pathnames #P".qlot/setup.lisp" project-dir))
+    ;; XXX: Not to modify the local project directories to install ros scripts in ~/.roswell/bin
+    ;;   ref. https://github.com/roswell/roswell/blob/5b267381a66d36a514e2eee7283543f828541a63/lisp/util-install-quicklisp.lisp#L146
+    (setf roswell:*local-project-directories* local-project-dir)))
 
 (defsystem "lem"
   :version "2.1.0"

--- a/roswell/lem-language-server.ros
+++ b/roswell/lem-language-server.ros
@@ -5,14 +5,16 @@ exec ros +Q -- $0 "$@"
 |#
 (progn ;;init forms
   (ros:ensure-asdf)
-  (let ((project-dir (asdf:system-source-directory :lem)))
-    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
-      (asdf:load-system :qlot)
-      (uiop:symbol-call :qlot :install project-dir))
+  (let ((*default-pathname-defaults* (asdf:system-source-directory :lem)))
+    (uiop:chdir *default-pathname-defaults*)
+    (setf (uiop:getenv "SBCL_HOME") "")
+    (uiop:run-program '("qlot" "install" "--no-deps")
+                      :output t
+                      :error-output t)
     #+quicklisp
     (setf ql:*quicklisp-home*
-          (merge-pathnames #P".qlot/" project-dir))
-    (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
+          (merge-pathnames #P".qlot/"))
+    (load (merge-pathnames #P".qlot/setup.lisp")))
   (uiop:symbol-call :ql :quickload '(:lem-language-server/cli) :silent t))
 
 (defpackage :ros.script.lem-language-server.3881471585

--- a/roswell/lem-language-server.ros
+++ b/roswell/lem-language-server.ros
@@ -1,11 +1,19 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
 #|
-exec ros -Q -- $0 "$@"
+exec ros +Q -- $0 "$@"
 |#
 (progn ;;init forms
   (ros:ensure-asdf)
-  #+quicklisp(ql:quickload '(:lem-language-server/cli) :silent t))
+  (let ((project-dir (asdf:system-source-directory :lem)))
+    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
+      (asdf:load-system :qlot)
+      (uiop:symbol-call :qlot :install project-dir))
+    #+quicklisp
+    (setf ql:*quicklisp-home*
+          (merge-pathnames #P".qlot/" project-dir))
+    (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
+  (uiop:symbol-call :ql :quickload '(:lem-language-server/cli) :silent t))
 
 (defpackage :ros.script.lem-language-server.3881471585
   (:use :cl))

--- a/roswell/lem-ncurses-ccl.ros
+++ b/roswell/lem-ncurses-ccl.ros
@@ -1,10 +1,19 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
-#| lem simple emacs clone 
-exec ros -Q -L ccl-bin -- $0 "$@"
+#| lem simple emacs clone
+exec ros +Q -L ccl-bin -- $0 "$@"
 |#
 (progn
-  (ql:quickload :lem-ncurses :silent t)
+  (ros:ensure-asdf)
+  (let ((project-dir (asdf:system-source-directory :lem)))
+    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
+      (asdf:load-system :qlot)
+      (uiop:symbol-call :qlot :install project-dir))
+    #+quicklisp
+    (setf ql:*quicklisp-home*
+          (merge-pathnames #P".qlot/" project-dir))
+    (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
+  (uiop:symbol-call :ql :quickload :lem-ncurses :silent t)
   (uiop:symbol-call :lem-core :load-site-init))
 
 (defpackage :ros.script.lem-ncurses-ccl.3724915314

--- a/roswell/lem-ncurses-ccl.ros
+++ b/roswell/lem-ncurses-ccl.ros
@@ -5,14 +5,16 @@ exec ros +Q -L ccl-bin -- $0 "$@"
 |#
 (progn
   (ros:ensure-asdf)
-  (let ((project-dir (asdf:system-source-directory :lem)))
-    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
-      (asdf:load-system :qlot)
-      (uiop:symbol-call :qlot :install project-dir))
+  (let ((*default-pathname-defaults* (asdf:system-source-directory :lem)))
+    (uiop:chdir *default-pathname-defaults*)
+    (setf (uiop:getenv "SBCL_HOME") "")
+    (uiop:run-program '("qlot" "install" "--no-deps")
+                      :output t
+                      :error-output t)
     #+quicklisp
     (setf ql:*quicklisp-home*
-          (merge-pathnames #P".qlot/" project-dir))
-    (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
+          (merge-pathnames #P".qlot/"))
+    (load (merge-pathnames #P".qlot/setup.lisp")))
   (uiop:symbol-call :ql :quickload :lem-ncurses :silent t)
   (uiop:symbol-call :lem-core :load-site-init))
 

--- a/roswell/lem-ncurses.ros
+++ b/roswell/lem-ncurses.ros
@@ -5,16 +5,18 @@ exec ros +Q -m lem-ncurses -L sbcl-bin -- $0 "$@"
 |#
 (progn
   (ros:ensure-asdf)
-  (let ((project-dir (asdf:system-source-directory :lem)))
-    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
-      (asdf:load-system :qlot)
-      (uiop:symbol-call :qlot :install project-dir))
+  (let ((*default-pathname-defaults* (asdf:system-source-directory :lem)))
+    (uiop:chdir *default-pathname-defaults*)
+    (setf (uiop:getenv "SBCL_HOME") "")
+    (uiop:run-program '("qlot" "install" "--no-deps")
+                      :output t
+                      :error-output t)
     #+quicklisp
     (setf ql:*quicklisp-home*
-          (merge-pathnames #P".qlot/" project-dir))
-    (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
+          (merge-pathnames #P".qlot/"))
+    (load (merge-pathnames #P".qlot/setup.lisp")))
   (unless (find-package :lem)
-    (ql:quickload :lem-ncurses :silent t)
+    (uiop:symbol-call :ql :quickload :lem-ncurses :silent t)
     (uiop:symbol-call :lem-core :load-site-init))
   (when (find :roswell.dump.executable *features*)
     (mapc (lambda (x)

--- a/roswell/lem-ncurses.ros
+++ b/roswell/lem-ncurses.ros
@@ -1,9 +1,18 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
 #| lem simple emacs clone.
-exec ros -Q -m lem-ncurses -L sbcl-bin -- $0 "$@"
+exec ros +Q -m lem-ncurses -L sbcl-bin -- $0 "$@"
 |#
 (progn
+  (ros:ensure-asdf)
+  (let ((project-dir (asdf:system-source-directory :lem)))
+    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
+      (asdf:load-system :qlot)
+      (uiop:symbol-call :qlot :install project-dir))
+    #+quicklisp
+    (setf ql:*quicklisp-home*
+          (merge-pathnames #P".qlot/" project-dir))
+    (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
   (unless (find-package :lem)
     (ql:quickload :lem-ncurses :silent t)
     (uiop:symbol-call :lem-core :load-site-init))

--- a/roswell/lem-rpc.ros
+++ b/roswell/lem-rpc.ros
@@ -5,14 +5,16 @@ exec ros +Q -m lem-rpc -L sbcl-bin -- $0 "$@"
 |#
 (progn ;;init forms
   (ros:ensure-asdf)
-  (let ((project-dir (asdf:system-source-directory :lem)))
-    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
-      (asdf:load-system :qlot)
-      (uiop:symbol-call :qlot :install project-dir))
+  (let ((*default-pathname-defaults* (asdf:system-source-directory :lem)))
+    (uiop:chdir *default-pathname-defaults*)
+    (setf (uiop:getenv "SBCL_HOME") "")
+    (uiop:run-program '("qlot" "install" "--no-deps")
+                      :output t
+                      :error-output t)
     #+quicklisp
     (setf ql:*quicklisp-home*
-          (merge-pathnames #P".qlot/" project-dir))
-    (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
+          (merge-pathnames #P".qlot/"))
+    (load (merge-pathnames #P".qlot/setup.lisp")))
   (uiop:symbol-call :ql :quickload '(:lem-jsonrpc :lem-electron-backend :command-line-arguments) :silent t)
   (uiop:symbol-call :lem-core :load-site-init))
 

--- a/roswell/lem-rpc.ros
+++ b/roswell/lem-rpc.ros
@@ -1,11 +1,19 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
 #|
-exec ros -Q -m lem-rpc -L sbcl-bin -- $0 "$@"
+exec ros +Q -m lem-rpc -L sbcl-bin -- $0 "$@"
 |#
 (progn ;;init forms
   (ros:ensure-asdf)
-  (ql:quickload '(:lem-jsonrpc :lem-electron-backend :command-line-arguments) :silent t)
+  (let ((project-dir (asdf:system-source-directory :lem)))
+    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
+      (asdf:load-system :qlot)
+      (uiop:symbol-call :qlot :install project-dir))
+    #+quicklisp
+    (setf ql:*quicklisp-home*
+          (merge-pathnames #P".qlot/" project-dir))
+    (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
+  (uiop:symbol-call :ql :quickload '(:lem-jsonrpc :lem-electron-backend :command-line-arguments) :silent t)
   (uiop:symbol-call :lem-core :load-site-init))
 
 (defpackage :ros.script.lem-rpc.3715592460

--- a/roswell/lem-sdl2.ros
+++ b/roswell/lem-sdl2.ros
@@ -5,14 +5,16 @@ exec ros +Q -m lem-sdl2 -L sbcl-bin -- $0 "$@"
 |#
 (progn
   (ros:ensure-asdf)
-  (let ((project-dir (asdf:system-source-directory :lem)))
-    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
-      (asdf:load-system :qlot)
-      (uiop:symbol-call :qlot :install project-dir))
+  (let ((*default-pathname-defaults* (asdf:system-source-directory :lem)))
+    (uiop:chdir *default-pathname-defaults*)
+    (setf (uiop:getenv "SBCL_HOME") "")
+    (uiop:run-program '("qlot" "install" "--no-deps")
+                      :output t
+                      :error-output t)
     #+quicklisp
     (setf ql:*quicklisp-home*
-          (merge-pathnames #P".qlot/" project-dir))
-    (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
+          (merge-pathnames #P".qlot/"))
+    (load (merge-pathnames #P".qlot/setup.lisp")))
   (unless (find-package :lem)
     (uiop:symbol-call :ql :quickload :lem-sdl2 :silent t)
     (uiop:symbol-call :lem-core :load-site-init))

--- a/roswell/lem-sdl2.ros
+++ b/roswell/lem-sdl2.ros
@@ -1,11 +1,20 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
 #| lem launcher for SDL2 frontend
-exec ros -Q -m lem-sdl2 -L sbcl-bin -- $0 "$@"
+exec ros +Q -m lem-sdl2 -L sbcl-bin -- $0 "$@"
 |#
 (progn
+  (ros:ensure-asdf)
+  (let ((project-dir (asdf:system-source-directory :lem)))
+    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
+      (asdf:load-system :qlot)
+      (uiop:symbol-call :qlot :install project-dir))
+    #+quicklisp
+    (setf ql:*quicklisp-home*
+          (merge-pathnames #P".qlot/" project-dir))
+    (load (merge-pathnames #P".qlot/setup.lisp" project-dir)))
   (unless (find-package :lem)
-    (ql:quickload :lem-sdl2 :silent t)
+    (uiop:symbol-call :ql :quickload :lem-sdl2 :silent t)
     (uiop:symbol-call :lem-core :load-site-init))
   (when (find :roswell.dump.executable *features*)
     (mapc (lambda (x)

--- a/roswell/lem.ros
+++ b/roswell/lem.ros
@@ -5,8 +5,11 @@ exec ros -Q -- $0 "$@"
 |#
 (progn ;;init forms
   (ros:ensure-asdf)
-  #+quicklisp(ql:quickload '() :silent t)
-  )
+  #+quicklisp (ql:quickload '(:qlot) :silent t)
+  (uiop:symbol-call :qlot :install (ql:where-is-system :lem))
+  (setf ql:*quicklisp-home*
+        (asdf:system-relative-pathname :lem #P".qlot/"))
+  (load (asdf:system-relative-pathname :lem #P".qlot/setup.lisp")))
 
 (defpackage :ros.script.lem.3864804718
   (:use :cl))

--- a/roswell/lem.ros
+++ b/roswell/lem.ros
@@ -1,14 +1,13 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
 #|
-exec ros -Q -- $0 "$@"
+exec ros +Q -- $0 "$@"
 |#
 (progn ;;init forms
   (ros:ensure-asdf)
-  #+quicklisp (ql:quickload '() :silent t)
   (let ((project-dir (asdf:system-source-directory :lem)))
     (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
-      (ql:quickload :qlot)
+      (asdf:load-system :qlot)
       (uiop:symbol-call :qlot :install project-dir))
     #+quicklisp
     (setf ql:*quicklisp-home*

--- a/roswell/lem.ros
+++ b/roswell/lem.ros
@@ -6,7 +6,11 @@ exec ros -Q -- $0 "$@"
 (progn ;;init forms
   (ros:ensure-asdf)
   #+quicklisp (ql:quickload '(:qlot) :silent t)
-  (uiop:symbol-call :qlot :install (ql:where-is-system :lem))
+  (unless (uiop:directory-exists-p (asdf:system-relative-pathname :lem #P".qlot/"))
+    (asdf:load-system :qlot)
+    (uiop:symbol-call :qlot :install
+                      (ql:where-is-system :lem)))
+  #+quicklisp
   (setf ql:*quicklisp-home*
         (asdf:system-relative-pathname :lem #P".qlot/"))
   (load (asdf:system-relative-pathname :lem #P".qlot/setup.lisp")))

--- a/roswell/lem.ros
+++ b/roswell/lem.ros
@@ -1,18 +1,12 @@
 #!/bin/sh
 #|-*- mode:lisp -*-|#
 #|
-exec ros +Q -- $0 "$@"
+exec ros -Q -- $0 "$@"
 |#
 (progn ;;init forms
   (ros:ensure-asdf)
-  (let ((project-dir (asdf:system-source-directory :lem)))
-    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
-      (asdf:load-system :qlot)
-      (uiop:symbol-call :qlot :install project-dir))
-    #+quicklisp
-    (setf ql:*quicklisp-home*
-          (merge-pathnames #P".qlot/" project-dir))
-    (load (merge-pathnames #P".qlot/setup.lisp" project-dir))))
+  #+quicklisp(ql:quickload '() :silent t)
+  )
 
 (defpackage :ros.script.lem.3864804718
   (:use :cl))

--- a/roswell/lem.ros
+++ b/roswell/lem.ros
@@ -5,15 +5,15 @@ exec ros -Q -- $0 "$@"
 |#
 (progn ;;init forms
   (ros:ensure-asdf)
-  #+quicklisp (ql:quickload '(:qlot) :silent t)
-  (unless (uiop:directory-exists-p (asdf:system-relative-pathname :lem #P".qlot/"))
-    (asdf:load-system :qlot)
-    (uiop:symbol-call :qlot :install
-                      (ql:where-is-system :lem)))
-  #+quicklisp
-  (setf ql:*quicklisp-home*
-        (asdf:system-relative-pathname :lem #P".qlot/"))
-  (load (asdf:system-relative-pathname :lem #P".qlot/setup.lisp")))
+  #+quicklisp (ql:quickload '() :silent t)
+  (let ((project-dir (asdf:system-source-directory :lem)))
+    (unless (uiop:directory-exists-p (merge-pathnames #P".qlot/" project-dir))
+      (ql:quickload :qlot)
+      (uiop:symbol-call :qlot :install project-dir))
+    #+quicklisp
+    (setf ql:*quicklisp-home*
+          (merge-pathnames #P".qlot/" project-dir))
+    (load (merge-pathnames #P".qlot/setup.lisp" project-dir))))
 
 (defpackage :ros.script.lem.3864804718
   (:use :cl))


### PR DESCRIPTION
Lem cannot be installed via Roswell since it adopts Qlot to manage dependencies.

This PR allows Lem to be installed via Roswell again. It needs to run `qlot install` while running `ros install lem-project/lem`. This feature actually doesn't work in the current Roswell, so users must update it first.

### Requirement

* Roswell [v23.10.14.114](https://github.com/roswell/roswell/commit/0e7a2f1b6d9153f33edf1cc7b780825913a93618) or above.
* [Qlot](https://github.com/fukamachi/qlot)

### Installation

```
$ ros install lem-project/lem
```

No need to specify `follow-dependency=t` anymore.

### Workaround

```
$ git clone https://github.com/lem-project/lem
$ cd lem
$ qlot install
$ qlot exec ros -S . install lem
```