### PR TITLE
Add micros path to child process started by slime command

### DIFF
--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -1050,6 +1050,10 @@
       process)))
 
 (defun send-swank-create-server (process port)
+  (let ((file (asdf:system-source-file (asdf:find-system :micros))))
+    (lem-process:process-send-input
+     process
+     (format nil "(asdf:load-asd ~S)" file)))
   (lem-process:process-send-input
    process
    "(ql:quickload :micros)")


### PR DESCRIPTION
Fix for https://github.com/lem-project/lem/issues/1122

There are cases where micros cannot be seen from outside sbcl when using qlot, so the micros.asd is explicitly loaded at startup.