### PR TITLE
Reuse the main thread's ASDF source registry in the editor thread.

### DIFF
--- a/src/lem.lisp
+++ b/src/lem.lisp
@@ -198,6 +198,11 @@ Options:
 (defun run-editor-thread (initialize args finalize)
   (bt:make-thread
    (lambda ()
+     (asdf:initialize-source-registry
+      `(:source-registry
+        :inherit-configuration
+        (:also-exclude ".qlot")
+        (:tree ,(asdf:system-source-directory :lem))))
      (when initialize (funcall initialize))
      (unwind-protect
           (let (#+lispworks (lw:*default-character-element-type* 'character))


### PR DESCRIPTION
This allows to load Lem extensions in .lem/init.lisp even when Lem source isn't in an ASDF load path (such as `~/common-lisp`).