### PR TITLE
legit: add --continue and --skip

### DIFF
--- a/extensions/legit/legit-rebase.lisp
+++ b/extensions/legit/legit-rebase.lisp
@@ -5,10 +5,14 @@ Done:
 
 - start a rebase process from the commit at point,
   - abort the ongoing rebase:
-   - with C-c C-k in the interactive buffer buffer
+   - with C-c C-k in the interactive buffer
    - or "r a" (M-x rebase-abort), which works when the rebase was started by another process.
+  - continue the ongoing rebase:
+   - with C-c C-c in the interactive buffer
+   - or "r c" (M-x rebase-continue)
 - open a rebase buffer and press p, f… to pick, fixup… the commit at point.
 - validate it, stop it.
+- show in legit-status when a rebase is in process.
 
 Nice to have:
 
@@ -19,8 +23,7 @@ Nice to have:
 TODOs:
 
 - when (e)dit or (r)eword are used, we need to handle another operation.
-- show in legit-status when a rebase is in process.
-- add commands to continue the rebase in process.
+- show rebase conflicts: when a rebase is interrupted with conflicts we don't see them in legit-status.
 
 and
 
@@ -67,10 +70,6 @@ and
 (define-key *legit-rebase-mode-keymap* "?" 'rebase-help)
 (define-key *legit-rebase-mode-keymap* "C-x ?" 'rebase-help)
 
-(define-command rebase-continue () ()
-  (run-function #'lem/porcelain::rebase-continue)
-  (kill-buffer "git-rebase-todo"))
-
 (define-command rebase-abort () ()
   (with-current-project ()
     (run-function #'lem/porcelain::rebase-abort)
@@ -78,10 +77,9 @@ and
       (kill-buffer "git-rebase-todo"))
     (message "rebase aborted.")))
 
-(define-command rebase-abort-yes-or-no () ()
-  ;; TODO: prompt for confirmation.
+(define-command rebase-continue () ()
   (with-current-project ()
-    (run-function #'lem/porcelain::rebase-kill)
+    (run-function #'lem/porcelain::rebase-continue)
     (when (get-buffer "git-rebase-todo")
       (kill-buffer "git-rebase-todo"))))
 

--- a/extensions/legit/legit-rebase.lisp
+++ b/extensions/legit/legit-rebase.lisp
@@ -10,6 +10,7 @@ Done:
   - continue the ongoing rebase:
    - with C-c C-c in the interactive buffer
    - or "r c" (M-x rebase-continue)
+  - skip it with "r s"
 - open a rebase buffer and press p, f… to pick, fixup… the commit at point.
 - validate it, stop it.
 - show in legit-status when a rebase is in process.
@@ -72,14 +73,20 @@ and
 
 (define-command rebase-abort () ()
   (with-current-project ()
-    (run-function #'lem/porcelain::rebase-abort)
+    (run-function #'lem/porcelain:rebase-abort)
     (when (get-buffer "git-rebase-todo")
       (kill-buffer "git-rebase-todo"))
     (message "rebase aborted.")))
 
 (define-command rebase-continue () ()
   (with-current-project ()
-    (run-function #'lem/porcelain::rebase-continue)
+    (run-function #'lem/porcelain:rebase-continue)
+    (when (get-buffer "git-rebase-todo")
+      (kill-buffer "git-rebase-todo"))))
+
+(define-command rebase-skip () ()
+  (with-current-project ()
+    (run-function #'lem/porcelain:rebase-skip)
     (when (get-buffer "git-rebase-todo")
       (kill-buffer "git-rebase-todo"))))
 

--- a/extensions/legit/legit.lisp
+++ b/extensions/legit/legit.lisp
@@ -96,6 +96,7 @@ Next:
 (define-key lem/peek-legit:*peek-legit-keymap* "r i" 'legit-rebase-interactive)
 (define-key lem/peek-legit:*peek-legit-keymap* "r a" 'rebase-abort)
 (define-key lem/peek-legit:*peek-legit-keymap* "r c" 'rebase-continue)
+(define-key lem/peek-legit:*peek-legit-keymap* "r s" 'rebase-skip)
 
 ;; redraw everything:
 (define-key lem/peek-legit:*peek-legit-keymap* "g" 'legit-status)

--- a/extensions/legit/legit.lisp
+++ b/extensions/legit/legit.lisp
@@ -37,7 +37,7 @@ TODO:
 
 Ongoing:
 
-- interactive rebase (POC working for Unix)
+- interactive rebase (POC working for Unix). See more in legit-rebase.lisp
 
 Nice to have/todo next:
 
@@ -95,6 +95,7 @@ Next:
 ;;; interactive
 (define-key lem/peek-legit:*peek-legit-keymap* "r i" 'legit-rebase-interactive)
 (define-key lem/peek-legit:*peek-legit-keymap* "r a" 'rebase-abort)
+(define-key lem/peek-legit:*peek-legit-keymap* "r c" 'rebase-continue)
 
 ;; redraw everything:
 (define-key lem/peek-legit:*peek-legit-keymap* "g" 'legit-status)


### PR DESCRIPTION
We can now use "r c" or "r s" to continue or skip a rebase process that was started outside of Lem. `C-c C-c` in the rebase buffer was telling git to continue the rebase and pick our changes, but now we can call "--continue" anytime.