### PR TITLE
Add command to go to quickdocs using the reference at point

### DIFF
--- a/extensions/lisp-mode/misc-commands.lisp
+++ b/extensions/lisp-mode/misc-commands.lisp
@@ -66,3 +66,24 @@
                              (current-buffer)))
          (package (first (lem/detective:references-packages buffer-references))))
     (%send-test-suite package)))
+
+
+(defvar *quickdocs-url* "https://quickdocs.org/")
+
+(defvar *quickdocs-check-url* nil)
+
+(define-command lisp-quickdocs-at-point  (point) ((current-point))
+  (let* ((symbol (cl-ppcre:regex-replace-all
+                  ":|#"
+                  (symbol-string-at-point point) ""))
+         (url (format nil "~a~a" *quickdocs-url* symbol))
+         (status-response
+           (and *quickdocs-check-url*
+                (second (multiple-value-list (ignore-errors
+                                               (dexador:get url)))))))
+    (if (or (and (numberp status-response)
+                  (= status-response 200))
+            (not *quickdocs-check-url*))
+        (open-external-file url)
+        (message "The symbol ~a, doesn't correspond to a ASDF system on Quickdocs."
+                 symbol))))

--- a/extensions/lisp-mode/misc-commands.lisp
+++ b/extensions/lisp-mode/misc-commands.lisp
@@ -70,7 +70,10 @@
 
 (defvar *quickdocs-url* "https://quickdocs.org/")
 
-(defvar *quickdocs-check-url* nil)
+(defvar *quickdocs-check-url* nil
+  "Boolean variable, if true, the function `lisp-quickdocs-at-point' ensure
+that the reference exists in the webpage, adding consistency but more delay.
+By default, is set to nil so the execution is faster.")
 
 (define-command lisp-quickdocs-at-point  (point) ((current-point))
   (let* ((symbol (cl-ppcre:regex-replace-all


### PR DESCRIPTION
A simple command to navigate to https://quickdocs.org from lisp mode.