### PR TITLE
Update version in .asd to latest

### DIFF
--- a/lem.asd
+++ b/lem.asd
@@ -15,7 +15,7 @@
     (set (intern (string :*local-project-directories*) :ql) local-project-dir)))
 
 (defsystem "lem"
-  :version "2.1.0"
+  :version "2.2.0"
   :depends-on ("iterate"
                "closer-mop"
                "trivia"


### PR DESCRIPTION
Regarding a comment in the discord, `M-x lem-version` fetches the version from the .asd file which is currently out of date