### PR TITLE
Fix for keystrokes when shift is pressed in linux

### DIFF
--- a/frontends/sdl2/keyboard.lisp
+++ b/frontends/sdl2/keyboard.lisp
@@ -82,13 +82,11 @@
   code
   modifier)
 
-(defun make-key-event (code modifier)
-  (%make-key-event :code code :modifier modifier))
-
 (defun keysym-to-key-event (keysym)
   (let ((code (sdl2:sym-value keysym))
         (modifier (get-modifier keysym)))
-    (make-key-event code modifier)))
+    (%make-key-event :code code
+                     :modifier modifier)))
 
 (defparameter *modifier-code-table*
   `((:shift ,sdl2-ffi:+kmod-lshift+ ,sdl2-ffi:+kmod-rshift+)
@@ -128,7 +126,8 @@
 
 ;; linux
 (defun modifier-is-accept-text-input-p (modifier)
-  (not (modifier-ctrl modifier)))
+  (and (not (modifier-ctrl modifier))
+       (modifier-meta modifier)))
 
 (defmethod handle-text-input ((platform lem-sdl2/platform:linux) text)
   (when (modifier-is-accept-text-input-p *modifier*)


### PR DESCRIPTION
In the linux version of sdl2 the textinput event receives the correct character when shift is pressed, but the keydown event receives the raw character with no shift taken into account.
However, while the alt is being pressed, the textinput event cannot be received, so it must be handled with the keydown event.