### PR TITLE
Give link-mode a name, so it shows up in DESCRIBE-MODE.

### DIFF
--- a/src/ext/link.lisp
+++ b/src/ext/link.lisp
@@ -35,7 +35,7 @@
     :reader url-link-url)))
 
 (define-minor-mode link-mode
-    (:name nil
+    (:name "link"
      :enable-hook 'enable
      :disable-hook 'disable))
 


### PR DESCRIPTION
Link mode doesn't have a name, so in `describe-mode`, the minor mode list contains `nil`.
Maybe this was done so the mode doesn't show up in the modeline?

If so, I think lem should have a mechanism to hide modes from the modeline, but a mode should always have a name, so describe mode shows something reasonable.