### PR TITLE
Adds a keymap for the frame-multiplexer.

### DIFF
--- a/src/ext/frame-multiplexer.lisp
+++ b/src/ext/frame-multiplexer.lisp
@@ -3,7 +3,8 @@
         :lem
         :lem/button
         :lem/common/ring)
-  (:export :frame-multiplexer-next
+  (:export :*keymap*
+           :frame-multiplexer-next
            :frame-multiplexer-prev
            :frame-multiplexer-switch
            :frame-multiplexer-create-with-new-buffer-list
@@ -37,11 +38,16 @@
         (frame-multiplexer-on)
         (frame-multiplexer-off))))
 
-(define-key *global-keymap* "C-z c" 'frame-multiplexer-create-with-new-buffer-list)
-(define-key *global-keymap* "C-z d" 'frame-multiplexer-delete)
-(define-key *global-keymap* "C-z p" 'frame-multiplexer-prev)
-(define-key *global-keymap* "C-z n" 'frame-multiplexer-next)
-(define-key *global-keymap* "C-z r" 'frame-mulitplexer-rename)
+(defvar *keymap*
+  (make-keymap :name '*frame-multiplexer-keymap*)
+  "Keymap for commands related to the frame-multiplexer.")
+
+(define-key *keymap* "c" 'frame-multiplexer-create-with-new-buffer-list)
+(define-key *keymap* "d" 'frame-multiplexer-delete)
+(define-key *keymap* "p" 'frame-multiplexer-prev)
+(define-key *keymap* "n" 'frame-multiplexer-next)
+(define-key *keymap* "r" 'frame-mulitplexer-rename)
+(define-key *global-keymap* "C-z" *keymap*)
 
 (defstruct tab
   focus-p


### PR DESCRIPTION
I am not sure about the name of the `*keymap*` variable.

Currently, there is a lot of repetition in `init.el`. If the variable is named `*keymap*`, the user writes this into it's init.el to remap it:
```
(define-key *global-keymap* "C-v" lem/frame-multiplexer:*keymap*)
```

But now, the name of the keymap does not match the of the variable. But naming the variable `*frame-multiplexer-keymap*` introduces a lot of repetition in `init.el`

```
(define-key *global-keymap* "C-v" lem/frame-multiplexer:*frame-multiplexer-keymap*)
```

What do you think? What is the name of the keymap used for, is it just for user information?
