### PR TITLE
(minor) legit: fix rebase

### DIFF
--- a/extensions/legit/legit-rebase.lisp
+++ b/extensions/legit/legit-rebase.lisp
@@ -69,7 +69,7 @@ and
   (kill-buffer "git-rebase-todo"))
 
 (define-command rebase-abort () ()
-  (run-function #'lem/porcelain::rebase-kill)
+  (run-function #'lem/porcelain::rebase-abort)
   (kill-buffer "git-rebase-todo"))
 
 (define-command rebase-abort-yes-or-no () ()

--- a/extensions/legit/porcelain.lisp
+++ b/extensions/legit/porcelain.lisp
@@ -663,11 +663,11 @@ M	src/ext/porcelain.lisp
       (uiop:symbol-call :lem :lem-home)
       (merge-pathnames ".lem/" (user-homedir-pathname))))
 
-(defun rebase-script ()
+(defun rebase-script-path ()
   (if (boundp '*rebase-script-path*)
     *rebase-script-path*
     (let* ((legit-path (merge-pathnames "legit/" (%maybe-lem-home)))
-           (script-path (uiop:merge-pathnames* "dumbrebaseeditor.sh" legit-path)))
+           (script-path (namestring (uiop:merge-pathnames* "dumbrebaseeditor.sh" legit-path))))
       (ensure-directories-exist legit-path)
       (unless (uiop:file-exists-p script-path)
         (str:to-file script-path *rebase-script-content*))
@@ -738,7 +738,7 @@ I am stopping in case you still have something valuable there."))
               1)))
 
   (let ((editor (uiop:getenv "EDITOR")))
-    (setf (uiop:getenv "EDITOR") *rebase-script-path*)
+    (setf (uiop:getenv "EDITOR") (rebase-script-path))
     (unwind-protect
          ;; xxx: get the error output, if any, to get explanations of failure.
          (let ((process (uiop:launch-program (list


### PR DESCRIPTION
Now the interactive rebase (legit status, "r" and "i" on a commit) works (the best case, still more workflows to tackle, like abort a rebase). Damn, I was persuaded it did. It is possible I didn't test from scratch, but was using old definitions in my running lisp :S