### PR TITLE
Make DIRECTORY-MODE-MARK-REGEXP keep old marks.

### DIFF
--- a/src/ext/directory-mode.lisp
+++ b/src/ext/directory-mode.lisp
@@ -429,9 +429,11 @@
   (filter-marks (current-point) (constantly nil)))
 
 (define-command directory-mode-mark-regexp (regex) ("sRegex: ")
-  (filter-marks (current-point)
-                (lambda (p)
-                  (ppcre:scan regex (get-name p)))))
+  (let ((scanner (ppcre:create-scanner regex)))
+    (filter-marks (current-point)
+                  (lambda (p)
+                    (or (get-mark p)
+                        (ppcre:scan scanner (get-name p)))))))
 
 (defun query-replace-marked-files (query-function)
   (destructuring-bind (before after)


### PR DESCRIPTION
I think it is more useful to keep already marked lines and make DIRECTORY-MODE-MARK-REGEXP just add new marks.
The user can always remove all existing marks before calling this function, or create a wrapper command which does so.

Currently, it can be quite complicated to mark many different kinds of files with a single regex.