### PR TITLE
run tetris-quit after killing buffer as well

### DIFF
--- a/contrib/tetris/tetris.lisp
+++ b/contrib/tetris/tetris.lisp
@@ -300,6 +300,8 @@
   (setf *tetris-buffer* (make-buffer "*tetris*"))
   (switch-to-buffer *tetris-buffer*)
   (tetris-mode)
+  (add-hook (variable-value 'kill-buffer-hook :buffer *tetris-buffer*)
+            #'(lambda (buffer) (declare (ignore buffer)) (tetris-quit)))
   (init-field)
   (init-player)
   (draw)


### PR DESCRIPTION
adds killing the tetris buffer as another method to quit otherwise timers will leak