### PR TITLE
Fixed cursor movement by mouse when line numbers are enabled

### DIFF
--- a/contrib/mouse-sgr1006/main.lisp
+++ b/contrib/mouse-sgr1006/main.lisp
@@ -28,7 +28,8 @@
 (defun move-to-cursor (window x y)
   (lem:move-point (lem:current-point) (lem:window-view-point window))
   (lem:move-to-next-virtual-line (lem:current-point) y)
-  (lem:move-to-virtual-line-column (lem:current-point) x))
+  (lem:move-to-virtual-line-column (lem:current-point)
+                                   (- x (lem:window-left-width window))))
 
 (defun all-window-list ()
   "returns a list of all windows including side windows"

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -258,6 +258,7 @@
    :window-x
    :window-y
    :window-width
+   :window-left-width
    :window-height
    :window-buffer
    :window-screen


### PR DESCRIPTION
Without this fix, the cursor position was be off by the width of the line number view to the right.