### PR TITLE
Fix process-block-region space padding of vi visual mode

### DIFF
--- a/extensions/vi-mode/registers.lisp
+++ b/extensions/vi-mode/registers.lisp
@@ -187,7 +187,7 @@
            (region-string (start end end-col)
              (concatenate 'string
                           (points-to-string start end)
-                          (make-string (- end-col (point-charpos end))
+                          (make-string (- end-col (point-column end))
                                        :initial-element #\Space))))
     (destructuring-bind (start-line end-line)
         (sort (list (line-number-at-point start)

--- a/extensions/vi-mode/tests/visual.lisp
+++ b/extensions/vi-mode/tests/visual.lisp
@@ -158,7 +158,18 @@
       (testing "左下"
         (with-vi-buffer (#?"あいうえお\nか[き]くけこ\nさしすせそ\n")
           (cmd "<C-v>hjx")
-          (ok (buf= #?"あいうえお\n[く]けこ\nすせそ\n")))))))
+          (ok (buf= #?"あいうえお\n[く]けこ\nすせそ\n")))))
+    
+    (testing "挿入"
+      (testing "右"
+        (with-vi-buffer (#?"あいうえお\nか[き]くけこ\nさしすせそ\n")
+          (cmd "<C-v>jlxlp")
+          (ok (buf= #?"あいうえお\nかけこ[き]く\nさせそしす\n"))))
+
+      (testing "左"
+        (with-vi-buffer (#?"あいうえお\nか[き]くけこ\nさしすせそ\n")
+          (cmd "<C-v>jlxhP")
+          (ok (buf= #?"あいうえお\n[き]くかけこ\nしすさせそ\n")))))))
 
 (deftest visual-swap-points
   (with-fake-interface ()


### PR DESCRIPTION
Fix process-block-region space padding of vi visual mode