### PR TITLE
Allow binding a key to a keymap.

### DIFF
--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -36,7 +36,7 @@
 
 (defun define-key (keymap keyspec command-name)
   (check-type keyspec (or symbol string))
-  (check-type command-name symbol)
+  (check-type command-name (or symbol keymap))
   (typecase keyspec
     (symbol
      (setf (gethash keyspec (keymap-function-table keymap))
@@ -119,9 +119,11 @@
     (let ((table (keymap-table keymap)))
       (labels ((f (k)
                  (let ((cmd (gethash k table)))
-                   (if (prefix-command-p cmd)
-                       (setf table cmd)
-                       cmd))))
+                   (cond ((prefix-command-p cmd)
+                          (setf table cmd))
+                         ((keymap-p cmd)
+                          (setf table (keymap-table cmd)))
+                         (t cmd)))))
         (let ((parent (keymap-parent keymap)))
           (when parent
             (setf cmd (keymap-find-keybind parent key cmd))))


### PR DESCRIPTION
This allows binding a key to a keymap instead of a command.

```
(define-key *global-keymap* "C-x w" lem-some-package:*some-package-keymap*)
```

This way, a package which provides multiple commands, but not a mode with which these commands are associated, the person implementing the package can provide a keymap, with all the commands bound to an appropriate key.

Users can then simply bind the keymap to a key-combination of their choice and can start using the package right away, without the need to bind many keys to a common prefix.