### PR TITLE
Lambda command prototype.

### DIFF
--- a/src/defcommand.lisp
+++ b/src/defcommand.lisp
@@ -136,7 +136,12 @@
 
            (register-command (make-instance ',class-name)
                              :mode-name ',mode-name
-                             :command-name ,command-name))))))
+                             :command-name ,command-name)
+           ',name)))))
+
+(defmacro lambda-command (params (&rest arg-descriptors) &body body)
+  (let ((name (gensym "LAMBDA-COMMAND")))
+    `(define-command ,name ,params ,arg-descriptors ,@body)))
 
 #|
 (defclass foo-advice () ())

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -359,7 +359,8 @@
    :all-command-names)
   ;; defcommand.lisp
   (:export
-   :define-command)
+   :define-command
+   :lambda-command)
   ;; mode.lisp
   (:export
    :ensure-mode-object


### PR DESCRIPTION
A was fooling around a bit and noticed, that the result of `define-command` could be bound using `define-key` with a very simple change. Just prototyped a `lambda-command`. Can be used as follows:

```
(define-key *global-keymap*
  "C-c C-a" (define-command my-lambda-command () ()
                  (message "Hello world")))

(define-key *global-keymap*
  "C-c C-o" (lambda-command () ()
              (message "Hello World")))
```

I removed the options from the `lambda-command`, otherwise it would look very awkward (`(lambda-command () () () ...)`).

I didn't think this through entirely yet, so there might be some side-effects I am not aware of. One "weird" thing for instance (from a users perspective): You can call the `lambda-command` via `M-x`.

What do you think about it?