### PR TITLE
define-keys

### DIFF
--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -391,6 +391,7 @@
    :make-keymap
    :*global-keymap*
    :define-key
+   :define-keys
    :keyseq-to-string
    :find-keybind
    :insertion-key-p

--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -46,6 +46,14 @@
        (define-key-internal keymap keys command-name))))
   (values))
 
+(defmacro define-keys (keymap &body bindings)
+  `(progn ,@(mapcar 
+             (lambda (binding)
+               `(define-key ,keymap
+                  ,(first binding) 
+                  ,(second binding)))
+             bindings)))
+
 (defun define-key-internal (keymap keys symbol)
   (loop :with table := (keymap-table keymap)
         :for rest :on (uiop:ensure-list keys)


### PR DESCRIPTION
A simple macro for defining multiple keys.

Example usage:
```lisp
(define-keys *global-keymap*
  ("C-a b" 'describe-bindings)
  ("C-a k" 'describe-key)
  ("C-a a" 'lem-lisp-mode:lisp-apropos)
  ("C-a c" 'apropos-command)
  ("C-a p" 'lem-lisp-mode:lisp-apropos-package)
  ("C-a f" 'lem-lisp-mode:lisp-describe-symbol))
```

It is a macro only because I prefer the &body indentation for this.  If you think a function is better, that is okay too.

Thank you.
