### PR TITLE
Add FreeBSD support

### DIFF
--- a/frontends/sdl2/keyboard.lisp
+++ b/frontends/sdl2/keyboard.lisp
@@ -131,6 +131,26 @@
   (not (modifier-ctrl modifier)))
 
 (defmethod handle-text-input ((platform lem-sdl2/platform:linux) text)
+  (handle-text-input-unix text))
+
+(defmethod handle-key-down ((platform lem-sdl2/platform:linux) key-event)
+  (handle-key-down-unix key-event))
+
+(defmethod handle-key-up ((platform lem-sdl2/platform:linux) key-event)
+  (handle-key-up-unix key-event))
+
+;; freebsd
+(defmethod handle-text-input ((platform lem-sdl2/platform:freebsd) text)
+  (handle-text-input-unix text))
+
+(defmethod handle-key-down ((platform lem-sdl2/platform:freebsd) key-event)
+  (handle-key-down-unix key-event))
+
+(defmethod handle-key-up ((platform lem-sdl2/platform:freebsd) key-event)
+  (handle-key-up-unix key-event))
+
+;; shared freebsd, linux
+(defun handle-text-input-unix (text)
   (when (modifier-is-accept-text-input-p *modifier*)
     (loop :for c :across text
           :do (multiple-value-bind (sym text-input-p) (convert-to-sym (char-code c))
@@ -142,7 +162,7 @@
                   (when text-input-p
                     (send-key-event key)))))))
 
-(defmethod handle-key-down ((platform lem-sdl2/platform:linux) key-event)
+(defun handle-key-down-unix (key-event)
   (let ((modifier (key-event-modifier key-event))
         (code (key-event-code key-event)))
     (update-modifier *modifier* modifier)
@@ -158,7 +178,7 @@
                                                 :sym sym)))
           (send-key-event key))))))
 
-(defmethod handle-key-up ((platform lem-sdl2/platform:linux) key-event)
+(defun handle-key-up-unix (key-event)
   (update-modifier *modifier* (key-event-modifier key-event)))
 
 ;;

--- a/frontends/sdl2/platform.lisp
+++ b/frontends/sdl2/platform.lisp
@@ -3,6 +3,7 @@
   (:export :platform
            :linux
            :mac
+           :freebsd
            :windows
            :get-platform))
 (in-package :lem-sdl2/platform)
@@ -11,6 +12,7 @@
 (defclass linux (platform) ())
 (defclass windows (platform) ())
 (defclass mac (platform) ())
+(defclass freebsd (platform) ())
 
 (defvar *platform* nil)
 
@@ -23,6 +25,8 @@
                  (make-instance 'linux))
                 ("Mac OS X"
                  (make-instance 'mac))
+                ("FreeBSD"
+                 (make-instance 'freebsd))
                 ("Windows"
                  (make-instance 'windows))
                 (otherwise


### PR DESCRIPTION
Adds FreeBSD as a platform. The methods for handling input on linux appear to work on FreeBSD too. Moves the common code to functions and calls them from the :linux and :freebsd methods.

