### PR TITLE
legit/porcelain: signal a lem:editor-error

### DIFF
--- a/extensions/legit/porcelain.lisp
+++ b/extensions/legit/porcelain.lisp
@@ -622,9 +622,10 @@ M	src/ext/porcelain.lisp
 
 ;; Save our script as a string at compile time.
 (defparameter *rebase-script-content*
-  (str:from-file
-   (asdf:system-relative-pathname (asdf:find-system "lem")
-                                  "scripts/dumbrebaseeditor.sh"))
+  (when (find-package :lem)
+    (str:from-file
+     (asdf:system-relative-pathname (uiop:symbol-call :asdf :find-system "lem")
+                                    "scripts/dumbrebaseeditor.sh")))
   "Our dumb editor shell script, saved as a string at compile time.
   We then save it to the user's ~/.lem/legit/rebaseetidor.sh at first use.")
 


### PR DESCRIPTION
As per your review on https://github.com/lem-project/lem/pull/1198

> ERROR is treated as an editor bug when the command loop catches it.
