### PR TITLE
Fixes line rendering for wrapped lines in sdl2 frontend.

### DIFF
--- a/frontends/sdl2/drawing.lisp
+++ b/frontends/sdl2/drawing.lisp
@@ -236,7 +236,7 @@
 
 (defmethod lem-if:render-line ((implementation lem-sdl2/sdl2:sdl2) view x y objects height)
   (display:with-display (display)
-    (fill-to-end-of-line display view 0 y height)
+    (fill-to-end-of-line display view x y height)
     (redraw-physical-line display view x y objects height)))
 
 (defmethod lem-if:render-line-on-modeline ((implementation lem-sdl2/sdl2:sdl2)

--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -259,7 +259,7 @@
            (separate-objects-by-width (create-drawing-objects logical-line)
                                       (- (window-view-width window) left-side-width)))
          (height (max-height-of-objects (car objects-per-physical-line)))
-         (empty-left-side-objects (list (make-object-with-type (make-string left-side-width :initial-element #\space) nil nil))))
+         (empty-left-side-objects (list (make-object-with-type (make-string left-side-width :initial-element #\space) nil (char-type #\space)))))
     (render-line-with-caching window 0 y left-side-objects height)
     (loop :for objects :in objects-per-physical-line
           :for height := (max-height-of-objects objects)


### PR DESCRIPTION
I am not sure if this is a complete fix for the rendering in the sdl2 frontend, but it fixes #1240
Maybe `render-line` should not fill to the end of the line but only to the width of the objects?

Or is it required that the objects given to `render-line-with-caching` always fill the whole line? If so, then `redraw-logical-line-when-line-wrapping` needs to be adapted to only call `render-line-with-caching` once per line.

![sdl2-line-wrapping](https://github.com/lem-project/lem/assets/1265113/e0e7903b-57f9-40d9-8f78-c5f9c73a28dd)
