### PR TITLE
Add lisp-search-asdf-definition command

### DIFF
--- a/extensions/lisp-mode/apropos-mode.lisp
+++ b/extensions/lisp-mode/apropos-mode.lisp
@@ -111,3 +111,12 @@
                                                     (completion-symbol-for-search-symbol
                                                      query)))))
     (display-xref-locations (find-definitions-by-name name))))
+
+(define-command lisp-search-asdf-definition () ()
+  (check-connection)
+  (let* ((system (read-asdf-system-name))
+         (file (read-from-string
+                (cadr (lisp-eval
+                       `(micros:eval-and-grab-output
+                         ,(format nil "(asdf:system-source-file \"~a\")" system)))))))
+    (find-file file)))

--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -394,6 +394,17 @@
                                      (find string package-names :test #'string=))
                     :history-symbol 'mh-lisp-package))))
 
+(defun read-asdf-system-name ()
+  (check-connection)
+  (let ((system-names (lisp-eval '(micros:list-systems))))
+    (prompt-for-string
+     "System: "
+     :completion-function (lambda (string)
+                            (completion string system-names))
+     :test-function (lambda (string)
+                      (find string system-names :test #'string=))
+     :history-symbol 'mh-lisp-system)))
+
 (defun lisp-beginning-of-defun (point n)
   (lem-lisp-syntax:beginning-of-defun point (- n)))
 


### PR DESCRIPTION
This commands gives autocompletion to all the asd systems on the image and then go to the .asd file that define that system.