### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM docker.io/fukamachi/qlot
+
+COPY . .
+
+RUN apt-get update && apt-get install gcc libncurses-dev -y
+
+RUN qlot install
+
+RUN qlot exec sbcl --noinform --no-sysinit --no-userinit --load .qlot/setup.lisp --load scripts/build-ncurses.lisp
+
+ENTRYPOINT qlot exec sbcl --eval "(ql:quickload :lem-ncurses)" --eval "(lem:lem)" --quit


### PR DESCRIPTION
Hey, the [current image on dockerhub](https://hub.docker.com/r/40ants/lem) that is mentioned in the README is 4 years old. I made this little `Dockerfile` to avoid the hassle of setting up quicklisp, roswell, qlot, ncurses, etc. You can run the following to build and run it.
```sh
docker build -t lem .
docker run --rm -it -v .:/shared lem
```