### PR TITLE
Actually enable/disable the auto-save mode.

### DIFF
--- a/src/ext/auto-save.lisp
+++ b/src/ext/auto-save.lisp
@@ -1,7 +1,8 @@
 (defpackage :lem/auto-save
   (:use :cl :lem)
   (:export :*make-backup-files*
-           :toggle-auto-save)
+           :toggle-auto-save
+           :auto-save-mode)
   #+sbcl
   (:lock t))
 (in-package :lem/auto-save)
@@ -51,22 +52,20 @@
     (let ((interval (variable-value 'auto-save-checkpoint-frequency)))
       (when (and (numberp interval) (plusp interval))
         (setf *timer*
-              (start-timer (make-idle-timer 'checkpoint-all-buffers
+              (start-timer (make-idle-timer #'checkpoint-all-buffers
                                             :handle-function (lambda (condition)
                                                                (pop-up-backtrace condition)
                                                                (disable))
                                             :name "autosave")
                            (* interval 1000)
-                           :repeat t))))
-    (add-hook *input-hook* 'count-keys)))
+                           :repeat t)))))
+  (add-hook *input-hook* #'count-keys))
 
 (defun disable ()
   (when *timer*
     (stop-timer *timer*)
-    (setf *timer* nil)
-    (remove-hook *input-hook* 'count-keys)))
+    (setf *timer* nil))
+  (remove-hook *input-hook* #'count-keys))
 
 (define-command toggle-auto-save () ()
-  (if *timer*
-      (disable)
-      (enable)))
+  (auto-save-mode))

--- a/src/ext/auto-save.lisp
+++ b/src/ext/auto-save.lisp
@@ -52,20 +52,20 @@
     (let ((interval (variable-value 'auto-save-checkpoint-frequency)))
       (when (and (numberp interval) (plusp interval))
         (setf *timer*
-              (start-timer (make-idle-timer #'checkpoint-all-buffers
+              (start-timer (make-idle-timer 'checkpoint-all-buffers
                                             :handle-function (lambda (condition)
                                                                (pop-up-backtrace condition)
                                                                (disable))
                                             :name "autosave")
                            (* interval 1000)
                            :repeat t)))))
-  (add-hook *input-hook* #'count-keys))
+  (add-hook *input-hook* 'count-keys))
 
 (defun disable ()
   (when *timer*
     (stop-timer *timer*)
     (setf *timer* nil))
-  (remove-hook *input-hook* #'count-keys))
+  (remove-hook *input-hook* 'count-keys))
 
 (define-command toggle-auto-save () ()
   (auto-save-mode))


### PR DESCRIPTION
The auto-save-mode was never actually enabled/disabled. Since `toggle-auto-save` does not call the mode, the user never sees the mode in the modeline.

Also: adding and removing the hook should be independent from wether the timer is set or not. Otherwise, disabling the mode will not remove the hook if the timer is not set, because the set `auto-save-checkpoint-frequency` to `nil`.