### PR TITLE
Adds vi-mode command # and fixes * to wrap around.

### DIFF
--- a/extensions/vi-mode/binds.lisp
+++ b/extensions/vi-mode/binds.lisp
@@ -58,6 +58,7 @@
 (define-key *motion-keymap* "n" 'vi-search-next)
 (define-key *motion-keymap* "N" 'vi-search-previous)
 (define-key *motion-keymap* "*" 'vi-search-forward-symbol-at-point)
+(define-key *motion-keymap* "#" 'vi-search-backward-symbol-at-point)
 (define-key *motion-keymap* "g g" 'vi-goto-first-line)
 (define-key *motion-keymap* "g e" 'vi-backward-word-end)
 (define-key *motion-keymap* "g E" 'vi-backward-word-end-broad)

--- a/extensions/vi-mode/tests/commands.lisp
+++ b/extensions/vi-mode/tests/commands.lisp
@@ -85,3 +85,27 @@
         (ok (buf= #?"abcd\nef[b]cgh\n  fg\nijk\n"))
         (cmd "u$2hP")
         (ok (buf= #?"abcd\ne[b]cfgh\n fg\nijk\n"))))))
+
+(deftest vi-search-forward-symbol-at-point
+  (with-fake-interface ()
+    (with-vi-buffer (#?"f[o]o\nbar\nfoo\nbar\nfoo")
+      (cmd "*")
+      (ok (buf= #?"foo\nbar\n[f]oo\nbar\nfoo")))
+    (with-vi-buffer (#?"f[o]o\nbar\nfoo\nbar\nfoo")
+      (cmd "1*")
+      (ok (buf= #?"foo\nbar\n[f]oo\nbar\nfoo")))
+    (with-vi-buffer (#?"f[o]o\nbar\nfoo\nbar\nfoo")
+      (cmd "2*")
+      (ok (buf= #?"foo\nbar\nfoo\nbar\n[f]oo")))))
+
+(deftest vi-search-backward-symbol-at-point
+  (with-fake-interface ()
+    (with-vi-buffer (#?"foo\nbar\nfoo\nbar\nf[o]o")
+      (cmd "#")
+      (ok (buf= #?"foo\nbar\n[f]oo\nbar\nfoo")))
+    (with-vi-buffer (#?"foo\nbar\nfoo\nbar\nf[o]o")
+      (cmd "1#")
+      (ok (buf= #?"foo\nbar\n[f]oo\nbar\nfoo")))
+    (with-vi-buffer (#?"foo\nbar\nfoo\nbar\nf[o]o")
+      (cmd "2#")
+      (ok (buf= #?"[f]oo\nbar\nfoo\nbar\nfoo")))))


### PR DESCRIPTION
Adds the vi command `vi-search-backward-symbol-at-point` `#`
https://vimdoc.sourceforge.net/htmldoc/pattern.html##

Enhances `vi-search-forward-symbol-at-point` `*` to wrap around and to accept a prefix-argument.