### PR TITLE
Adds vi-mode ex command :read.

### DIFF
--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -190,6 +190,26 @@
             (lem:show-message (format nil "~A: ~S" option-name (encode-value option-value))
                               :timeout 10))))))
 
+(define-ex-command "^r(?:e|ead)?$" (range filename)
+  ;; TODO: range currently does not distinguish between :0 and :1.
+  ;; This makes it impossible to insert at the beginning of the file
+  (cond
+    ((string= "" filename)
+     (lem:message "No file name"))
+    ((char= #\! (char filename 0))
+     (lem:message "Command execution not supported"))
+    (t
+     (let ((insert-point (case (length range)
+                           (0 (lem:current-point))
+                           (1 (first range))
+                           (2 (lem:point-max (first range) (second range))))))
+       (lem:move-point (lem:current-point) insert-point)
+       (lem:line-start (lem:current-point))
+       (unless (lem:line-offset (lem:current-point) 1)
+         (lem:line-end (lem:current-point))
+         (lem:newline))
+       (lem:insert-file-contents (lem:current-point) filename)))))
+
 (define-ex-command "^cd$" (range new-directory)
   (declare (ignore range))
   (let ((new-directory (change-directory (expand-filename-modifiers new-directory))))

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -195,9 +195,9 @@
   ;; This makes it impossible to insert at the beginning of the file
   (cond
     ((string= "" filename)
-     (lem:message "No file name"))
+     (lem:editor-error "No file name"))
     ((char= #\! (char filename 0))
-     (lem:message "Command execution not supported"))
+     (lem:editor-error "Command execution not supported"))
     (t
      (let ((insert-point (case (length range)
                            (0 (lem:current-point))
@@ -207,7 +207,7 @@
        (lem:line-start (lem:current-point))
        (unless (lem:line-offset (lem:current-point) 1)
          (lem:line-end (lem:current-point))
-         (lem:newline))
+         (lem:insert-character (lem:current-point) #\newline))
        (lem:insert-file-contents (lem:current-point) filename)))))
 
 (define-ex-command "^cd$" (range new-directory)


### PR DESCRIPTION
Only a partial implementation.
Executing a command and inserting its output is not yet supported.

The range currently does not distinguish between `:0` and `:1` so it is not possible to insert at the beginning of the file.

https://vimdoc.sourceforge.net/htmldoc/insert.html#:r