### PR TITLE
Fix the pathname detection

### DIFF
--- a/src/commands/file.lisp
+++ b/src/commands/file.lisp
@@ -82,7 +82,8 @@
                     :directory (buffer-directory)
                     :default nil
                     :existing nil))
-                  ((pathnamep arg)
+                  ((or (pathnamep arg)
+                       (uiop:absolute-pathname-p arg))
                    (namestring arg)))))
       (let (buffer)
         (dolist (pathname (expand-files* filename))


### PR DESCRIPTION
Seems like when the file is on the ARG, not always is a PATHNAME, sometimes is a string that can be a valid absolute pathname.

Checking the absolute path seems to solve the issue.