### PR TITLE
Wrap SDL2 call with trivial-main-thread to run in main thread

### DIFF
--- a/frontends/sdl2/lem-sdl2.asd
+++ b/frontends/sdl2/lem-sdl2.asd
@@ -3,7 +3,8 @@
                "sdl2-ttf"
                "sdl2-image"
                "lem"
-               "lem/extensions")
+               "lem/extensions"
+               "trivial-main-thread")
   :serial t
   :components ((:file "wm")
                (:file "resource")

--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -205,17 +205,18 @@
                      (if (lem:config :darwin-use-native-fullscreen) 1 0))
       ;; sdl2 should not install any signal handlers, since the lisp runtime already does so
       (sdl2:set-hint :no-signal-handlers 1)
-      (sdl2:make-this-thread-main (lambda ()
-                                    (handler-bind
-                                        (#+(and linux sbcl)
-                                         (sb-sys:interactive-interrupt
-                                           (lambda (c)
-                                             (declare (ignore c))
-                                             (invoke-restart 'sdl2::abort))))
-                                      (progn
-                                        (create-display #'thunk)
-                                        (when (sbcl-on-darwin-p)
-                                          (cffi:foreign-funcall "_exit")))))))))
+      (tmt:with-body-in-main-thread ()
+        (sdl2:make-this-thread-main (lambda ()
+                                      (handler-bind
+                                          (#+(and linux sbcl)
+                                              (sb-sys:interactive-interrupt
+                                               (lambda (c)
+                                                 (declare (ignore c))
+                                                 (invoke-restart 'sdl2::abort))))
+                                        (progn
+                                          (create-display #'thunk)
+                                          (when (sbcl-on-darwin-p)
+                                            (cffi:foreign-funcall "_exit"))))))))))
 
 (defmethod lem-if:get-background-color ((implementation sdl2))
   (with-debug ("lem-if:get-background-color")


### PR DESCRIPTION
On Mac OSx the GUI needs to run in the main thread. If running from another thread such as a REPL, the SDL2 frontend will fail so it's necessary to ensure execution is running in the actual main thread.