### PR TITLE
prompt-after-hook

### DIFF
--- a/src/ext/popup-window.lisp
+++ b/src/ext/popup-window.lisp
@@ -20,6 +20,7 @@
   ((offset-x :initarg :offset-x :accessor gravity-offset-x :initform 0)
    (offset-y :initarg :offset-y :accessor gravity-offset-y :initform 0)))
 (defclass gravity-center (gravity) ())
+(defclass gravity-top-display (gravity) ())
 (defclass gravity-top (gravity) ())
 (defclass gravity-topright (gravity) ())
 (defclass gravity-cursor (gravity) ())
@@ -53,13 +54,15 @@
       gravity
       (ecase gravity
         (:center (make-instance 'gravity-center))
+        (:top-display (make-instance 'gravity-top-display))
         (:top (make-instance 'gravity-top))
         (:topright (make-instance 'gravity-topright))
         (:cursor (make-instance 'gravity-cursor))
         (:follow-cursor (make-instance 'gravity-follow-cursor))
         (:mouse-cursor (make-instance 'gravity-mouse-cursor))
         (:vertically-adjacent-window (make-instance 'gravity-vertically-adjacent-window))
-        (:horizontally-adjacent-window (make-instance 'gravity-horizontally-adjacent-window)))))
+        (:horizontally-adjacent-window (make-instance 'gravity-horizontally-adjacent-window))))
+  )
 
 (defmethod adjust-for-redrawing ((gravity gravity-follow-cursor) popup-window)
   (destructuring-bind (x y width height)
@@ -70,8 +73,8 @@
                                       :border-size (floating-window-border popup-window))
     (lem-core::window-set-size popup-window width height)
     (lem-core::window-set-pos popup-window
-                                  (+ x (floating-window-border popup-window))
-                                  (+ y (floating-window-border popup-window)))))
+                              (+ x (floating-window-border popup-window))
+                              (+ y (floating-window-border popup-window)))))
 
 (defmethod compute-popup-window-rectangle :around ((gravity gravity) &key &allow-other-keys)
   (destructuring-bind (x y width height)
@@ -135,6 +138,14 @@
   (multiple-value-bind (x y)
       (lem-if:get-mouse-position (lem:implementation))
     (list x y width height)))
+
+(defmethod compute-popup-window-rectangle ((gravity gravity-top-display) &key source-window width height
+                                                                         &allow-other-keys)
+  (declare (ignore source-window))
+  (let* ((x (- (floor (display-width) 2)
+               (floor width 2)))
+         (y 1))
+    (list x y (1- width) height)))
 
 (defmethod compute-popup-window-rectangle ((gravity gravity-top) &key source-window width height
                                                                  &allow-other-keys)
@@ -303,6 +314,6 @@
                                         :border-size border-size)
       (lem-core::window-set-size destination-window w h)
       (lem-core::window-set-pos destination-window
-                                    (+ x border-size)
-                                    (+ y border-size))
+                                (+ x border-size)
+                                (+ y border-size))
       destination-window)))

--- a/src/ext/popup-window.lisp
+++ b/src/ext/popup-window.lisp
@@ -61,8 +61,7 @@
         (:follow-cursor (make-instance 'gravity-follow-cursor))
         (:mouse-cursor (make-instance 'gravity-mouse-cursor))
         (:vertically-adjacent-window (make-instance 'gravity-vertically-adjacent-window))
-        (:horizontally-adjacent-window (make-instance 'gravity-horizontally-adjacent-window))))
-  )
+        (:horizontally-adjacent-window (make-instance 'gravity-horizontally-adjacent-window)))))
 
 (defmethod adjust-for-redrawing ((gravity gravity-follow-cursor) popup-window)
   (destructuring-bind (x y width height)

--- a/src/ext/popup-window.lisp
+++ b/src/ext/popup-window.lisp
@@ -21,6 +21,7 @@
    (offset-y :initarg :offset-y :accessor gravity-offset-y :initform 0)))
 (defclass gravity-center (gravity) ())
 (defclass gravity-top-display (gravity) ())
+(defclass gravity-bottom-display (gravity) ())
 (defclass gravity-top (gravity) ())
 (defclass gravity-topright (gravity) ())
 (defclass gravity-cursor (gravity) ())
@@ -28,6 +29,7 @@
 (defclass gravity-mouse-cursor (gravity) ())
 (defclass gravity-vertically-adjacent-window (gravity) ())
 (defclass gravity-horizontally-adjacent-window (gravity) ())
+(defclass gravity-horizontally-above-window (gravity) ())
 
 (defclass popup-window (floating-window)
   ((gravity
@@ -55,13 +57,15 @@
       (ecase gravity
         (:center (make-instance 'gravity-center))
         (:top-display (make-instance 'gravity-top-display))
+        (:bottom-display (make-instance 'gravity-bottom-display))
         (:top (make-instance 'gravity-top))
         (:topright (make-instance 'gravity-topright))
         (:cursor (make-instance 'gravity-cursor))
         (:follow-cursor (make-instance 'gravity-follow-cursor))
         (:mouse-cursor (make-instance 'gravity-mouse-cursor))
         (:vertically-adjacent-window (make-instance 'gravity-vertically-adjacent-window))
-        (:horizontally-adjacent-window (make-instance 'gravity-horizontally-adjacent-window)))))
+        (:horizontally-adjacent-window (make-instance 'gravity-horizontally-adjacent-window))
+        (:horizontally-above-window (make-instance 'gravity-horizontally-above-window)))))
 
 (defmethod adjust-for-redrawing ((gravity gravity-follow-cursor) popup-window)
   (destructuring-bind (x y width height)
@@ -138,12 +142,20 @@
       (lem-if:get-mouse-position (lem:implementation))
     (list x y width height)))
 
-(defmethod compute-popup-window-rectangle ((gravity gravity-top-display) &key source-window width height
-                                                                         &allow-other-keys)
-  (declare (ignore source-window))
+(defmethod compute-popup-window-rectangle ((gravity gravity-top-display)
+                                           &key width height
+                                           &allow-other-keys)
   (let* ((x (- (floor (display-width) 2)
                (floor width 2)))
          (y 1))
+    (list x y (1- width) height)))
+
+(defmethod compute-popup-window-rectangle ((gravity gravity-bottom-display)
+                                           &key width height
+                                           &allow-other-keys)
+  (let* ((x (- (floor (display-width) 2)
+               (floor width 2)))
+         (y (- (display-height) height)))
     (list x y (1- width) height)))
 
 (defmethod compute-popup-window-rectangle ((gravity gravity-top) &key source-window width height
@@ -197,6 +209,21 @@
   (let ((x (- (window-x source-window) border-size))
         (y (+ (window-y source-window)
               (window-height source-window)
+              border-size)))
+    ;; workaround: cases that extend beyond the screen
+    (when (< (display-height) (+ y height))
+      (setf height (- (display-height) y 1)))
+    (list x
+          y
+          (max width (window-width source-window))
+          height)))
+
+(defmethod compute-popup-window-rectangle ((gravity gravity-horizontally-above-window)
+                                           &key source-window width height border-size
+                                           &allow-other-keys)
+  (let ((x (- (window-x source-window) border-size))
+        (y (- (window-y source-window)
+              height
               border-size)))
     ;; workaround: cases that extend beyond the screen
     (when (< (display-height) (+ y height))

--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -13,6 +13,7 @@
 (defconstant +min-width+   10)
 (defconstant +min-height+  1)
 
+(defvar *fill-width* nil)
 (defvar *history-table* (make-hash-table))
 
 (defvar *special-paths*
@@ -166,7 +167,9 @@
         (replace-if-history-exists #'lem/common/history:restore-edit-string))))
 
 (defun min-width ()
-  +min-width+)
+  (if *fill-width*
+      (1- (display-width))
+      +min-width+))
 
 (defun compute-window-rectangle (buffer &key gravity source-window)
   (destructuring-bind (width height) (lem/popup-window::compute-buffer-size buffer)
@@ -369,7 +372,7 @@
                                              :existing-test-function test-function
                                              :caller-of-prompt-window (current-window)
                                              :history (get-history history-symbol)
-                                             :gravity (or gravity :center)
+                                             :gravity (or gravity lem-core::*default-prompt-gravity*)
                                              :use-border use-border)
                   :syntax-table syntax-table
                   :body-function #'prompt-for-line-command-loop

--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -131,6 +131,7 @@
       (error 'execute-condition :input input))))
 
 (defvar *prompt-completion-window-shape* :drop-curtain)
+(defvar *prompt-completion-window-gravity* :horizontally-adjacent-window)
 
 (define-command prompt-completion () ()
   (alexandria:when-let (completion-fn (prompt-window-completion-function (current-prompt-window)))
@@ -151,7 +152,7 @@
                            (lem/completion-mode:completion-item
                             item))
                    :collect :it))))
-       :style `(:gravity :horizontally-adjacent-window
+       :style `(:gravity ,*prompt-completion-window-gravity*
                 :offset-y -1
                 :shape ,*prompt-completion-window-shape*)))))
 

--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -317,6 +317,7 @@
                             (lambda ()
                               (when (typep (this-command) 'lem:editable-advice)
                                 (funcall edit-callback (get-input-string))))))
+                (run-hooks *prompt-after-activate-hook*)
                 (with-special-keymap (special-keymap)
                   (if syntax-table
                       (with-current-syntax syntax-table
@@ -352,15 +353,15 @@
     (command-loop)))
 
 (defmethod lem-core::%prompt-for-line (prompt-string
-                                           &key initial-value
-                                                completion-function
-                                                test-function
-                                                history-symbol
-                                                (syntax-table (current-syntax))
-                                                gravity
-                                                edit-callback
-                                                special-keymap
-                                                (use-border t))
+                                       &key initial-value
+                                            completion-function
+                                            test-function
+                                            history-symbol
+                                            (syntax-table (current-syntax))
+                                            gravity
+                                            edit-callback
+                                            special-keymap
+                                            (use-border t))
   (prompt-for-aux :prompt-string prompt-string
                   :initial-string initial-value
                   :parameters (make-instance 'prompt-parameters
@@ -384,12 +385,12 @@
 (defun normalize-path-marker (path marker replace)
   (let ((split (str:split marker path)))
     (if (= 1 (length split))
-        path 
+        path
         (concatenate 'string replace (car (last split))))))
 
 (defun normalize-path-input (path)
   (reduce (lambda (ag pair) (normalize-path-marker ag (car pair) (cdr pair)))
-          *special-paths* 
+          *special-paths*
           :initial-value path))
 
 

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -221,6 +221,7 @@
   ;; prompt.lisp
   (:export
    :*prompt-activate-hook*
+   :*prompt-after-activate-hook*
    :*prompt-deactivate-hook*
    :*prompt-buffer-completion-function*
    :*prompt-file-completion-function*

--- a/src/prompt.lisp
+++ b/src/prompt.lisp
@@ -3,6 +3,7 @@
 (defparameter *default-prompt-gravity* :center)
 
 (defvar *prompt-activate-hook* '())
+(defvar *prompt-after-activate-hook* '())
 (defvar *prompt-deactivate-hook* '())
 
 (defvar *prompt-buffer-completion-function* nil)


### PR DESCRIPTION
This will let people hook prompt completion when a prompt window is activated like this:

```lisp
(add-hook *prompt-after-activate-hook*
          (lambda ()
            (call-command 'lem/prompt-window::prompt-completion nil)))

(add-hook *prompt-deactivate-hook*
          (lambda ()
            (lem/completion-mode:completion-end)))
```

This will show completion items without needing to press `<Tab>`