### PR TITLE
Fix backward-prompt glitches where a prompt is skipped.

### DIFF
--- a/extensions/lisp-mode/repl.lisp
+++ b/extensions/lisp-mode/repl.lisp
@@ -443,12 +443,12 @@
 
 (define-command backward-prompt () ()
   (when (equal (current-buffer) (repl-buffer))
-    (move-to-previous-virtual-line (current-point))
+    (line-start (current-point))
     (lem:previous-single-property-change (lem:current-point) :field)))
 
 (define-command forward-prompt () ()
   (when (equal (current-buffer) (repl-buffer))
-    (move-to-next-virtual-line (current-point))
+    (line-end (current-point))
     (lem:next-single-property-change (lem:current-point) :field)
     (lem:next-single-property-change (lem:current-point) :field)))
 


### PR DESCRIPTION
I have some glitches with `backward-prompt` and `forward-prompt`. If the evaluation does not produce any output, like
```
CL-USER> (error "foo")
CL-USER> (error "foo")
```
The next prompt is right on the next line. Since `move-to-previous-virtual-line` moves the cursor to the start of the line, one prompt is skipped. The same happens for `forward-prompt` if there are multiple prompts which didn't produce any output.

This fix resolves the issues for me, could someone have a look if it makes sense?