### PR TITLE
Enhances vi-mode ex :edit command to be able to revert the buffer.

### DIFF
--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -13,6 +13,13 @@
                 :expand-filename-modifiers))
 (in-package :lem-vi-mode/ex-command)
 
+(defun ex-edit (filename force)
+  (if (string= filename "")
+      (lem:revert-buffer force)
+      (with-jumplist
+        (lem:find-file (merge-pathnames (expand-filename-modifiers filename)
+                                        (uiop:getcwd))))))
+
 (defun ex-write (range filename touch)
   (case (length range)
     (0 (if (string= filename "")
@@ -28,10 +35,13 @@
   (ex-write range filename touch)
   (lem-vi-mode/commands:vi-quit force))
 
-(define-ex-command "^e$" (range filename)
+(define-ex-command "^e(?:dit)?$" (range filename)
   (declare (ignore range))
-  (with-jumplist
-    (lem:find-file (merge-pathnames (expand-filename-modifiers filename) (uiop:getcwd)))))
+  (ex-edit filename nil))
+
+(define-ex-command "^e(?:dit)?!$" (range filename)
+  (declare (ignore range))
+  (ex-edit filename t))
 
 (define-ex-command "^(w|write)$" (range filename)
   (ex-write range filename t))


### PR DESCRIPTION
Old behaviour if a filename is given stays the same. Without a filename, revert the buffer. Dependent an `!` user will be asked.
https://vimdoc.sourceforge.net/htmldoc/editing.html#:edit