### PR TITLE
Paredit insert vertical line

### DIFF
--- a/extensions/paredit-mode/lem-paredit-mode.asd
+++ b/extensions/paredit-mode/lem-paredit-mode.asd
@@ -1,3 +1,17 @@
 (defsystem "lem-paredit-mode"
   :depends-on ("lem")
-  :components ((:file "paredit-mode")))
+  :components ((:file "paredit-mode"))
+  :in-order-to ((test-op (test-op "lem-paredit-mode/tests"))))
+
+(defsystem "lem-paredit-mode/tests"
+  :depends-on ("lem"
+               "lem-lisp-mode"
+               "lem-lisp-syntax"
+               "lem-paredit-mode"
+               "rove"
+               "cl-ppcre")
+  :components
+  ((:module "tests"
+    :components
+    ((:file "main"))))
+  :perform (test-op (op c) (symbol-call :rove '#:run c)))

--- a/extensions/paredit-mode/tests/main.lisp
+++ b/extensions/paredit-mode/tests/main.lisp
@@ -1,0 +1,36 @@
+(defpackage :lem-paredit-mode/tests/main
+  (:use :cl :rove :lem :lem-paredit-mode)
+  (:import-from :lem-base
+                :with-current-buffers))
+(in-package :lem-paredit-mode/tests/main)
+
+(defun setup-testing-current-buffer (text)
+  (let ((buffer (make-buffer "*paredit test*" :syntax-table lem-lisp-syntax:*syntax-table*)))
+    (insert-string (buffer-point buffer) text)
+    (buffer-start (buffer-point buffer))
+    (setf (current-buffer) buffer)))
+
+(deftest paredit-insert-vertical-line
+  (testing "inside normal text"
+    (with-current-buffers ()
+      (setup-testing-current-buffer "asdf")
+      (paredit-insert-vertical-line)
+      (ok (equal "||asdf" (buffer-text (current-buffer))))
+      (paredit-backward-delete)
+      (ok (equal "asdf" (buffer-text (current-buffer))))))
+  (testing "inside comment"
+    (with-current-buffers ()
+      (setup-testing-current-buffer ";asdf")
+      (character-offset (current-point) 1)
+      (paredit-insert-vertical-line)
+      (ok (equal ";|asdf" (buffer-text (current-buffer))))
+      (paredit-backward-delete)
+      (ok (equal ";asdf" (buffer-text (current-buffer))))))
+  (testing "inside string"
+    (with-current-buffers ()
+      (setup-testing-current-buffer "\"asdf\"")
+      (character-offset (current-point) 1)
+      (paredit-insert-vertical-line)
+      (ok (equal "\"|asdf\"" (buffer-text (current-buffer))))
+      (paredit-backward-delete)
+      (ok (equal "\"asdf\"" (buffer-text (current-buffer)))))))

--- a/extensions/paredit-mode/tests/main.lisp
+++ b/extensions/paredit-mode/tests/main.lisp
@@ -34,3 +34,9 @@
       (ok (equal "\"|asdf\"" (buffer-text (current-buffer))))
       (paredit-backward-delete)
       (ok (equal "\"asdf\"" (buffer-text (current-buffer)))))))
+
+(deftest paredit-vertical-line-wrap
+  (with-current-buffers ()
+    (setup-testing-current-buffer "asdf")
+    (paredit-vertical-line-wrap)
+    (ok (equal "|asdf|" (buffer-text (current-buffer))))))


### PR DESCRIPTION
To work more conveniently with `||` embraced symbols (e.g. `|aSdF|`) implemented pair insertion, deletion and wrapping similar to `()` and `""`.
With corresponding tests.