### PR TITLE
Make initialisation of Quicklisp conditional on whether it is present

### DIFF
--- a/src/lem.lisp
+++ b/src/lem.lisp
@@ -204,8 +204,7 @@ See scripts/build-ncurses.lisp or scripts/build-sdl2.lisp"
 (defun init (args)
   (unless (equal (funcall 'user-homedir-pathname) ;; funcall for sbcl optimization
                  *original-home*)
-    ;; (init-quicklisp (merge-pathnames "quicklisp/" (lem-home)))
-    )
+    (when uiop:featurep :quicklisp (init-quicklisp (merge-pathnames "quicklisp/" (lem-home)))))
   (run-hooks *before-init-hook*)
   (unless (command-line-arguments-no-init-file args)
     (load-init-file))

--- a/src/lem.lisp
+++ b/src/lem.lisp
@@ -204,7 +204,8 @@ See scripts/build-ncurses.lisp or scripts/build-sdl2.lisp"
 (defun init (args)
   (unless (equal (funcall 'user-homedir-pathname) ;; funcall for sbcl optimization
                  *original-home*)
-    (when uiop:featurep :quicklisp (init-quicklisp (merge-pathnames "quicklisp/" (lem-home)))))
+    (when (uiop:featurep :quicklisp)
+      (init-quicklisp (merge-pathnames "quicklisp/" (lem-home)))))
   (run-hooks *before-init-hook*)
   (unless (command-line-arguments-no-init-file args)
     (load-init-file))

--- a/src/lem.lisp
+++ b/src/lem.lisp
@@ -204,7 +204,8 @@ See scripts/build-ncurses.lisp or scripts/build-sdl2.lisp"
 (defun init (args)
   (unless (equal (funcall 'user-homedir-pathname) ;; funcall for sbcl optimization
                  *original-home*)
-    (init-quicklisp (merge-pathnames "quicklisp/" (lem-home))))
+    ;; (init-quicklisp (merge-pathnames "quicklisp/" (lem-home)))
+    )
   (run-hooks *before-init-hook*)
   (unless (command-line-arguments-no-init-file args)
     (load-init-file))


### PR DESCRIPTION
On some systems (like Guix), Quicklisp is not present. When this is the case, Lem shows a disruptive error on startup. Lem initialisation continues after this, but getting rid of the needless error would be nice. 