### PR TITLE
Change log-pathname from being set at compile time

### DIFF
--- a/lib/language-client/request.lisp
+++ b/lib/language-client/request.lisp
@@ -13,21 +13,21 @@
 
 (cl-package-locks:lock-package :lem-lsp-mode/request)
 
-(defvar *log-pathname* (merge-pathnames "language-client.log" (lem:lem-logdir-pathname)))
 (defvar *log-enable* t)
 (defvar *log-mutex* (bt:make-lock))
 
 (defun do-log (string &rest args)
   (when *log-enable*
     (bt:with-lock-held (*log-mutex*)
-      (ensure-directories-exist *log-pathname*)
-      (with-open-file (out *log-pathname*
-                           :direction :output
-                           :if-exists :append
-                           :if-does-not-exist :create)
-        (fresh-line out)
-        (apply #'format out string args)
-        (terpri out)))))
+      (let ((log-pathname (merge-pathnames "language-client.log" (lem:lem-logdir-pathname))))
+        (ensure-directories-exist log-pathname)
+        (with-open-file (out log-pathname
+                             :direction :output
+                             :if-exists :append
+                             :if-does-not-exist :create)
+          (fresh-line out)
+          (apply #'format out string args)
+          (terpri out))))))
 
 (defun pretty-json (params)
   (with-output-to-string (stream)


### PR DESCRIPTION
Fix lsp client to work when built using guix.
The client logs to the file specified by `lem-language-client/request::*log-pathname*`
This variable is calculated at compile time, and in guix the build environment does not have access to the user directories, which means that the variable is set incorrectly to `/gnu/store/...`
I imagine this would be preferable to fix anyway, the change makes the variable a bit more resilient to changes in the environment