### PR TITLE
sdl2 icons workaround

### DIFF
--- a/src/base/icon.lisp
+++ b/src/base/icon.lisp
@@ -38,5 +38,4 @@
 (register-icon "folder" #x1f4c1)
 (register-icon "right-pointing-triangle" #x25B8)
 (register-icon "down-pointing-triangle" #x25BE)
-(register-icon "down-pointing-triangle" #x25BE)
 (register-icon "lock" #xD83D)

--- a/src/base/icon.lisp
+++ b/src/base/icon.lisp
@@ -36,3 +36,7 @@
       (getf (icon-plist icon) key))))
 
 (register-icon "folder" #x1f4c1)
+(register-icon "right-pointing-triangle" #x25B8)
+(register-icon "down-pointing-triangle" #x25BE)
+(register-icon "down-pointing-triangle" #x25BE)
+(register-icon "lock" #xD83D)

--- a/src/ext/filer.lisp
+++ b/src/ext/filer.lisp
@@ -109,10 +109,11 @@
 
 (defmethod render-item (point (item directory-item) depth)
   (insert-string point
-                 (strcat (if (directory-item-open-p item)
-                             (icon-string "down-pointing-triangle")
-                             (icon-string "right-pointing-triangle"))
-                         " ")
+                 (uiop:strcat 
+                  (if (directory-item-open-p item)
+                      (icon-string "down-pointing-triangle")
+                      (icon-string "right-pointing-triangle"))
+                  " ")
                  :attribute 'triangle-attribute)
   (insert-item point item)
   (dolist (item (directory-item-children item))

--- a/src/ext/filer.lisp
+++ b/src/ext/filer.lisp
@@ -2,12 +2,6 @@
   (:use :cl :lem))
 (in-package :lem/filer)
 
-(defparameter *right-pointing-triangle* 
-  (uiop:strcat (icon-string "right-pointing-triangle") " "))
-
-(defparameter *down-pointing-triangle* 
-  (uiop:strcat (icon-string "down-pointing-triangle") " "))
-
 (define-attribute triangle-attribute
   (t :bold t :foreground :base0D))
 
@@ -115,9 +109,10 @@
 
 (defmethod render-item (point (item directory-item) depth)
   (insert-string point
-                 (if (directory-item-open-p item)
-                     *down-pointing-triangle*
-                     *right-pointing-triangle*)
+                 (strcat (if (directory-item-open-p item)
+                             (icon-string "down-pointing-triangle")
+                             (icon-string "right-pointing-triangle"))
+                         " ")
                  :attribute 'triangle-attribute)
   (insert-item point item)
   (dolist (item (directory-item-children item))

--- a/src/ext/filer.lisp
+++ b/src/ext/filer.lisp
@@ -2,8 +2,11 @@
   (:use :cl :lem))
 (in-package :lem/filer)
 
-(defparameter *right-pointing-triangle* (uiop:strcat (string (code-char #x25B8)) " "))
-(defparameter *down-pointing-triangle* (uiop:strcat (string (code-char #x25BE)) " "))
+(defparameter *right-pointing-triangle* 
+  (uiop:strcat (icon-string "right-pointing-triangle") " "))
+
+(defparameter *down-pointing-triangle* 
+  (uiop:strcat (icon-string "down-pointing-triangle") " "))
 
 (define-attribute triangle-attribute
   (t :bold t :foreground :base0D))

--- a/src/modeline.lisp
+++ b/src/modeline.lisp
@@ -62,7 +62,7 @@
 (defun modeline-write-info (window)
   (let ((buffer (window-buffer window)))
     (cond ((buffer-read-only-p buffer)
-           (format nil "~a" (icon-string "lock")))
+           (format nil " ~a " (icon-string "lock")))
           ((buffer-modified-p buffer)
            " * ")
           (t

--- a/src/modeline.lisp
+++ b/src/modeline.lisp
@@ -62,7 +62,7 @@
 (defun modeline-write-info (window)
   (let ((buffer (window-buffer window)))
     (cond ((buffer-read-only-p buffer)
-           " L ")
+           (format nil "~a" (icon-string "lock")))
           ((buffer-modified-p buffer)
            " * ")
           (t

--- a/src/modeline.lisp
+++ b/src/modeline.lisp
@@ -62,7 +62,7 @@
 (defun modeline-write-info (window)
   (let ((buffer (window-buffer window)))
     (cond ((buffer-read-only-p buffer)
-           " 🔒 ")
+           " L ")
           ((buffer-modified-p buffer)
            " * ")
           (t


### PR DESCRIPTION
This fixes https://github.com/lem-project/lem/issues/1178

The issue exists on Arch and OpenBSD as far as I am currently aware, the freetype2 package that sdl2_ttf depends on is built without certain options on these systems that break icons in lem.

Using the icon registry, we go from having a pointer error, to just displaying an empty box icon, which is much preferred.

There are probably other icons elsewhere in the source that I haven't run into yet, but the solution is just to add them to src/base/icons.lisp

Before:
![image](https://github.com/lem-project/lem/assets/43155857/6108d4a6-bff7-4ead-bd60-92154fb2e0b9)


After:
![image](https://github.com/lem-project/lem/assets/43155857/866abd82-1b34-4597-9ddc-fd64019d5821)
