### PR TITLE
Paredit improvements

### DIFF
--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -28,7 +28,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 (in-package :lem-paredit-mode)
 
 (define-minor-mode paredit-mode
-    (:name "paredit" 
+    (:name "paredit"
      :description "Helps to handle parentheses balanced in your Lisp code."
      :keymap *paredit-mode-keymap*))
 
@@ -223,8 +223,11 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
         ((paredit-whitespace-prefix p)
          (delete-trailing-whitespace)
          (delete-previous-char (1+ (point-column p)))
-         (unless (eq #\) (character-at (current-point)))
-           (insert-character (current-point) #\ )))
+         (let* ((p (current-point))
+                (c (character-at p)))
+           (unless (or (whitespace-p c)) (eq #\) c)
+             (insert-character p #\ )))
+         (indent-buffer (current-buffer)))
         (t
          (delete-previous-char))))
     (paredit-backward-delete (1- n))))

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -219,6 +219,12 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
              (eql (character-at p -1) #\")
              (eql (character-at p -1) #\|))
          (backward-char))
+        ;; go back line when point prefixed with whitespace
+        ((paredit-whitespace-prefix p)
+         (delete-trailing-whitespace)
+         (delete-previous-char (1+ (point-column p)))
+         (unless (eq #\) (character-at (current-point)))
+           (insert-string (current-point) " ")))
         (t
          (delete-previous-char))))
     (paredit-backward-delete (1- n))))

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -46,7 +46,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
                    (or (syntax-closed-paren-char-p (character-at point))
                        (syntax-space-char-p (character-at point))))
         do (character-offset point 1))
-  (unless skip-last-whitespaces
+  (unless skip-last-whitespaces 
     (skip-whitespace-backward point)))
 
 (defun move-to-string-start (point)
@@ -128,6 +128,10 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
   (ignore-errors
     (let ((prefix (subseq (line-string point) 0 (point-column point))))
       (not (find-if (lambda (char) (not (whitespace-p char))) (coerce prefix 'list))))))
+
+(define-command paredit-insert-newline () ()
+  (insert-character (current-point) #\Newline)
+  (indent-buffer (current-buffer)))
 
 (define-command paredit-insert-paren () ()
   (let ((p (current-point)))
@@ -545,6 +549,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 
 (loop for (k . f) in '((forward-sexp . paredit-forward)
                        (backward-sexp . paredit-backward)
+                       ("Return" . paredit-insert-newline)
                        ("(" . paredit-insert-paren)
                        (")" . paredit-close-parenthesis)
                        ("\"" . paredit-insert-doublequote)

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -28,7 +28,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 (in-package :lem-paredit-mode)
 
 (define-minor-mode paredit-mode
-    (:name "paredit" 
+    (:name "paredit"
      :description "Helps to handle parentheses balanced in your Lisp code."
      :keymap *paredit-mode-keymap*))
 
@@ -124,7 +124,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 (defun whitespace-prefix-p (point)
   (ignore-errors
     (let ((prefix (subseq (line-string point) 0 (point-column point))))
-      (not (find-if (lambda (char) (not (syntax-space-char-p char))) prefix)))))
+      (not (find-if-not #'syntax-space-char-p prefix)))))
 
 (defun forward-skip-whitespace (point)
   "Move point to the next character that is not whitespace."

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -67,7 +67,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 (define-command paredit-backward (&optional (n 1)) ("p")
   (handler-case
       (backward-sexp n)
-    (error ()
+    (error () 
       (unless (start-buffer-p (current-point))
         (lem:backward-up-list (current-point))))))
 
@@ -546,7 +546,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 
 (loop for (k . f) in '((forward-sexp . paredit-forward)
                        (backward-sexp . paredit-backward)
-                       ("Return" . paredit-insert-newline)
+                       ("C-Return" . paredit-insert-newline)
                        ("(" . paredit-insert-paren)
                        (")" . paredit-close-parenthesis)
                        ("\"" . paredit-insert-doublequote)

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -121,13 +121,10 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
       (sharp-n-literal-p #\A p)
       (sharp-n-literal-p #\= p)))
 
-(defun whitespace-p (char)
-  (find char str:*whitespaces*))
-
 (defun whitespace-prefix-p (point)
   (ignore-errors
     (let ((prefix (subseq (line-string point) 0 (point-column point))))
-      (not (find-if (lambda (char) (not (whitespace-p char))) (coerce prefix 'list))))))
+      (not (find-if (lambda (char) (not (syntax-space-char-p char))) (coerce prefix 'list))))))
 
 (define-command paredit-insert-newline () ()
   (insert-character (current-point) #\Newline)
@@ -229,7 +226,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
          (delete-previous-char (1+ (point-column p)))
          (let* ((new-p (current-point))
                 (c (character-at new-p)))
-           (unless (or (whitespace-p c) (eq #\) c))
+           (unless (or (syntax-space-char-p c) (eq #\) c))
              (insert-character new-p #\ )))
          (indent-current-buffer))
         (t

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -46,7 +46,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
                    (or (syntax-closed-paren-char-p (character-at point))
                        (syntax-space-char-p (character-at point))))
         do (character-offset point 1))
-  (unless skip-last-whitespaces 
+  (unless skip-last-whitespaces
     (skip-whitespace-backward point)))
 
 (defun move-to-string-start (point)

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -28,7 +28,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 (in-package :lem-paredit-mode)
 
 (define-minor-mode paredit-mode
-    (:name "paredit"
+    (:name "paredit" 
      :description "Helps to handle parentheses balanced in your Lisp code."
      :keymap *paredit-mode-keymap*))
 
@@ -124,7 +124,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 (defun whitespace-prefix-p (point)
   (ignore-errors
     (let ((prefix (subseq (line-string point) 0 (point-column point))))
-      (not (find-if (lambda (char) (not (syntax-space-char-p char))) (coerce prefix 'list))))))
+      (not (find-if (lambda (char) (not (syntax-space-char-p char))) prefix)))))
 
 (defun forward-skip-whitespace (point)
   "Move point to the next character that is not whitespace."
@@ -134,6 +134,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
         :do (character-offset point 1)))
 
 (define-command paredit-insert-newline () ()
+  "Insert newline, and correct indentation."
   (insert-character (current-point) #\Newline)
   (indent-current-buffer))
 

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -124,7 +124,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 (defun whitespace-p (char)
   (find char str:*whitespaces*))
 
-(defun paredit-whitespace-prefix (point)
+(defun whitespace-prefix-p (point)
   (ignore-errors
     (let ((prefix (subseq (line-string point) 0 (point-column point))))
       (not (find-if (lambda (char) (not (whitespace-p char))) (coerce prefix 'list))))))
@@ -224,14 +224,14 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
              (eql (character-at p -1) #\|))
          (backward-char))
         ;; go back line when point prefixed with whitespace
-        ((paredit-whitespace-prefix p)
+        ((whitespace-prefix-p p)
          (delete-trailing-whitespace)
          (delete-previous-char (1+ (point-column p)))
          (let* ((new-p (current-point))
                 (c (character-at new-p)))
            (unless (or (whitespace-p c) (eq #\) c))
              (insert-character new-p #\ )))
-         (indent-buffer (current-buffer)))
+         (indent-current-buffer))
         (t
          (delete-previous-char))))
     (paredit-backward-delete (1- n))))

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -67,7 +67,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 (define-command paredit-backward (&optional (n 1)) ("p")
   (handler-case
       (backward-sexp n)
-    (error () 
+    (error ()
       (unless (start-buffer-p (current-point))
         (lem:backward-up-list (current-point))))))
 
@@ -125,6 +125,13 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
   (ignore-errors
     (let ((prefix (subseq (line-string point) 0 (point-column point))))
       (not (find-if (lambda (char) (not (syntax-space-char-p char))) (coerce prefix 'list))))))
+
+(defun forward-skip-whitespace (point)
+  "Move point to the next character that is not whitespace."
+  (loop :for p := (character-at point)
+        :while (syntax-space-char-p p)
+        :while (not (eq #\Newline p))
+        :do (character-offset point 1)))
 
 (define-command paredit-insert-newline () ()
   (insert-character (current-point) #\Newline)
@@ -220,8 +227,9 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
              (eql (character-at p -1) #\")
              (eql (character-at p -1) #\|))
          (backward-char))
-        ;; go back line when point prefixed with whitespace
+        ;; Go back line when point prefixed with whitespace
         ((whitespace-prefix-p p)
+         (forward-skip-whitespace p)
          (delete-trailing-whitespace)
          (delete-previous-char (1+ (point-column p)))
          (let* ((new-p (current-point))

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -131,7 +131,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 
 (define-command paredit-insert-newline () ()
   (insert-character (current-point) #\Newline)
-  (indent-buffer (current-buffer)))
+  (indent-current-buffer))
 
 (define-command paredit-insert-paren () ()
   (let ((p (current-point)))
@@ -227,10 +227,10 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
         ((paredit-whitespace-prefix p)
          (delete-trailing-whitespace)
          (delete-previous-char (1+ (point-column p)))
-         (let* ((p (current-point))
-                (c (character-at p)))
-           (unless (or (whitespace-p c)) (eq #\) c)
-             (insert-character p #\ )))
+         (let* ((new-p (current-point))
+                (c (character-at new-p)))
+           (unless (or (whitespace-p c) (eq #\) c))
+             (insert-character new-p #\ )))
          (indent-buffer (current-buffer)))
         (t
          (delete-previous-char))))

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -28,7 +28,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 (in-package :lem-paredit-mode)
 
 (define-minor-mode paredit-mode
-    (:name "paredit"
+    (:name "paredit" 
      :description "Helps to handle parentheses balanced in your Lisp code."
      :keymap *paredit-mode-keymap*))
 
@@ -224,7 +224,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
          (delete-trailing-whitespace)
          (delete-previous-char (1+ (point-column p)))
          (unless (eq #\) (character-at (current-point)))
-           (insert-string (current-point) " ")))
+           (insert-character (current-point) #\ )))
         (t
          (delete-previous-char))))
     (paredit-backward-delete (1- n))))

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -78,7 +78,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
   (let ((len (length (line-string point))))
     (or (zerop len)
         (>= (point-charpos point)
-            (1- len)))))
+             (1- len)))))
 
 (defun integer-char-p (char)
   (< (char-code #\0) (char-code char) (char-code #\9)))
@@ -120,6 +120,14 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
       (sharp-literal-p #\- p)
       (sharp-n-literal-p #\A p)
       (sharp-n-literal-p #\= p)))
+
+(defun whitespace-p (char)
+  (find char str:*whitespaces*))
+
+(defun paredit-whitespace-prefix (point)
+  (ignore-errors
+    (let ((prefix (subseq (line-string point) 0 (point-column point))))
+      (not (find-if (lambda (char) (not (whitespace-p char))) (coerce prefix 'list))))))
 
 (define-command paredit-insert-paren () ()
   (let ((p (current-point)))


### PR DESCRIPTION
I have added some quality of life improvements for paredit. 
1.  When you enter a backspace when everything before `#'current-point` on a line is whitespace, it goes back a line and conditionally inserts a space.  
2.  When you press "Return", it will automatically fix the indentation using `#'indent-current-buffer`.

Example of using it:
[Screencast from 2024-01-23 18-25-05.webm](https://github.com/lem-project/lem/assets/43155857/0c7ebb37-44e0-46f6-b580-6449886f013c)
