### PR TITLE
Associated python shebang with python-mode.

### DIFF
--- a/extensions/python-mode/python-mode.lisp
+++ b/extensions/python-mode/python-mode.lisp
@@ -98,3 +98,4 @@
     (move-point point p)))
 
 (define-file-type ("py") python-mode)
+(define-program-name-with-mode ("python" "python2" "python3") python-mode)


### PR DESCRIPTION
Associate python shebang with python mode.
Would maybe be good if it would be possible to define a regex for that?