### PR TITLE
Change key bindings `k` to `C-k` in directory-mode, to avoid conflicts with keys in vi-mode

### DIFF
--- a/src/ext/directory-mode.lisp
+++ b/src/ext/directory-mode.lisp
@@ -68,7 +68,7 @@
 (define-key *directory-mode-keymap* "r" 'directory-mode-rename-file)
 (define-key *directory-mode-keymap* "s" 'directory-mode-sort-files)
 (define-key *directory-mode-keymap* "+" 'make-directory)
-(define-key *directory-mode-keymap* "k" 'directory-mode-kill-lines)
+(define-key *directory-mode-keymap* "C-k" 'directory-mode-kill-lines)
 
 (defun run-command (command)
   (when (consp command)


### PR DESCRIPTION
The key bindings added in https://github.com/lem-project/lem/pull/1296  conflict with vi-mode, so I changed them to C-k.