### PR TITLE
Adds vi-mode binding for Shift arrow keys in insert mode.

### DIFF
--- a/extensions/vi-mode/binds.lisp
+++ b/extensions/vi-mode/binds.lisp
@@ -126,6 +126,10 @@
 (define-key *insert-keymap* "Escape" 'vi-end-insert)
 (define-key *insert-keymap* "C-p" 'abbrev)
 (define-key *insert-keymap* "C-w" 'vi-kill-last-word)
+(define-key *insert-keymap* "Shift-Up" 'previous-page)
+(define-key *insert-keymap* "Shift-Down" 'next-page)
+(define-key *insert-keymap* "Shift-Left" 'vi-backward-word-begin)
+(define-key *insert-keymap* "Shift-Right" 'vi-forward-word-begin)
 
 (define-key *normal-keymap* "C-p" 'yank-pop)
 (define-key *normal-keymap* "C-n" 'yank-pop-next)


### PR DESCRIPTION
Vim shift + arrow keys in insert mode:
https://vimdoc.sourceforge.net/htmldoc/insert.html#ins-special-special