### PR TITLE
Fixes rendering of long lines when line wrapping is on.

### DIFF
--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -256,13 +256,16 @@
                                                left-side-objects
                                                left-side-width)
   (let* ((objects-per-physical-line
-           (separate-objects-by-width
-            (append left-side-objects (create-drawing-objects logical-line))
-            (window-view-width window))))
+           (separate-objects-by-width (create-drawing-objects logical-line)
+                                      (- (window-view-width window) left-side-width)))
+         (height (max-height-of-objects (car objects-per-physical-line)))
+         (empty-left-side-objects (list (make-object-with-type (make-string left-side-width :initial-element #\space) nil nil))))
+    (render-line-with-caching window 0 y left-side-objects height)
     (loop :for objects :in objects-per-physical-line
           :for height := (max-height-of-objects objects)
-          :for x := 0 :then left-side-width
-          :do (render-line-with-caching window x y objects height)
+          :for first := t :then nil
+          :do (unless first (render-line-with-caching window 0 y empty-left-side-objects height))
+              (render-line-with-caching window left-side-width y objects height)
               (incf y height)
           :sum height)))
 


### PR DESCRIPTION
This patch fixes rendering of long lines when **line-wrapping** and **line-numbers** are enabled.

Previously, the separation of objects was done on the whole width of the window, which includes the `left-side-width`. This makes rendering of the first line correct, but following lines of the same logical line are wrong.

Now, the separation of objects is done without the `left-side-objects` on the reduced width. The left side is rendered separately.

The `empty-left-side-objects` are needed, otherwise there might be artefacts of the message buffer on the left side, because the empty space is never rendered.

I don't think is a nice solution, but I am not so familiar with the rendering code. Feel free to suggest any changes, or drop this PR if you have a better idea. It works for me right now and might give hints to come up with a correct solution.