### PR TITLE
Export with-current-buffer and with-buffer-point, close #1152

### DIFF
--- a/src/base/buffer.lisp
+++ b/src/base/buffer.lisp
@@ -390,3 +390,7 @@ Options that can be specified by arguments are ignored if `temporary` is NIL and
 
 (defmacro with-buffer-point ((buffer point) &body body)
   `(call-with-buffer-point ,buffer ,point (lambda () ,@body)))
+
+(defmacro with-current-buffer (buffer-or-name &body body)
+  `(let ((*current-buffer* (get-buffer ,buffer-or-name)))
+     ,@body))

--- a/src/base/package.lisp
+++ b/src/base/package.lisp
@@ -113,7 +113,9 @@
    :buffer-disable-undo-boundary
    :buffer-value
    :buffer-unbound
-   :clear-buffer-variables)
+   :clear-buffer-variables
+   :with-buffer-point
+   :with-current-buffer)
   ;; buffer-insert.lisp
   (:export
    :*inhibit-read-only*


### PR DESCRIPTION
It seems that `with-buffer-point` is also user facing (not used in lem-base itself) so I'm also exporting it.