### PR TITLE
Update the stored display size in the virtual frame.

### DIFF
--- a/src/ext/frame-multiplexer.lisp
+++ b/src/ext/frame-multiplexer.lisp
@@ -278,6 +278,8 @@
               (not (equal-tabs tabs (virtual-frame-last-displayed-tabs window))))
       (setf (virtual-frame-last-displayed-tabs window) tabs)
       (write-tabs-to-buffer window frames tabs))
+    (setf (virtual-frame-width window) (display-width))
+    (setf (virtual-frame-height window) (display-height))
     (call-next-method)))
 
 (defun frame-multiplexer-init ()


### PR DESCRIPTION
The `virtual-frame-width` and `virtual-frame-height` is never updated.
This leads to two problems:

1. As soon as the native window (or terminal) is resized, the virtual frame thinks constantly that it needs to be redrawn. This makes the frame-multiplexer erase its buffer and re-write it, which leads to a redraw in the front-end. This is noticeable in the CPU usage (not extreme on my machine, but still).
2. Since the internal size is not updated, as soon as the native window gets back to its original size, this last resize will not lead to a redraw of the frame-multiplexer. Therefore, the header line will remain as it was before (I noticed that the background colour is not redrawn). As soon as you do something (like `M-x`), the whole window is redrawn again and one can see the change in the header line.

I am not sure if this place is the correct one to update those two fields, but I didn't find a better way to deal with it.