### PR TITLE
Enabled focusing leftside window with mouse in ncurses frontend

### DIFF
--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -181,6 +181,7 @@
    :frame-floating-prompt-window
    :frame-prompt-window
    :frame-message-window
+   :frame-leftside-window
    :notify-frame-redisplay-required
    :map-frame
    :get-frame
@@ -333,6 +334,7 @@
   ;; side-window.lisp
   (:export
    :side-window
+   :side-window-p
    :make-leftside-window
    :delete-leftside-window)
   ;; popup.lisp

--- a/src/window/side-window.lisp
+++ b/src/window/side-window.lisp
@@ -38,3 +38,6 @@
                        (window-height window))
       (balance-windows)
       t)))
+
+(defun side-window-p (window)
+  (typep window 'side-window))


### PR DESCRIPTION
With the ncurses front-end, I could not switch the focus to the left side window (Filer window) by clicking on it. The mouse support was enabled by loading the `mouse-sgr1006` contrib library.

This PR fixes it by considering all the windows when calculating the window to which it should shift focus to.