### PR TITLE
directory-mode: add C-x C-j to open this file's directory

### DIFF
--- a/src/ext/directory-mode.lisp
+++ b/src/ext/directory-mode.lisp
@@ -38,6 +38,8 @@
      :keymap *directory-mode-keymap*)
   (setf (variable-value 'highlight-line :buffer (current-buffer)) nil))
 
+(define-key *global-keymap* "C-x C-j" 'find-file-directory)
+
 (define-key *directory-mode-keymap* "q" 'quit-active-window)
 (define-key *directory-mode-keymap* "M-q" 'quit-active-window)
 (define-key *directory-mode-keymap* "g" 'directory-mode-update-buffer)
@@ -551,6 +553,18 @@
   (setf filename (uiop:ensure-directory-pathname filename))
   (ensure-directories-exist filename)
   (update-all))
+
+(define-command find-file-directory () ()
+  "Open this file's directory and place point on the filename."
+  (let ((fullpath (buffer-filename)))
+    (cond
+      ((null fullpath)
+       (message "No file at point"))
+      (t
+       (switch-to-buffer
+        (find-file-buffer (lem-core/commands/file::directory-for-file-or-lose (buffer-directory))))
+       (let ((filename (file-namestring fullpath)))
+         (search-filename-and-recenter (file-namestring filename)))))))
 
 (setf *find-directory-function* 'directory-buffer)
 


### PR DESCRIPTION
and put the cursor on the file name.

previous discussion: https://github.com/lem-project/lem/pull/868

I still find this feature useful, last time in July you seemed to find it useful too.

---

It doesn't work with an image buffer:

- buffer-filename is not set
- but if I set it (image-buffer.lisp, open-image-buffer), I have an encoding error coming from find-file-buffer.