### PR TITLE
find-file unix path normalization

### DIFF
--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -387,10 +387,9 @@
         (concatenate 'string replace (car (last split))))))
 
 (defun normalize-path-input (path)
-  (reduce 
-   (lambda (ag pair) (normalize-path-marker ag (car pair) (cdr pair)) ) 
-   *special-paths* 
-   :initial-value path))
+  (reduce (lambda (ag pair) (normalize-path-marker ag (car pair) (cdr pair)))
+          *special-paths* 
+          :initial-value path))
 
 
 (defun prompt-file-completion (string directory &key directory-only)

--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -384,18 +384,13 @@
   (let ((split (str:split marker path)))
     (if (= 1 (length split))
         path 
-        (concatenate 'string 
-                     (or replace marker)
-                     (car (last split))))))
+        (concatenate 'string replace (car (last split))))))
 
 (defun normalize-path-input (path)
-  (let ((result path))
-    (loop :for pair :in *special-paths*
-          :do (setf result (normalize-path-marker 
-                            result 
-                            (car pair) 
-                            (cdr pair))))
-    result))
+  (reduce 
+   (lambda (ag pair) (normalize-path-marker ag (car pair) (cdr pair)) ) 
+   *special-paths* 
+   :initial-value path))
 
 
 (defun prompt-file-completion (string directory &key directory-only)


### PR DESCRIPTION
In find-file prompt, it is helpful to truncate the path before ~/ or // on Unix-style systems, otherwise paths can get really long.  This change modifies `lem/prompt-window::prompt-file-completion` to do this.  I do not use windows so this is behind a read-time feature condition and should only affect Linux/Mac

Thank you.