### PR TITLE
Export point accessors point-line and point-linum.

### DIFF
--- a/src/base/package.lisp
+++ b/src/base/package.lisp
@@ -151,6 +151,8 @@
    :copy-point
    :delete-point
    :point-buffer
+   :point-line
+   :point-linum
    :point-charpos
    :point-kind
    :point=


### PR DESCRIPTION
Small change which exports the two accessors `point-line` and `point-linum`.
There might be more functions which should be exported but I didn't go through the whole file.