### PR TITLE
Fixes an SDL2 crash which happens when texture have no size.

### DIFF
--- a/frontends/sdl2/view.lisp
+++ b/frontends/sdl2/view.lisp
@@ -76,7 +76,7 @@
                  :width width
                  :height height
                  :use-modeline use-modeline
-                 :texture (display:create-view-texture display width height)))
+                 :texture (display:create-view-texture display (max width 1) (max height 1))))
 
 (defmethod delete-view ((view view))
   (when (view-texture view)
@@ -94,7 +94,7 @@
         (view-height view) height)
   (sdl2:destroy-texture (view-texture view))
   (setf (view-texture view)
-        (display:create-view-texture display width height)))
+        (display:create-view-texture display (max width 1) (max height 1))))
 
 (defmethod move-position ((view view) x y)
   (setf (view-x view) x

--- a/src/ext/popup-window.lisp
+++ b/src/ext/popup-window.lisp
@@ -78,8 +78,8 @@
       (call-next-method)
     (list (+ x (gravity-offset-x gravity))
           (+ y (gravity-offset-y gravity))
-          width
-          height)))
+          (max width 1)
+          (max height 1))))
 
 (defmethod compute-popup-window-rectangle ((gravity gravity-center)
                                            &key width height &allow-other-keys)


### PR DESCRIPTION
This fixes a crash in SDL2 when a texture is empty:
```
debugger invoked on a SDL2::SDL-ERROR in thread
#<THREAD tid=37708 "main thread" RUNNING {1007760253}>:
  SDL Error: Texture dimensions can't be 0

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE] Return to the SDL2 main loop.
  1: [ABORT   ] Abort, quitting SDL2 entirely.

(SDL2:CREATE-TEXTURE #<SDL2-FFI:SDL-RENDERER {#X5638722A74A0}> 373694468 2 288 0)
   source: (CHECK-NULLPTR
            (SDL-CREATE-TEXTURE RENDERER
             (ENUM-VALUE 'SDL-PIXEL-FORMAT PIXEL-FORMAT)
             (ENUM-VALUE 'SDL2-FFI:SDL-TEXTURE-ACCESS ACCESS) WIDTH HEIGHT))
```

The change in `popup-window` is needed for an assertion in `window`:
```
debugger invoked on a SIMPLE-ERROR in thread
#<THREAD tid=38102 "main thread" RUNNING {10077781B3}>:
  The assertion (LEM-CORE::VALID-WINDOW-HEIGHT-P LEM-CORE::HEIGHT) failed with
  LEM-CORE::HEIGHT = 0.

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE] Retry assertion.
  1:            Return to the SDL2 main loop.
  2: [ABORT   ] Abort, quitting SDL2 entirely.

(SB-KERNEL:ASSERT-ERROR (LEM-CORE::VALID-WINDOW-HEIGHT-P LEM-CORE::HEIGHT) 1 LEM-CORE::HEIGHT 0)
```

Both of these happen if you shrink the system window height as small as possible and then execute `M-x`, or shrink the window while the `M-x` popup is open.