### PR TITLE
Completion tweaks

### DIFF
--- a/src/ext/completion-mode.lisp
+++ b/src/ext/completion-mode.lisp
@@ -186,6 +186,7 @@
              (completion-end)))))
 
 (define-command completion-delete-previous-char (n) ("p")
+  (message "back")
   (delete-previous-char n)
   (continue-completion *completion-context*))
 
@@ -265,10 +266,10 @@
 
 (define-command completion-narrowing-down-or-next-line () ()
   (or (narrowing-down *completion-context* (context-last-items *completion-context*))
-      (ignore-errors
-        (if *completion-reverse*
-            (completion-previous-line)
-            (completion-next-line)))))
+      ;; (ignore-errors)
+      (if *completion-reverse*
+          (completion-previous-line)
+          (completion-next-line))))
 
 (defun limitation-items (items)
   (let ((result (if (and *limit-number-of-items*

--- a/src/ext/completion-mode.lisp
+++ b/src/ext/completion-mode.lisp
@@ -186,7 +186,6 @@
              (completion-end)))))
 
 (define-command completion-delete-previous-char (n) ("p")
-  (message "back")
   (delete-previous-char n)
   (continue-completion *completion-context*))
 
@@ -266,7 +265,6 @@
 
 (define-command completion-narrowing-down-or-next-line () ()
   (or (narrowing-down *completion-context* (context-last-items *completion-context*))
-      ;; (ignore-errors)
       (if *completion-reverse*
           (completion-previous-line)
           (completion-next-line))))


### PR DESCRIPTION
Allow the order of completions to be reversed, this is helpful when the prompt is at the bottom of the screen so you don't have to move your eyes.

I am using this in my config so that completions are reversed in regular prompts, but normal in code completion:
```lisp
(add-hook *prompt-after-activate-hook*
          (lambda ()
            (setf lem/completion-mode::*completion-reverse* t)
            (call-command 'lem/prompt-window::prompt-completion nil)))

(add-hook *prompt-deactivate-hook*
          (lambda ()
            (setf lem/completion-mode::*completion-reverse* nil)
            (lem/completion-mode:completion-end)))
```