### PR TITLE
Make it possible to recenter the window to an arbitrary line.

### DIFF
--- a/src/window/virtual-line.lisp
+++ b/src/window/virtual-line.lisp
@@ -1,8 +1,8 @@
 (in-package :lem-core)
 
-(defun window-recenter (window &key (line nil) (from-bottom nil))
+(defun window-recenter (window &key line from-bottom)
   "Recenter WINDOW to the given LINE number.
-LINE must be omitted, NIL, or a positive number.
+LINE must be NIL or a positive number.
 If LINE is NIL, recenter to the middle of the WINDOW.
 Otherwise, recenter to the nth LINE (starting at 0), counted from the top.
 If FROM-BOTTOM is T, start counting from the bottom."

--- a/src/window/virtual-line.lisp
+++ b/src/window/virtual-line.lisp
@@ -1,14 +1,23 @@
 (in-package :lem-core)
 
-(defun window-recenter (window)
-  (unless (= (window-cursor-y window)
-             (floor (window-height-without-modeline window) 2))
+(defun window-recenter (window &key (line nil) (from-bottom nil))
+  "Recenter WINDOW to the given LINE number.
+LINE must be omitted, NIL, or a positive number.
+If LINE is NIL, recenter to the middle of the WINDOW.
+Otherwise, recenter to the nth LINE (starting at 0), counted from the top.
+If FROM-BOTTOM is T, start counting from the bottom."
+  (check-type line (or null integer))
+  (check-type from-bottom boolean)
+  (setq line (cond ((null line)
+                    (floor (window-height-without-modeline window) 2))
+                   (from-bottom
+                    (- (window-height-without-modeline window) line 1))
+                   (t line)))
+  (unless (= line (window-cursor-y window))
     (line-start
      (move-point (window-view-point window)
                  (window-buffer-point window)))
-    (let* ((height (window-height-without-modeline window))
-           (n      (- (window-cursor-y window)
-                      (floor height 2))))
+    (let ((n (- (window-cursor-y window) line)))
       (window-scroll window n)
       n)))
 


### PR DESCRIPTION
Adds two new keyword arguments to `window-recenter` to make it possible to scroll the window to an arbitrary line.
Emacs uses a single argument, interpreting negative numbers as `from-bottom`, but as this is not a command, I think the additional keyword argument might be better.

I did implement it in `window-recenter`. I could also introduce a new function for arbitrary scrolling, and re-implement `window-recenter` using this new function, if you think the function name is not appropriate for this feature.