### PR TITLE
remove old define-command

### DIFF
--- a/extensions/go-mode/go-mode.lisp
+++ b/extensions/go-mode/go-mode.lisp
@@ -142,9 +142,6 @@
   (self-insert n)
   (indent))
 
-(define-command gofmt () ()
-  (filter-buffer "gofmt"))
-
 (define-command godoc (command)
     ((prompt-for-string "godoc "))
   (let ((text


### PR DESCRIPTION
This should fix Ejdă's error, but I can't recreate it, so please let him test it first.