### PR TITLE
Tetris fix

### DIFF
--- a/contrib/tetris/tetris.lisp
+++ b/contrib/tetris/tetris.lisp
@@ -216,8 +216,8 @@
         (when (< 0 (- (floor *delete-nlines* 4)
                       (floor prev-nlines 4)))
           (incf *level*)
-          (when (< 100 (timer-ms *timer*))
-            (decf (timer-ms *timer*) 100)))))))
+          (when (< 100 (lem/common/timer:timer-ms *timer*))
+            (decf (lem/common/timer:timer-ms *timer*) 100)))))))
 
 (defun gameover-p ()
   (loop :for x :from 1 :below (1- +field-width+) :do

--- a/src/common/timer.lisp
+++ b/src/common/timer.lisp
@@ -15,6 +15,7 @@
    :stop-timer
    :with-idle-timers
    :update-idle-timers
+   :timer-ms
    :get-next-timer-timing-ms)
   #+sbcl
   (:lock t))


### PR DESCRIPTION
In Tetris, when multiple rows need to be removed at once, calling the timer-ms accessor does not work since the function is neither exported in timer package, nor used in the Tetris source.

This fixes the game.