### PR TITLE
Interactive markdown

### DIFF
--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -133,6 +133,8 @@
   "Register evaluator for Lisp blocks."
   (lem-lisp-mode:check-connection)
   (lem-lisp-mode:lisp-eval-async
-   `(handler-case (eval (read-from-string (format nil "(progn ~a)" ,string)))
-      (error (c) (format nil "Error: ~a" c)))
+   (read-from-string (format nil "(progn ~a)" string))
    callback))
+
+;; `(handler-case (eval (read-from-string (format nil "(progn ~a)" ,string)))
+;;    (error (c) (format nil "Error: ~a" c)))

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -12,12 +12,11 @@
          (lambda (,string ,callback)
            ,@body)))
 
-(defmacro with-constant-position (&body body)
-  "This allows you to move around the buffer point without worry."
-  `(let* ((buf (current-buffer))
-          (p (copy-point (buffer-point buf))))
-     (prog1 ,@body
-       (move-point (buffer-point buf) p))))
+(defmacro with-constant-position ((point) &body body)
+  "This allows you to move around the point without worry."
+  `(let ((tmp (copy-point ,point)))
+     (prog1 (progn ,@body)
+       (move-point ,point tmp))))
 
 (defmacro when-markdown-mode (&body body)
   "Ensure the major mode is markdown-mode and alert the user if not."
@@ -44,59 +43,64 @@
 (defun block-at-point (point)
   "Ugly hack to get the string in a code block at point."
   (search-backward-regexp point "```")
-  (when-let ((lang (block-fence-lang (str:trim (line-string (current-point))))))
-    (search-forward (current-point) (format nil "~%"))
-    (let ((start (copy-point (current-point))))
-      (search-forward-regexp (current-point) "```")
-      (search-backward (current-point) (format nil "~%"))
-      (let ((end (current-point)))
+  (when-let ((lang (block-fence-lang (str:trim (line-string point)))))
+    (search-forward point (format nil "~%"))
+    (let ((start (copy-point point)))
+      (search-forward-regexp point "```")
+      (search-backward point (format nil "~%"))
+      (let ((end point))
         (values lang (points-to-string start end))))))
 
-(define-command kill-block-eval-result () ()
+(define-command kill-block-eval-result (&optional (point (current-point))) ()
   "Searches for a result block below the current code block, and kills it."
   (when-markdown-mode
-    (with-constant-position
-      (when (block-at-point (current-point))
-        (search-forward-regexp (current-point) "```")
-        (line-offset (current-point) 2)
-        (when (equal "result" (block-fence-lang (line-string (current-point))))
-          (loop :while (not (equal "```" (line-string (current-point))))
+    (with-constant-position (point)
+      (when (block-at-point point)
+        (search-forward-regexp point "```")
+        (line-offset point 2)
+        (when (equal "result" (block-fence-lang (line-string point)))
+          (loop :while (not (equal "```" (line-string point)))
                 :do (kill-whole-line)
-                :do (line-offset (current-point) 1))
+                :do (line-offset point 1))
           (kill-whole-line)
           (kill-whole-line))))))
 
-(defun pop-up-eval-result (result)
+(defun pop-up-eval-result (point result)
   "Display results of evaluation in a popup buffer."
+  (declare (ignore point))
   (pop-up-buffer "*literate*" (format nil "~a" result)))
 
 (defun insert-eval-result (point result)
   "Insert results of evaluation in a code block."
-  (with-constant-position
-    (kill-block-eval-result)
+  (with-constant-position (point)
     (block-at-point point)
     (search-forward-regexp point "```")
     (insert-string point (format nil "~%~%```result~%~a~%```" result)))
   (redraw-display))
 
-(defun eval-block-internal (handler)
+(defun eval-block-internal (point handler)
   "Evaluate code block and apply handler to result."
-  (with-constant-position
-    (multiple-value-bind (lang block) (block-at-point (current-point))
+  (with-constant-position (point)
+    (multiple-value-bind (lang block) (block-at-point (copy-point point))
       (when lang
         (if-let ((evaluator (gethash lang *block-evaluators*)))
-          (funcall evaluator block handler)
+          (funcall evaluator block (curry handler point))
           (message "No evaluator registered for ~a." lang))))))
 
 (define-command eval-block () ()
   "Evaluate current markdown code block and display results in popup."
   (when-markdown-mode
-    (eval-block-internal #'pop-up-eval-result)))
+    (eval-block-internal
+     (copy-point (current-point))
+     #'pop-up-eval-result)))
 
 (define-command eval-block-and-insert () ()
   "Evaluate current markdown code block and display results in popup."
   (when-markdown-mode
-    (eval-block-internal (curry #'insert-eval-result (current-point)))))
+    (kill-block-eval-result)
+    (eval-block-internal
+     (copy-point (current-point))
+     #'insert-eval-result)))
 
 ;;
 ;; Default evaluators:

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -22,7 +22,8 @@
   "This allows you to move around the point without worry."
   `(let ((tmp (copy-point ,point)))
      (prog1 (progn ,@body)
-       (move-point ,point tmp))))
+       (move-point ,point tmp)
+       (delete-point tmp))))
 
 (defmacro when-markdown-mode (&body body)
   "Ensure the major mode is markdown-mode and alert the user if not."
@@ -54,8 +55,9 @@
     (let ((start (copy-point point)))
       (search-forward-regexp point "```")
       (search-backward point (format nil "~%"))
-      (let ((end point))
-        (values lang (points-to-string start end))))))
+      (let ((string (points-to-string start point)))
+        (delete-point start)
+        (values lang string)))))
 
 (define-command markdown-kill-block-result (&optional (point (current-point))) ()
   "Searches for a result block below the current code block, and kills it."
@@ -73,15 +75,16 @@
 
 (defun pop-up-eval-result (point result)
   "Display results of evaluation in a pop-up buffer."
-  (declare (ignore point))
-  (pop-up-buffer "*result*" (format nil "~a" result)))
+  (pop-up-buffer "*result*" (format nil "~a" result))
+  (delete-point point))
 
 (defun insert-eval-result (point result)
   "Insert results of evaluation in a code block."
   (block-at-point point)
   (search-forward-regexp point "```")
   (insert-string point (format nil "~%~%```result~%~a~%```" result))
-  (message "Block evaluated."))
+  (message "Block evaluated.")
+  (delete-point point))
 
 (defun eval-block-internal (point handler)
   "Evaluate code block and apply handler to result."

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -88,7 +88,7 @@
   (delete-point point))
 
 (defun nop-eval-result (point result)
-  "Evaluate block and do nothing with result."
+  "Clean up and do nothing with result."
   (declare (ignore result))
   (message "Block evaluated.")
   (delete-point point))
@@ -107,7 +107,7 @@
     (eval-block-internal (copy-point (current-point)) #'pop-up-eval-result)))
 
 (define-command markdown-eval-block-nop () ()
-  "Evaluate current markdown code block and display results in pop-up."
+  "Evaluate current markdown code block and do nothing with result."
   (when-markdown-mode
     (eval-block-internal (copy-point (current-point)) #'nop-eval-result)))
 

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -102,5 +102,6 @@
      (funcall callback result))))
 
 (define-keys lem-markdown-mode::*markdown-mode-keymap*
-  ("C-c C-c" 'eval-block)
-  ("C-c C-e" 'eval-block-and-insert))
+  ("C-c C-e" 'eval-block)
+  ("C-c C-c" 'eval-block-and-insert)
+  ("C-c C-d" 'kill-block-eval-result))

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -112,8 +112,7 @@
   (lem-lisp-mode:check-connection)
   (lem-lisp-mode:lisp-eval-async
    `(eval (read-from-string ,(format nil "(progn ~a)" string)))
-   (lambda (result)
-     (funcall callback result))))
+   callback))
 
 ;;
 ;; Keybindings

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -69,7 +69,7 @@
 (defun pop-up-eval-result (point result)
   "Display results of evaluation in a popup buffer."
   (declare (ignore point))
-  (pop-up-buffer "*literate*" (format nil "~a" result)))
+  (pop-up-buffer "*result*" (format nil "~a" result)))
 
 (defun insert-eval-result (point result)
   "Insert results of evaluation in a code block."

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -111,7 +111,7 @@
   "Register evaluator for Lisp blocks."
   (lem-lisp-mode:check-connection)
   (lem-lisp-mode:lisp-eval-async
-   (read-from-string (format nil "(progn ~a)" string))
+   `(eval (read-from-string ,(format nil "(progn ~a)" string)))
    (lambda (result)
      (funcall callback result))))
 

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -76,12 +76,12 @@
     (block-at-point point)
     (search-forward-regexp point "```")
     (insert-string point (format nil "~%~%```result~%~a~%```" result)))
-  (redraw-display))
+  (message "Block evaluated."))
 
 (defun eval-block-internal (point handler)
   "Evaluate code block and apply handler to result."
   (with-constant-position (point)
-    (multiple-value-bind (lang block) (block-at-point (copy-point point))
+    (multiple-value-bind (lang block) (block-at-point point)
       (when lang
         (if-let ((evaluator (gethash lang *block-evaluators*)))
           (funcall evaluator block (curry handler point))

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -45,11 +45,24 @@
       (let ((end (current-point)))
         (values lang (points-to-string start end))))))
 
+(defun delete-old-result ()
+  "Searches for a result block below the current code block, and kills it."
+  (with-constant-position
+    (search-forward-regexp (current-point) "```")
+    (line-offset (current-point) 2)
+    (when (equal "result" (block-fence-lang (line-string (current-point))))
+      (loop :while (not (equal "```" (line-string (current-point))))
+            :do (kill-whole-line)
+            :do (line-offset (current-point) 1))
+      (kill-whole-line)
+      (kill-whole-line))))
+
 (defun pop-up-eval-result (result)
   "Display results of evaluation."
   (pop-up-buffer "*literate*" (format nil "~a" result)))
 
 (defun insert-eval-result (result)
+  (delete-old-result)
   (search-forward-regexp (current-point) "```")
   (insert-string (current-point)
                  (format nil "~%~%```result~%~a~%```" result))

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -6,6 +6,7 @@
 
 (define-keys lem-markdown-mode::*markdown-mode-keymap*
   ("C-c C-e" 'markdown-eval-block)
+  ("C-c C-r" 'markdown-eval-block-nop)
   ("C-c C-c" 'markdown-eval-block-and-insert)
   ("C-c C-d" 'markdown-kill-block-result))
 
@@ -86,6 +87,12 @@
   (message "Block evaluated.")
   (delete-point point))
 
+(defun nop-eval-result (point result)
+  "Evaluate block and do nothing with result."
+  (declare (ignore result))
+  (message "Block evaluated.")
+  (delete-point point))
+
 (defun eval-block-internal (point handler)
   "Evaluate code block and apply handler to result."
   (multiple-value-bind (lang block) (block-at-point point)
@@ -98,6 +105,11 @@
   "Evaluate current markdown code block and display results in pop-up."
   (when-markdown-mode
     (eval-block-internal (copy-point (current-point)) #'pop-up-eval-result)))
+
+(define-command markdown-eval-block-nop () ()
+  "Evaluate current markdown code block and display results in pop-up."
+  (when-markdown-mode
+    (eval-block-internal (copy-point (current-point)) #'nop-eval-result)))
 
 (define-command markdown-eval-block-and-insert () ()
   "Evaluate current markdown code block and display results in pop-up."

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -5,9 +5,9 @@
 (in-package :lem-markdown-mode/interactive)
 
 (define-keys lem-markdown-mode::*markdown-mode-keymap*
-  ("C-c C-e" 'eval-block)
-  ("C-c C-c" 'eval-block-and-insert)
-  ("C-c C-d" 'kill-block-eval-result))
+  ("C-c C-e" 'markdown-eval-block)
+  ("C-c C-c" 'markdown-eval-block-and-insert)
+  ("C-c C-d" 'markdown-kill-block-result))
 
 (defvar *block-evaluators* (make-hash-table :test #'equal)
   "Dispatch table for block evaluators per language.")
@@ -57,7 +57,7 @@
       (let ((end point))
         (values lang (points-to-string start end))))))
 
-(define-command kill-block-eval-result (&optional (point (current-point))) ()
+(define-command markdown-kill-block-result (&optional (point (current-point))) ()
   "Searches for a result block below the current code block, and kills it."
   (when-markdown-mode
     (with-constant-position (point)
@@ -91,15 +91,15 @@
         (funcall evaluator block (curry handler point))
         (message "No evaluator registered for ~a." lang)))))
 
-(define-command eval-block () ()
+(define-command markdown-eval-block () ()
   "Evaluate current markdown code block and display results in pop-up."
   (when-markdown-mode
     (eval-block-internal (copy-point (current-point)) #'pop-up-eval-result)))
 
-(define-command eval-block-and-insert () ()
+(define-command markdown-eval-block-and-insert () ()
   "Evaluate current markdown code block and display results in pop-up."
   (when-markdown-mode
-    (kill-block-eval-result)
+    (markdown-kill-block-result)
     (eval-block-internal (copy-point (current-point)) #'insert-eval-result)))
 
 ;;

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -22,7 +22,7 @@
 (defmacro with-constant-position ((point) &body body)
   "This allows you to move around the point without worry."
   `(let ((tmp (copy-point ,point)))
-     (prog1 (progn ,@body)
+     (unwind-protect (progn ,@body)
        (move-point ,point tmp)
        (delete-point tmp))))
 
@@ -133,5 +133,6 @@
   "Register evaluator for Lisp blocks."
   (lem-lisp-mode:check-connection)
   (lem-lisp-mode:lisp-eval-async
-   `(eval (read-from-string ,(format nil "(progn ~a)" string)))
+   `(handler-case (eval (read-from-string (format nil "(progn ~a)" ,string)))
+      (error (c) (format nil "Error: ~a" c)))
    callback))

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -4,6 +4,11 @@
   (:export :register-block-evaluator))
 (in-package :lem-markdown-mode/interactive)
 
+(define-keys lem-markdown-mode::*markdown-mode-keymap*
+  ("C-c C-e" 'eval-block)
+  ("C-c C-c" 'eval-block-and-insert)
+  ("C-c C-d" 'kill-block-eval-result))
+
 (defvar *block-evaluators* (make-hash-table :test #'equal)
   "Dispatch table for block evaluators per language.")
 
@@ -27,7 +32,7 @@
        (message "Not in markdown mode.")))
 
 (defun pop-up-buffer (name text)
-  "Create a popup with name containing text."
+  "Create a pop-up with name containing text."
   (let ((buffer (make-buffer name)))
     (erase-buffer buffer)
     (with-buffer-read-only buffer nil
@@ -67,7 +72,7 @@
           (kill-whole-line))))))
 
 (defun pop-up-eval-result (point result)
-  "Display results of evaluation in a popup buffer."
+  "Display results of evaluation in a pop-up buffer."
   (declare (ignore point))
   (pop-up-buffer "*result*" (format nil "~a" result)))
 
@@ -87,12 +92,12 @@
         (message "No evaluator registered for ~a." lang)))))
 
 (define-command eval-block () ()
-  "Evaluate current markdown code block and display results in popup."
+  "Evaluate current markdown code block and display results in pop-up."
   (when-markdown-mode
     (eval-block-internal (copy-point (current-point)) #'pop-up-eval-result)))
 
 (define-command eval-block-and-insert () ()
-  "Evaluate current markdown code block and display results in popup."
+  "Evaluate current markdown code block and display results in pop-up."
   (when-markdown-mode
     (kill-block-eval-result)
     (eval-block-internal (copy-point (current-point)) #'insert-eval-result)))
@@ -113,12 +118,3 @@
   (lem-lisp-mode:lisp-eval-async
    `(eval (read-from-string ,(format nil "(progn ~a)" string)))
    callback))
-
-;;
-;; Keybindings
-;;
-
-(define-keys lem-markdown-mode::*markdown-mode-keymap*
-  ("C-c C-e" 'eval-block)
-  ("C-c C-c" 'eval-block-and-insert)
-  ("C-c C-d" 'kill-block-eval-result))

--- a/extensions/markdown-mode/interactive.lisp
+++ b/extensions/markdown-mode/interactive.lisp
@@ -1,0 +1,77 @@
+(defpackage :lem-markdown-mode/interactive
+  (:use :cl :lem)
+  (:import-from #:alexandria :if-let :when-let))
+(in-package :lem-markdown-mode/interactive)
+
+(defvar *block-evaluators* (make-hash-table :test #'equal)
+  "Dispatch table for block evaluators per language.")
+
+(defmacro register-block-evaluator (language (string callback) &body body)
+  "Convenience macro to register block evaluators, wraps setf."
+  `(setf (gethash ,language *block-evaluators*)
+         (lambda (,string ,callback)
+           ,@body)))
+
+(defmacro with-constant-position (&body body)
+  "This allows you to move around the buffer point without worry."
+  `(let* ((buf (current-buffer))
+          (p (copy-point (buffer-point buf))))
+     (prog1 ,@body
+       (move-point (buffer-point buf) p))))
+
+(defun pop-up-buffer (name text)
+  "Create a popup with name containing text."
+  (let ((buffer (make-buffer name)))
+    (erase-buffer buffer)
+    (with-buffer-read-only buffer nil
+      (insert-string (buffer-point buffer) text)
+      (with-pop-up-typeout-window (s buffer)
+        (declare (ignore s))))))
+
+(defun block-fence-lang (fence)
+  "Get language from a block fence string."
+  (let ((str (coerce (cdddr (coerce fence 'list)) 'string)))
+    (unless (str:emptyp str)
+      str)))
+
+(defun block-at-point (point)
+  "Ugly hack to get the string in a code block at point."
+  (search-backward-regexp point "```")
+  (when-let ((lang (block-fence-lang (str:trim (line-string (current-point))))))
+    (search-forward (current-point) (format nil "~%"))
+    (let ((start (copy-point (current-point))))
+      (search-forward-regexp (current-point) "```")
+      (search-backward (current-point) (format nil "~%"))
+      (let ((end (current-point)))
+        (values lang (points-to-string start end))))))
+
+(defun handle-eval-result (result)
+  "Display results of evaluation."
+  (pop-up-buffer "*literate*" (format nil "~a" result)))
+
+(define-command eval-block () ()
+  "Evaluate current markdown code block and display results in popup."
+  (with-constant-position
+    (multiple-value-bind (lang block) (block-at-point (current-point))
+      (when lang
+        (if-let ((evaluator (gethash lang *block-evaluators*)))
+          (funcall evaluator block #'handle-eval-result)
+          (message "No evaluator registered for ~a" lang))))))
+
+(register-block-evaluator "bash" (string callback)
+  "Register evaluator for Bash blocks."
+  (bt:make-thread
+   (lambda ()
+     (funcall callback (uiop:run-program string :output :string)))))
+
+(register-block-evaluator "lisp" (string callback)
+  "Register evaluator for Lisp blocks."
+  (lem-lisp-mode:check-connection)
+  (lem-lisp-mode:lisp-eval-async
+   (read-from-string
+    (format nil "(progn ~a)" string))
+   (lambda (result)
+     (funcall callback result))))
+
+(define-key lem-markdown-mode::*markdown-mode-keymap*
+  "C-c C-c" 'eval-block)

--- a/extensions/markdown-mode/lem-markdown-mode.asd
+++ b/extensions/markdown-mode/lem-markdown-mode.asd
@@ -1,4 +1,5 @@
-(defsystem "lem-markdown-mode"
+(asdf:defsystem "lem-markdown-mode"
   :depends-on ("lem")
   :serial t
-  :components ((:file "markdown-mode")))
+  :components ((:file "markdown-mode")
+               (:file "interactive")))

--- a/extensions/markdown-mode/lem-markdown-mode.asd
+++ b/extensions/markdown-mode/lem-markdown-mode.asd
@@ -1,4 +1,4 @@
-(asdf:defsystem "lem-markdown-mode"
+(defsystem "lem-markdown-mode"
   :depends-on ("lem")
   :serial t
   :components ((:file "markdown-mode")


### PR DESCRIPTION
This adds interactive features to markdown code blocks, like how src blocks in org-mode work.

The API consists of 3 commands: `markdown-eval-block`, `markdown-eval-block-and-insert`, and `markdown-kill-block-result`, as well as one macro, `register-block-evaluator` for users to add support for other languages (lisp and bash work by default).

`markdown-eval-block` evaluates the source block your cursor is in, and outputs the result to a popup buffer (just like `lisp-macroexpand`)

`markdown-eval-block-and-insert` evaluates the block and inserts it's result below the block.  If there was already a result there, it first deletes the old one.

`markdown-kill-block-result` deletes the result block below the code block your cursor is in, this is run automatically before `markdown-eval-block-and-insert`.

If you try to evaluate a block and there is no registered evaluator, a message is displayed saying so.  If you use any of these commands outside a code block, nothing happens.  If you use these commands while not in markdown-mode, a warning is displayed.

Evaluation commands work asynchronously and you can do whatever you want while it is working.

Here is a demo:
[Screencast from 2024-02-17 14-15-46.webm](https://github.com/lem-project/lem/assets/43155857/63621806-b594-42b6-842e-788ca5e36203)
