### PR TITLE
Add a simple package manager for lisp/lem libraries

### DIFF
--- a/lem.asd
+++ b/lem.asd
@@ -157,7 +157,8 @@
                              (:file "filer")
                              (:file "deepl")
                              (:file "themes")
-                             (:file "detective")))))
+                             (:file "detective")
+                             (:file "simple-package")))))
 
 (defsystem "lem/extensions"
   :depends-on (#+sbcl

--- a/src/ext/simple-package.lisp
+++ b/src/ext/simple-package.lisp
@@ -7,9 +7,9 @@
 
 (in-package :lem/simple-package)
 
-(defparameter *installed-packages* nil)
+(defvar *installed-packages* nil)
 
-(defparameter *packages-directory*
+(defvar *packages-directory*
   (pathname (str:concat
              (directory-namestring (lem-home))
              "packages"
@@ -47,10 +47,9 @@
 
 (defstruct (quicklisp (:include source)))
 
-(eval-when (:compile-toplevel)
-  (defparameter *quicklisp-system-list*
-    (remove-duplicates
-     (mapcar #'ql-dist:release (ql:system-list)))))
+(defvar *quicklisp-system-list*
+  (remove-duplicates
+   (mapcar #'ql-dist:release (ql:system-list))))
 
 (defmethod download-source ((source quicklisp) (output-location String))
   (let* ((output-dir (str:concat

--- a/src/ext/simple-package.lisp
+++ b/src/ext/simple-package.lisp
@@ -1,0 +1,89 @@
+(defpackage :lem/simple-package
+  (:use :cl :lem))
+
+(in-package :lem/simple-package)
+
+(defparameter *installed-packages* nil)
+
+(defparameter *packages-directory*
+  (pathname (str:concat
+             (directory-namestring (lem-home))
+             "packages"
+             (string  (uiop:directory-separator-for-host)))))
+
+(defstruct source name)
+
+(defgeneric download-source (source output-location)
+  (:documentation "It downloads the SOURCE to the desired location."))
+
+;; From porcelain.lisp
+(defvar *git-base-arglist* (list "git")
+  "The git program, to be appended command-line options.")
+
+(defun run-git (arglist)
+  (uiop:wait-process
+   (uiop:launch-program (concatenate 'list *git-base-arglist* arglist)
+                        :ignore-error-status t)))
+
+(defstruct (git (:include source)) url commit)
+
+(defmethod download-source ((source git) (output-location String))
+  (run-git (list "clone" (git-url source)
+                 (str:concat
+                  (namestring *packages-directory*) output-location))))
+
+(defmethod download-source (source output-location)
+  (editor-error "Source ~a not available." source))
+
+;; source (list type url commit)
+
+(defclass simple-package ()
+  ((name :initarg :name
+         :accessor simple-package-name)
+   (source :initarg :source
+           :accessor simple-package-source)))
+
+(defun packages-list ()
+  (mapcar #'(lambda (d) (pathname (directory-namestring d)))
+          (directory (merge-pathnames "**/*.asd" *packages-directory*))))
+
+(defmacro lem-use-package (name &key source config
+                                 after bind
+                                 hooks force)
+  (declare (ignore hooks bind after config ))
+  (labels ((dfsource (source-list)
+             (let ((s (car source-list)))
+               (ecase s
+                 (:git
+                  (destructuring-bind (_ url commit)
+                      source-list
+                    (declare (ignore _ commit))
+                      (make-git :name name
+                                :url url)))
+                 (t (editor-error "Source ~a not available." s))))))
+    (alexandria:with-gensyms (spackage rsource pdir)
+      `(let* ((asdf:*central-registry*
+                (union (packages-list)
+                       asdf:*central-registry*
+                       :test #'equal))
+              (,rsource ,(dfsource source))
+              (,spackage (make-instance 'simple-package
+                                        :name ,name
+                                        :source ,rsource))
+              (,pdir (merge-pathnames *packages-directory* ,name)))
+         (when (or ,force
+                   (not (uiop:directory-exists-p ,pdir)))
+           (message "Downloading ~a..." ,name)
+           (download-source ,rsource ,name)
+           (message "Done downloading ~a!" ,name))
+         (pushnew ,spackage *installed-packages*
+                  :test #'(lambda (a b)
+                            (string=
+                             (simple-package-name a)
+                             (simple-package-name b))))
+         (maybe-quickload (alexandria:make-keyword ,name)
+                          :silent t)))))
+
+;;(lem-use-package "lem-pareto" :source (:git "https://github.com/40ants/lem-pareto.git" nil))
+
+;;(lem-use-package "modf" :source (:git "https://github.com/smithzvk/modf.git" nil))

--- a/src/ext/simple-package.lisp
+++ b/src/ext/simple-package.lisp
@@ -25,65 +25,177 @@
    (uiop:launch-program (concatenate 'list *git-base-arglist* arglist)
                         :ignore-error-status t)))
 
-(defstruct (git (:include source)) url commit)
+(defstruct (git (:include source)) url branch commit)
 
 (defmethod download-source ((source git) (output-location String))
-  (run-git (list "clone" (git-url source)
-                 (str:concat
-                  (namestring *packages-directory*) output-location))))
+  (let ((output-dir (str:concat
+                     (namestring *packages-directory*) output-location)))
+    (run-git (list "clone" (git-url source) output-dir))
+    (when (git-branch source)
+      (uiop:with-current-directory (output-dir)
+        (run-git (list "checkout" "-b" (git-branch source)))))
+
+    (when (git-commit source)
+      (uiop:with-current-directory (output-dir)
+        (run-git (list "checkout" (git-commit source)))))
+    output-dir))
+
+(defstruct (quicklisp (:include source)))
+
+(eval-when (:compile-toplevel)
+  (defparameter *quicklisp-system-list*
+    (remove-duplicates
+     (mapcar #'ql-dist:release (ql:system-list)))))
+
+(defmethod download-source ((source quicklisp) (output-location String))
+  (let* ((output-dir (str:concat
+                     (namestring *packages-directory*) output-location))
+         (release (find (source-name source)
+                       *quicklisp-system-list*
+                       :key #'ql-dist:project-name
+                       :test #'string=))
+         (url (ql-dist:archive-url release))
+         (name (source-name source))
+         (tgzfile (str:concat name ".tgz"))
+         (tarfile (str:concat name ".tar")))
+    (if release
+        (prog1 output-dir
+          (uiop:with-current-directory (*packages-directory*)
+            (quicklisp-client::maybe-fetch-gzipped url tgzfile
+                                                   :quietly t)
+            (ql-gunzipper:gunzip tgzfile tarfile)
+            (ql-minitar:unpack-tarball tarfile)
+            (delete-file tgzfile)
+            (delete-file tarfile)
+            (uiop/cl:rename-file (ql-dist:prefix release) output-location)))
+        (editor-error "Package ~a not found!." (source-name source)))))
 
 (defmethod download-source (source output-location)
   (editor-error "Source ~a not available." source))
-
-;; source (list type url commit)
 
 (defclass simple-package ()
   ((name :initarg :name
          :accessor simple-package-name)
    (source :initarg :source
-           :accessor simple-package-source)))
+           :accessor simple-package-source)
+   (directory :initarg :directory
+              :accessor simple-package-directory)))
+
+(defgeneric package-remove (package))
+
+(defmethod package-remove ((package simple-package))
+  (uiop:delete-directory-tree
+   (uiop:truename* (simple-package-directory package)) :validate t)
+  (delete package *installed-packages*))
 
 (defun packages-list ()
-  (mapcar #'(lambda (d) (pathname (directory-namestring d)))
-          (directory (merge-pathnames "**/*.asd" *packages-directory*))))
+  (remove-duplicates
+   (mapcar #'(lambda (d) (pathname (directory-namestring d)))
+           (directory (merge-pathnames "**/*.asd" *packages-directory*)))))
 
+(defun insert-package (package)
+  (pushnew package *installed-packages*
+           :test #'(lambda (a b)
+                     (string=
+                      (simple-package-name a)
+                      (simple-package-name b)))))
+
+;; git source (list :type type :url url :branch branch :commit commit)
 (defmacro lem-use-package (name &key source config
                                  after bind
                                  hooks force)
   (declare (ignore hooks bind after config ))
-  (labels ((dfsource (source-list)
-             (let ((s (car source-list)))
-               (ecase s
-                 (:git
-                  (destructuring-bind (_ url commit)
-                      source-list
-                    (declare (ignore _ commit))
-                      (make-git :name name
-                                :url url)))
-                 (t (editor-error "Source ~a not available." s))))))
-    (alexandria:with-gensyms (spackage rsource pdir)
-      `(let* ((asdf:*central-registry*
+  (alexandria:with-gensyms (spackage rsource pdir)
+    `(labels ((dfsource (source-list)
+                (let ((s (getf source-list :type)))
+                  (ecase s
+                    (:git
+                     (destructuring-bind (&key type url branch commit)
+                         source-list
+                       (declare (ignore type))
+                       (make-git :name ,name
+                                 :url url
+                                 :branch branch
+                                 :commit commit)))
+                    (:quicklisp
+                     (destructuring-bind (&key type)
+                         source-list
+                       (declare (ignore type))
+                       (make-quicklisp :name ,name)))
+                    (t (editor-error "Source ~a not available." s))))))
+       (let* ((asdf:*central-registry*
                 (union (packages-list)
                        asdf:*central-registry*
                        :test #'equal))
-              (,rsource ,(dfsource source))
+              (ql:*local-project-directories*
+                (nconc (list *packages-directory*)
+                       ql:*local-project-directories*))
+              (,rsource (dfsource ,source))
+              (,pdir (merge-pathnames *packages-directory* ,name))
               (,spackage (make-instance 'simple-package
                                         :name ,name
-                                        :source ,rsource))
-              (,pdir (merge-pathnames *packages-directory* ,name)))
+                                        :source ,rsource
+                                        :directory ,pdir)))
          (when (or ,force
                    (not (uiop:directory-exists-p ,pdir)))
            (message "Downloading ~a..." ,name)
            (download-source ,rsource ,name)
            (message "Done downloading ~a!" ,name))
-         (pushnew ,spackage *installed-packages*
-                  :test #'(lambda (a b)
-                            (string=
-                             (simple-package-name a)
-                             (simple-package-name b))))
+
+         (insert-package ,spackage)
+         (uiop:symbol-call :quicklisp :register-local-projects)
          (maybe-quickload (alexandria:make-keyword ,name)
                           :silent t)))))
 
-;;(lem-use-package "lem-pareto" :source (:git "https://github.com/40ants/lem-pareto.git" nil))
+;(lem-use-package "versioned-objects"
+;                 :source '(:type :git
+;                           :url "https://github.com/smithzvk/Versioned-Objects.git"
+;                           :branch "advance-versioning"))
 
-;;(lem-use-package "modf" :source (:git "https://github.com/smithzvk/modf.git" nil))
+;(lem-use-package "fiveam" :source (:type :quicklisp))
+
+;; Package util commands
+
+(defun load-packages ()
+  (let ((ql:*local-project-directories* (list *packages-directory*)))
+    (loop for dpackage in (directory (merge-pathnames "*/" *packages-directory*))
+          for spackage = (car
+                          (last
+                           (pathname-directory
+                            (uiop:directorize-pathname-host-device dpackage))))
+          do (insert-package
+              (make-instance 'simple-package
+                             :name spackage
+                             :source (make-local :name spackage)
+                             :directory dpackage))
+          do (maybe-quickload (alexandria:make-keyword spackage) :silent t))))
+
+(define-command simple-package-install-ql-package () ()
+  (let* ((packages (mapcar #'ql-dist:project-name
+                           *quicklisp-system-list*))
+         (rpackage
+           (prompt-for-string "Select package: "
+                              :completion-function
+                              (lambda (string)
+                                (completion string packages)))))
+
+    (lem-use-package rpackage :source '(:type :quicklisp))
+    (message "Package ~a installed!" rpackage)))
+
+(define-command simple-package-remove-package () ()
+  (if *installed-packages*
+      (let* ((packages (and *installed-packages*
+                            (mapcar #'simple-package-name
+                                    *installed-packages*)))
+             (rpackage
+               (prompt-for-string "Select package: "
+                                  :completion-function
+                                  (lambda (string)
+                                    (completion string packages)))))
+        (package-remove
+         (find rpackage *installed-packages*
+               :key #'simple-package-name
+               :test #'string=))
+        (message "Package remove from system!"))
+
+      (message "No packages installed!")))

--- a/src/ext/simple-package.lisp
+++ b/src/ext/simple-package.lisp
@@ -175,7 +175,7 @@
                              :directory dpackage))
           do (maybe-quickload (alexandria:make-keyword spackage) :silent t))))
 
-(define-command simple-package-install-ql-package () ()
+(define-command sp-install-ql-package () ()
   (let* ((packages (mapcar #'ql-dist:project-name
                            *quicklisp-system-list*))
          (rpackage
@@ -187,7 +187,7 @@
     (lem-use-package rpackage :source '(:type :quicklisp))
     (message "Package ~a installed!" rpackage)))
 
-(define-command simple-package-remove-package () ()
+(define-command sp-remove-package () ()
   (if *installed-packages*
       (let* ((packages (and *installed-packages*
                             (mapcar #'simple-package-name
@@ -204,3 +204,22 @@
         (message "Package remove from system!"))
 
       (message "No packages installed!")))
+
+
+(define-command sp-purge-packages () ()
+  (let* ((plist (packages-list))
+        (extra-packages
+          (set-difference
+           (mapcar (lambda (p)
+                     (first (last (pathname-directory p))))
+                   plist)
+           (mapcar #'simple-package-name *installed-packages*)
+           :test #'string=)))
+    (loop for e in extra-packages
+          for dir = (find e plist
+                          :key (lambda (p) (first (last (pathname-directory p))))
+                          :test #'string=)
+          do (and (uiop:directory-exists-p dir)
+              (uiop:delete-directory-tree
+                    (uiop:truename* dir)
+                    :validate t)))))

--- a/src/ext/simple-package.lisp
+++ b/src/ext/simple-package.lisp
@@ -1,5 +1,9 @@
 (defpackage :lem/simple-package
-  (:use :cl :lem))
+  (:use :cl :lem)
+  (:export :*installed-packages*
+           :*packages-directory*
+           :lem-use-package
+           :load-packages))
 
 (in-package :lem/simple-package)
 
@@ -13,10 +17,11 @@
 
 (defstruct source name)
 
+(defstruct (local (:include source)))
+
 (defgeneric download-source (source output-location)
   (:documentation "It downloads the SOURCE to the desired location."))
 
-;; From porcelain.lisp
 (defvar *git-base-arglist* (list "git")
   "The git program, to be appended command-line options.")
 

--- a/src/ext/simple-package.lisp
+++ b/src/ext/simple-package.lisp
@@ -144,7 +144,7 @@
 ;; git source (list :type type :url url :branch branch :commit commit)
 (defmacro lem-use-package (name &key source after
                                  bind hooks force)
-  (declare (ignore hooks bind ))
+  (declare (ignore hooks bind after))
   (alexandria:with-gensyms (spackage rsource pdir)
     `(let* ((asdf:*central-registry*
                 (union (packages-list)

--- a/src/site-init.lisp
+++ b/src/site-init.lisp
@@ -15,10 +15,11 @@
               `(asdf:defsystem ,*site-init-name*)))
     path))
 
+(defun raw-init-files ()
+  (directory (merge-pathnames "inits/*.lisp" (lem-home))))
+
 (defun site-init-list-inits ()
-  (loop for i in (sort (mapcar #'pathname-name
-                               (directory (merge-pathnames "inits/*.lisp"
-                                                           (lem-home))))
+  (loop for i in (sort (mapcar #'pathname-name (raw-init-files))
                        #'string<)
      collect (list :file (format nil "inits/~A" i))))
 
@@ -67,6 +68,11 @@
       (asdf:load-asd (site-init-path))
       (let ((*package* (find-package :lem-user)))
         (maybe-quickload system-name :silent t)))))
+
+(defun load-init-files ()
+  (let ((*package* (find-package :lem-user)))
+    (loop for file in (raw-init-files)
+          do (load file))))
 
 (define-command site-init-add-dependency (symbols)
     ((prompt-for-library "library: " :history-symbol 'load-library))

--- a/src/site-init.lisp
+++ b/src/site-init.lisp
@@ -46,11 +46,16 @@
 
 (defun load-site-init (&key force)
   (let* ((asdf:*central-registry*
-           (union (mapcar #'pathname
-                          (mapcar #'directory-namestring
-                                  (directory
-                                   (merge-pathnames "**/*.asd"
-                                                    (lem-home)))))
+           (union (remove-duplicates
+                   (mapcar #'pathname
+                           (mapcar #'directory-namestring
+                                   (directory
+                                    (merge-pathnames
+                                     "**/*.asd"
+                                     (pathname (str:concat
+                                                (directory-namestring (lem-home))
+                                                "lisp"
+                                                (string  (uiop:directory-separator-for-host)))))))))
                   asdf:*central-registry*
                   :test #'equal))
          (system-name *site-init-name*)


### PR DESCRIPTION
This is the initial proposal of a simple package manager, this implementations contains the following features:

- A simple and declarative way of defining an external package (in this context, "package" is basically an asd system), both using quicklisp and git (with the possibility of using a custom branch and/or commit)  as a source:

https://github.com/lem-project/lem/assets/26670956/51c503e0-6878-44a5-957d-72756b2244bf

- Two commands to manage packages (install/remove) from quicklisp and from git:

https://github.com/lem-project/lem/assets/26670956/ddbcda58-eb38-4323-afa5-56d3eab16b8e

I chose to use a folder in "~/.lem/packages" to save the packages, the dependencies of the packages will be managed by quicklisp. This approach helps developing external packages while using Lem (I can load packages from git, modify them and push the changes to the package repository).

I'm planning to extend the `lem-use-package` options in the future to add more useful features.

(The idea of this simple approach is to just have something to manage packages until https://github.com/lem-project/lem-extension-manager is finished)



