### PR TITLE
Adds more mark commands for directory-mode.

### DIFF
--- a/src/ext/directory-mode.lisp
+++ b/src/ext/directory-mode.lisp
@@ -49,12 +49,18 @@
 (define-key *directory-mode-keymap* "o" 'directory-mode-find-file-next-window)
 (define-key *directory-mode-keymap* "n" 'directory-mode-next-line)
 (define-key *directory-mode-keymap* "p" 'directory-mode-previous-line)
+(define-key *directory-mode-keymap* "M-}" 'directory-mode-next-mark)
+(define-key *directory-mode-keymap* "M-{" 'directory-mode-previous-mark)
 (define-key *directory-mode-keymap* "m" 'directory-mode-mark-and-next-line)
 (define-key *directory-mode-keymap* "u" 'directory-mode-unmark-and-next-line)
 (define-key *directory-mode-keymap* "U" 'directory-mode-unmark-and-previous-line)
 (define-key *directory-mode-keymap* "t" 'directory-mode-toggle-marks)
 (define-key *directory-mode-keymap* "* !" 'directory-mode-unmark-all)
 (define-key *directory-mode-keymap* "* %" 'directory-mode-mark-regexp)
+(define-key *directory-mode-keymap* "* /" 'directory-mode-mark-directories)
+(define-key *directory-mode-keymap* "* @" 'directory-mode-mark-links)
+(define-key *directory-mode-keymap* "* C-n" 'directory-mode-next-mark)
+(define-key *directory-mode-keymap* "* C-p" 'directory-mode-previous-mark)
 (define-key *directory-mode-keymap* "Q" 'directory-mode-query-replace)
 (define-key *directory-mode-keymap* "D" 'directory-mode-delete-files)
 (define-key *directory-mode-keymap* "C" 'directory-mode-copy-files)
@@ -433,12 +439,94 @@
 (define-command directory-mode-unmark-all () ()
   (filter-marks (current-point) (constantly nil)))
 
-(define-command directory-mode-mark-regexp (regex) ("sRegex: ")
+(define-command directory-mode-mark-regexp (regex &optional arg) ("sRegex: " "P")
+  "Mark all files matching the regular expression REGEX.
+With prefix argument ARG, unmark all those files."
   (let ((scanner (ppcre:create-scanner regex)))
     (filter-marks (current-point)
                   (lambda (p)
-                    (or (get-mark p)
-                        (ppcre:scan scanner (get-name p)))))))
+                    (if (ppcre:scan scanner (get-name p))
+                        (not arg)
+                        (get-mark p))))))
+
+(define-command directory-mode-mark-directories (&optional arg) ("P")
+  "Mark all directories in the current buffer except '..'.
+With prefix argument ARG, unmark all those directories."
+  (filter-marks (current-point)
+                (lambda (p)
+                  (line-start p)
+                  (move-to-file-position p)
+                  (if (eq 'directory-attribute (text-property-at p :attribute))
+                      (not arg)
+                      (get-mark p)))))
+
+(define-command directory-mode-mark-links (&optional arg) ("P")
+  "Mark all symbolic links in the current buffer.
+With prefix argument ARG, unmark all those links."
+  (filter-marks (current-point)
+                (lambda (p)
+                  (line-start p)
+                  (move-to-file-position p)
+                  (if (eq 'link-attribute (text-property-at p :attribute))
+                      (not arg)
+                      (get-mark p)))))
+
+(define-command directory-mode-mark-suffix (suffix &optional arg) ("sSuffix: " "P")
+  "Mark all files with the given SUFFIX.
+The provided SUFFIX is a string, and not a file extenion, meaning every file with
+a name ending in SUFFIX will be marked.
+With prefix argument ARG, unmark all those files."
+  (filter-marks (current-point)
+                (lambda (p)
+                  (let ((name (get-name p)))
+                    ;; Use < so exact matches are not marked
+                    (if (and (< (length suffix) (length name))
+                             (string= name suffix :start1 (- (length name) (length suffix))))
+                        (not arg)
+                        (get-mark p))))))
+
+(define-command directory-mode-mark-extension (extension &optional arg) ("sExtension: " "P")
+  "Mark all files with the given EXTENSION.
+A '.' is prepended to the EXTENSION if not present.
+With prefix argument ARG, unmark all those files."
+  ;; Support empty extension, which will mark all files ending with a '.'.
+  (when (or (= 0 (length extension))
+            (char/= (aref extension 0) #\.))
+    (setf extension (concatenate 'string "." extension)))
+  (directory-mode-mark-suffix extension arg))
+
+(define-command directory-mode-next-mark (n) ("p")
+  "Move to the next Nth marked entry."
+  (cond ((= 0 n)
+         nil)
+        ((< n 0)
+         (directory-mode-previous-mark (- n)))
+        (t (let* ((all-marks (delete-if (lambda (p)
+                                          (point< p (current-point)))
+                                        (marked-lines (current-point))))
+                  (result (nth (- n 1) all-marks)))
+             (if result
+                 (progn
+                   (move-point (current-point) result)
+                   (move-to-file-position (current-point)))
+                 (editor-error "No next mark"))))))
+
+(define-command directory-mode-previous-mark (n) ("p")
+  "Move to the previous Nth marked entry."
+  (cond ((= 0 n) nil)
+        ((< n 0) (directory-mode-next-mark (- n)))
+        (t (with-point ((point (current-point)))
+             (line-start point)
+             (let* ((all-marks (delete-if (lambda (p)
+                                            (point>= p point))
+                                          (marked-lines point)))
+                    (result (last all-marks n)))
+               (if (and result
+                        (= n (length result)))
+                   (progn
+                     (move-point (current-point) (car result))
+                     (move-to-file-position (current-point)))
+                   (editor-error "No previous mark")))))))
 
 (defun query-replace-marked-files (query-function)
   (destructuring-bind (before after)


### PR DESCRIPTION
The following new commands have been added:

DIRECTORY-MODE-MARK-DIRECTORIES
> Mark all directories in the current buffer except '..'.
> With prefix argument ARG, unmark all those directories.

DIRECTORY-MODE-MARK-LINKS
> Mark all symbolic links in the current buffer.
> With prefix argument ARG, unmark all those links.

DIRECTORY-MODE-MARK-SUFFIX
> Mark all files with the given SUFFIX.
> The provided SUFFIX is a string, and not a file extenion, meaning every file with
> a name ending in SUFFIX will be marked.
> With prefix argument ARG, unmark all those files.

DIRECTORY-MODE-MARK-EXTENSION
> Mark all files with the given EXTENSION.
> A '.' is prepended to the EXTENSION if not present.
> With prefix argument ARG, unmark all those files.

DIRECTORY-MODE-NEXT-MARK
> Move to the next Nth marked entry.

DIRECTORY-MODE-PREVIOUS-MARK
> Move to the previous Nth marked entry.

The DIRECTORY-MODE-MARK-REGEXP command has an additional prefix argument to behave like the other commands.