### PR TITLE
Remove hard dependency on quicklisp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ build/*
 
 *.lx64fsl
 .qlot
+/systems/

--- a/lem.asd
+++ b/lem.asd
@@ -85,7 +85,7 @@
                              (:file "file")
                              (:file "indent")))
                (:file "internal-packages")
-               (:file "quicklisp-utils")
+               (:file "system-utils")
                (:file "version")
                (:file "config")
                (:file "errors")

--- a/src/commands/other.lisp
+++ b/src/commands/other.lisp
@@ -59,7 +59,7 @@
                     (format nil "~D M-x " arg)
                     "M-x ")
                 :completion-function (lambda (str)
-                                       (sort 
+                                       (sort
                                         (if (find #\- str)
                                             (completion-hypheen str (all-command-names))
                                             (completion str (all-command-names)))
@@ -81,7 +81,7 @@
     ((prompt-for-library "load library: " :history-symbol 'load-library))
   "Load the Lisp library named NAME."
   (message "Loading ~A." name)
-  (cond ((ignore-errors (maybe-quickload (format nil "lem-~A" name) :silent t))
+  (cond ((ignore-errors (maybe-load-systems (format nil "lem-~A" name) :silent t))
          (message "Loaded ~A." name))
         (t (message "Can't find Library ~A." name))))
 

--- a/src/interface.lisp
+++ b/src/interface.lisp
@@ -26,7 +26,7 @@
                   (0
                    (when errorp
                      (error "Implementation does not exist.~
-                             (probably because you didn't quickload lem-ncurses)")))
+                             (probably because you didn't load the lem-ncurses system)")))
                   (1
                    (first classes))
                   (otherwise

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -63,7 +63,7 @@
    :yank-from-clipboard-or-killring)
   ;; quicklisp-utils.lisp
   (:export
-   :maybe-quickload)
+   :maybe-load-systems)
   ;; config.lisp
   (:export
    :lem-home
@@ -576,7 +576,7 @@
   ;; format.lisp
   (:export
    :*auto-format*
-   :register-formatter 
+   :register-formatter
    :register-formatters
    :format-buffer))
 #+sbcl

--- a/src/lem.lisp
+++ b/src/lem.lisp
@@ -260,7 +260,7 @@ See scripts/build-ncurses.lisp or scripts/build-sdl2.lisp"
         (t
          (let ((implementation (get-default-implementation :errorp nil)))
            (unless implementation
-             (ql:quickload :lem-ncurses)
+             (maybe-load-systems :lem-ncurses)
              (setf implementation (get-default-implementation)))
            (invoke-frontend
             (lambda (&optional initialize finalize)

--- a/src/quicklisp-utils.lisp
+++ b/src/quicklisp-utils.lisp
@@ -1,9 +1,0 @@
-(in-package :lem-core)
-
-(defun maybe-quickload (systems &rest keys &key error-on-failure-p &allow-other-keys)
-  (cond
-    ((uiop:featurep :quicklisp)
-     (apply #'uiop:symbol-call :quicklisp :quickload systems keys))
-    (t (if error-on-failure-p
-           (apply #'asdf:load-systems systems)
-           (ignore-errors (apply #'asdf:load-systems systems))))))

--- a/src/site-init.lisp
+++ b/src/site-init.lisp
@@ -61,7 +61,7 @@
       (update-site-init-inits)
       (asdf:load-asd (site-init-path))
       (let ((*package* (find-package :lem-user)))
-        (maybe-quickload system-name :silent t)))))
+        (maybe-load-systems system-name :silent t)))))
 
 (define-command site-init-add-dependency (symbols)
     ((prompt-for-library "library: " :history-symbol 'load-library))
@@ -71,7 +71,7 @@
         :for s :in (uiop:split-string symbols)
         :for key := (read-from-string (format nil ":lem-~A" s))
         :do (unless (find key depends-on)
-              (maybe-quickload key :silent t)
+              (maybe-load-systems key :silent t)
               (push key depends-on))
         :finally (setf (getf (cddr site-init) :depends-on) depends-on)
                  (setf (site-init) site-init)

--- a/src/system-utils.lisp
+++ b/src/system-utils.lisp
@@ -6,7 +6,9 @@
  systems. Loader behavior is modified by VERBOSE and SILENT."
   (unless (listp systems)
     (setf systems (list systems)))
-  (handler-case
+  (handler-bind ((error (lambda (e)
+                          (unless error-on-failure-p
+                            (return-from maybe-load-systems nil)))))
       (flet ((try-load-system (system)
                (or
                 (when (find-package '#:OCICL-RUNTIME)
@@ -20,8 +22,4 @@
                 (when (find-package '#:ASDF)
                   (funcall (find-symbol "LOAD-SYSTEM" '#:ASDF) system))
                 (error "Unable to find any system-loading mechanism."))))
-        (mapcar #'try-load-system systems))
-    (error (e)
-      (if error-on-failure-p
-          (error e)
-          nil))))
+        (mapcar #'try-load-system systems))))

--- a/src/system-utils.lisp
+++ b/src/system-utils.lisp
@@ -7,6 +7,7 @@
   (unless (listp systems)
     (setf systems (list systems)))
   (handler-bind ((error (lambda (e)
+                          (declare (ignore e))
                           (unless error-on-failure-p
                             (return-from maybe-load-systems nil)))))
       (flet ((try-load-system (system)

--- a/src/system-utils.lisp
+++ b/src/system-utils.lisp
@@ -1,0 +1,27 @@
+(in-package :lem-core)
+
+(defun maybe-load-systems (systems &key (silent t) verbose error-on-failure-p)
+  "Load system SYSTEMS, potentially downloading them from an external
+ repository.  SYSTEMS may be a single system or a list of
+ systems. Loader behavior is modified by VERBOSE and SILENT."
+  (unless (listp systems)
+    (setf systems (list systems)))
+  (handler-case
+      (flet ((try-load-system (system)
+               (or
+                (when (find-package '#:OCICL-RUNTIME)
+                  (progv (list (find-symbol "*DOWNLOAD*" '#:OCICL-RUNTIME)
+                               (find-symbol "*VERBOSE*" '#:OCICL-RUNTIME))
+                      (list t (or verbose (not silent)))
+                    (funcall (find-symbol "LOAD-SYSTEM" '#:ASDF) system)))
+                (when (find-package '#:QUICKLISP)
+                  (funcall (find-symbol "QUICKLOAD" '#:QUICKLISP)
+                           system :verbose verbose :silent silent))
+                (when (find-package '#:ASDF)
+                  (funcall (find-symbol "LOAD-SYSTEM" '#:ASDF) system))
+                (error "Unable to find any system-loading mechanism."))))
+        (mapcar #'try-load-system systems))
+    (error (e)
+      (if error-on-failure-p
+          (error e)
+          nil))))


### PR DESCRIPTION
This patch removes a hard dependency on quicklisp, and allows for the use of ocicl instead.  There should be no change for quicklisp users, but users with the `ocicl-runtime` package loaded will pull dependencies from an ocicl OCI registry.