### PR TITLE
Adds the commend current-directory and the ex command pwd.

### DIFF
--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -198,3 +198,7 @@
 (define-ex-command "^noh(?:lsearch)?$" (range argument)
   (declare (ignore range argument))
   (lem/isearch:isearch-end))
+
+(define-ex-command "^pwd?$" (range argument)
+  (declare (ignore range argument))
+  (lem:current-directory))

--- a/src/commands/file.lisp
+++ b/src/commands/file.lisp
@@ -18,6 +18,7 @@
            :revert-buffer
            :revert-buffer-function
            :change-directory
+           :current-directory
            :prompt-for-files-recursively))
 (in-package :lem-core/commands/file)
 
@@ -373,3 +374,11 @@
     (uiop:chdir directory)
     (setf *default-pathname-defaults* (uiop:getcwd)))
   t)
+
+(define-command current-directory (&optional insert) ("P")
+  "Display the directory of the active buffer.
+With prefix argument INSERT, insert the directory of the active buffer at point."
+  (let ((dir (buffer-directory)))
+    (if insert
+        (insert-string (current-point) dir)
+        (message "Directory ~a" dir))))


### PR DESCRIPTION
Adds the command `current-directory` to display the directory of the buffer as a message, or insert it into the current buffer.
Adds the vi-mode ex command `:pwd`.