### PR TITLE
Fix typo with-current-buffers in lem-base export

### DIFF
--- a/src/base/package.lisp
+++ b/src/base/package.lisp
@@ -124,7 +124,7 @@
   (:export
    :delete-buffer-using-manager
    :buffer-list-manager
-   :with-current-buffer)
+   :with-current-buffers)
   ;; buffers.lisp
   (:export
    :kill-buffer-hook


### PR DESCRIPTION
This must be a typo?