### PR TITLE
Fixes line-rendering for wrapping and scrolling.

### DIFF
--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -255,18 +255,24 @@
                                                logical-line
                                                left-side-objects
                                                left-side-width)
-  (let* ((objects-per-physical-line
+  (let* ((left-side-characters (loop :for obj :in left-side-objects
+                                     :when (typep obj 'text-object)
+                                     :sum (length (text-object-string obj))))
+         (objects-per-physical-line
            (separate-objects-by-width (create-drawing-objects logical-line)
                                       (- (window-view-width window) left-side-width)))
-         (height (max-height-of-objects (car objects-per-physical-line)))
-         (empty-left-side-objects (list (make-object-with-type (make-string left-side-width :initial-element #\space) nil (char-type #\space)))))
-    (render-line-with-caching window 0 y left-side-objects height)
+         (empty-left-side-object (if (< 0 left-side-width)
+                                     (list (make-object-with-type
+                                            (make-string left-side-characters :initial-element #\space)
+                                            nil
+                                            (char-type #\space)))
+                                     nil)))
     (loop :for objects :in objects-per-physical-line
-          :for height := (max-height-of-objects objects)
-          :for first := t :then nil
-          :do (unless first (render-line-with-caching window 0 y empty-left-side-objects height))
-              (render-line-with-caching window left-side-width y objects height)
+          :for all-objects := (append left-side-objects objects)
+          :for height := (max-height-of-objects all-objects)
+          :do (render-line-with-caching window 0 y all-objects height)
               (incf y height)
+              (setq left-side-objects (copy-list empty-left-side-object))
           :sum height)))
 
 (defun find-cursor-object (objects)
@@ -298,10 +304,10 @@
            (check-type text-object text-object)
            (loop :for c :across (text-object-string text-object)
                  :collect (make-letter-object c (text-object-attribute text-object)))))
-    (let* ((objects
-             (append left-side-objects (create-drawing-objects logical-line)))
+    (let* ((objects (create-drawing-objects logical-line))
            (height
-             (max-height-of-objects objects)))
+             (max (max-height-of-objects left-side-objects)
+                  (max-height-of-objects objects))))
       (multiple-value-bind (cursor-object cursor-x)
           (find-cursor-object objects)
         (when cursor-object
@@ -324,7 +330,7 @@
                  (horizontal-scroll-start window)
                  (+ (horizontal-scroll-start window)
                     (window-view-width window)))))
-        (render-line-with-caching window 0 y objects height))
+        (render-line-with-caching window 0 y (append left-side-objects objects) height))
       height)))
 
 (defun redraw-lines (window)

--- a/src/window/virtual-line.lisp
+++ b/src/window/virtual-line.lisp
@@ -29,7 +29,7 @@ next line because it is at the end of width."
   (let* ((tab-size (variable-value 'tab-width :default (window-buffer window)))
          (charpos (point-charpos point))
          (line    (line-string point))
-         (width   (1- (window-width window)))
+         (width   (1- (window-body-width window)))
          (cur-x   0)
          (add-x   (if (< charpos (length line))
                       (char-width (schar line charpos) 0 :tab-size tab-size)
@@ -59,7 +59,7 @@ next line because it is at the end of width."
 (defun map-wrapping-line (window string fn)
   (let ((tab-size (variable-value 'tab-width :default (window-buffer window))))
     (loop :with start := 0
-          :and width := (1- (window-width window))
+          :and width := (1- (window-body-width window))
           :for i := (wide-index string width :start start :tab-size tab-size)
           :while i
           :do (funcall fn i)
@@ -241,7 +241,7 @@ next line because it is at the end of width."
                (eq point (window-buffer-point window))
                (variable-value 'line-wrap :default (point-buffer point))
                (numberp (cursor-saved-column point))
-               (>= (cursor-saved-column point) (- (window-width window) 3)))
+               (>= (cursor-saved-column point) (- (window-body-width window) 3)))
       (setf (cursor-saved-column point) 0))
 
     (if *use-new-vertical-move-function*

--- a/src/window/window.lisp
+++ b/src/window/window.lisp
@@ -145,6 +145,11 @@
                  :height height
                  :use-modeline-p use-modeline-p))
 
+(defun window-body-width (window)
+  "Return the width of the body of WINDOW.
+This is the content area in which the buffer is displayed, without any side margins."
+  (- (window-width window) (window-left-width window)))
+
 (defun clear-screens-of-window-list ()
   (flet ((clear-screen (window)
            (need-to-redraw window)


### PR DESCRIPTION
The next attempt to fix line rendering for #1243 

The sdl2 front-end requires the whole line to be rendered. Otherwise, the caching of lines won't work. It also doesn't like empty strings.

The `left-side-width` depends on the front-end. For ncurses, it is the number of characters, for sdl2 the number of pixels.

I also tried to fix the scrolling version with line-numbers. Because the line-numbers are appended before the calculations are done, those will be scrolled out as well.

Hopefully this works now.