### PR TITLE
load initialization build-init.lisp when creating executable

### DIFF
--- a/scripts/build-ncurses.lisp
+++ b/scripts/build-ncurses.lisp
@@ -1,2 +1,7 @@
 (ql:quickload :lem-ncurses)
-(asdf:make :lem/executable)
+
+(lem:init-at-build-time)
+
+(sb-ext:save-lisp-and-die "lem"
+                          :toplevel #'lem:lem
+                          :executable t)

--- a/scripts/build-sdl2.lisp
+++ b/scripts/build-sdl2.lisp
@@ -1,2 +1,7 @@
 (ql:quickload :lem-sdl2)
-(asdf:make :lem-sdl2/executable)
+
+(lem:init-at-build-time)
+
+(sb-ext:save-lisp-and-die "lem"
+                          :toplevel #'lem:lem
+                          :executable t)

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -479,6 +479,7 @@
    :*splash-function*
    :setup-first-frame
    :find-editor-thread
+   :init-at-build-time
    :lem
    :main)
   ;; command-advices.lisp


### PR DESCRIPTION
Load $HOME/.lem/build-init.lisp when creating executables with make.

asdf:initialize-source-registry is slow when starting lem (also load-site-init is slow)
Commenting out these two will reduce startup time from 1 second to less than 0.1 second

The reason we are using asdf:initialize-source-registry is that when we are managing lem using qlot, there are cases where the lem is not in the asdf load path.
In this case, the system in lem/contrib is not found when you try to quickload it.
https://github.com/lem-project/lem/pull/1123

As a solution, I prepared an initialization file to be loaded at build time.


