### PR TITLE
Restore back original thing-at-point functionality

### DIFF
--- a/src/ext/thingatp.lisp
+++ b/src/ext/thingatp.lisp
@@ -1,6 +1,38 @@
 (defpackage :lem/thingatp
-  (:use :cl :lem))
+  (:use :cl :lem)
+  (:export 
+   :urlp
+   :url
+   :pathp
+   :path))
 (in-package :lem/thingatp)
 
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  ;; URL
+  (defun urlp (thing)
+    (and
+     (stringp thing)
+     (numberp
+      (ppcre:scan 
+       "(https://www\\.|http://www\\.|https://|http://|file://)[a-zA-Z0-9]{2,}(\\.[a-zA-Z0-9]{2,})?(\\.[a-zA-Z0-9]{2,})?" thing))))
+
+  (deftype url ()
+    `(satisfies urlp))
+
+  ;; PATH
+  (defun pathp (thing)
+    (and (ppcre:scan "^(.*)\/([^\/]*)$" thing)
+	 (or (uiop:directory-exists-p thing) 
+	     (uiop:file-exists-p thing))))
+
+  (deftype path ()
+    `(satisfies pathp)))
+
 (define-command open-at-point () ()
-  (lem/link:link-open))
+  (let ((thing (symbol-string-at-point (lem:current-point))))
+    (typecase thing
+      (url (open-external-file thing))
+      (path
+       (lem:find-file (pathname thing)))
+      (t
+       (lem/language-mode:find-definitions)))))

--- a/src/ext/thingatp.lisp
+++ b/src/ext/thingatp.lisp
@@ -1,6 +1,6 @@
 (defpackage :lem/thingatp
   (:use :cl :lem)
-  (:export 
+  (:export
    :urlp
    :url
    :pathp
@@ -13,7 +13,7 @@
     (and
      (stringp thing)
      (numberp
-      (ppcre:scan 
+      (ppcre:scan
        "(https://www\\.|http://www\\.|https://|http://|file://)[a-zA-Z0-9]{2,}(\\.[a-zA-Z0-9]{2,})?(\\.[a-zA-Z0-9]{2,})?" thing))))
 
   (deftype url ()
@@ -22,7 +22,7 @@
   ;; PATH
   (defun pathp (thing)
     (and (ppcre:scan "^(.*)\/([^\/]*)$" thing)
-	 (or (uiop:directory-exists-p thing) 
+	 (or (uiop:directory-exists-p thing)
 	     (uiop:file-exists-p thing))))
 
   (deftype path ()

--- a/tests/thingatp.lisp
+++ b/tests/thingatp.lisp
@@ -1,0 +1,48 @@
+(defpackage :lem-tests/thingatp
+  (:use :cl :rove :lem/thingatp :lem))
+
+
+(in-package :lem-tests/thingatp)
+
+(deftest url-type
+  (let ((url-list-correct
+	  '("https://mypage.com/directory"
+	    "https://mypage.com/directory.txt"
+	    "https://mypage.com/directory.php"
+	    "https://mypage.com/my/dire/c/tory"
+	    "https://mypage.com/my/dire/c/tory.txt"
+
+	    "file://mypage/myfile.htm"
+	    ))
+	(url-list-wrong
+	  '("not an url"
+	    "3"
+	    "this is a number"
+	    "htttttttp hey"
+	    "http:_+____"
+	    "none")))
+    (loop :for correct :in url-list-correct
+	  :for wrong :in url-list-wrong
+	  :do (progn
+		(ok (typep correct 'url) )
+		(ok (not (typep wrong 'url)))))))
+
+(deftest path-type
+  (let ((url-list-correct
+	  '("/usr/bin/"
+	    "/boot/initrd.img"
+	    "/"
+	    "/usr"
+	    "/usr/sbin/mkfs"
+	    ))
+	(url-list-wrong
+	  '("not an url"
+	    "3"
+	    "___ 23 path_"
+	    "/ / / / / hey"
+	    "none")))
+    (loop :for correct :in url-list-correct
+	  :for wrong :in url-list-wrong
+	  :do (progn
+		(ok (typep correct 'path) )
+		(ok (not (typep wrong 'path)))))))


### PR DESCRIPTION
I was wrong, this is a different way of interacting with link, only taking into account the point context (way more simpler than links).

So the actual implementation doesn't work and break the functionality of it. 

With this PR we can restore it back keep both functionality (as original intended)