### PR TITLE
Revert "Export point accessors point-line and point-linum."

### DIFF
--- a/src/base/package.lisp
+++ b/src/base/package.lisp
@@ -151,8 +151,6 @@
    :copy-point
    :delete-point
    :point-buffer
-   :point-line
-   :point-linum
    :point-charpos
    :point-kind
    :point=


### PR DESCRIPTION
Reverts lem-project/lem#1204

reason
- line structure is an internal structure and should not be exported
- The same is true for point-linum; line-number-at-point exists instead.