### PR TITLE
Translated most (all?) doc-strings.

### DIFF
--- a/src/buffer/internal/buffer-insert.lisp
+++ b/src/buffer/internal/buffer-insert.lisp
@@ -1,10 +1,10 @@
 (in-package :lem/buffer/internal)
 
 (defvar *inhibit-read-only* nil
-  "Tなら`buffer`のread-onlyを無効にします。")
+  "If T, disables read-only for `buffer`.")
 
 (defvar *inhibit-modification-hooks* nil
-  "Tなら`before-change-functions`と`after-change-functions`が実行されません。")
+  "If T, prevents `before-change-functions` and `after-change-functions` from being called.")
 
 (define-editor-variable before-change-functions '())
 (define-editor-variable after-change-functions '())
@@ -306,16 +306,16 @@
 (defvar *undo-mode* :edit)
 
 (defun buffer-enable-undo-p (&optional (buffer (current-buffer)))
-  "`buffer`でアンドゥが有効ならT、それ以外ならNILを返します。"
+  "Returns T if undo is enabled for `buffer`, otherwise returns NIL."
   (buffer-%enable-undo-p buffer))
 
 (defun buffer-enable-undo (buffer)
-  "`buffer`のアンドゥを有効にします。"
+  "Enables undo for `buffer`."
   (setf (buffer-%enable-undo-p buffer) t)
   nil)
 
 (defun buffer-disable-undo (buffer)
-  "`buffer`のアンドゥを無効にしてアンドゥ用の情報を空にします。"
+  "Disables undo for `buffer` and remove all undo information."
   (setf (buffer-%enable-undo-p buffer) nil)
   (setf (buffer-edit-history buffer) (make-array 0 :adjustable t :fill-pointer 0))
   (setf (buffer-redo-stack buffer) nil)

--- a/src/buffer/internal/buffer.lisp
+++ b/src/buffer/internal/buffer.lisp
@@ -105,10 +105,13 @@
   "set default buffer encoding to utf-8"
   (setf (buffer-encoding buffer) (encoding :utf-8 :lf)))
 
-(setf (documentation 'buffer-point 'function) "`buffer`の現在の`point`を返します。")
-(setf (documentation 'buffer-mark 'function) "`buffer`の現在のマークの`point`を返します。")
-(setf (documentation 'buffer-start-point 'function) "`buffer`の最初の位置の`point`を返します。")
-(setf (documentation 'buffer-end-point 'function) "`buffer`の最後の位置の`point`を返します。")
+(setf (documentation 'buffer-point 'function) "Returns the current `point` of `buffer`.")
+(setf (documentation 'buffer-mark 'function)
+      "Returns the `point` of the current mark in the `buffer`")
+(setf (documentation 'buffer-start-point 'function)
+      "Returns the `point` at the start of the `buffer`.")
+(setf (documentation 'buffer-end-point 'function)
+      "Returns the `point` at the end of the `buffer`.")
 
 (defvar *current-buffer*)
 

--- a/src/buffer/internal/point.lisp
+++ b/src/buffer/internal/point.lisp
@@ -46,7 +46,7 @@ When using `:left-inserting` or `:right-inserting`, you must explicitly delete t
             (line-str (point-line object)))))
 
 (defun pointp (x)
-  "`x`が`point`ならT、それ以外ならNILを返します。"
+  "Returns T if `x` is a `point`, otherwise returns NIL."
   (typep x 'point))
 
 (defun initialize-point-slot-values
@@ -91,16 +91,16 @@ When using `:left-inserting` or `:right-inserting`, you must explicitly delete t
   point)
 
 (defun copy-point (point &optional kind)
-  "`point`のコピーを作って返します。
-`kind`は`:temporary`、`:left-inserting`または `right-inserting`です。
-省略された場合は`point`と同じ値です。"
+  "Make and return a copy of `point`
+`kind` is `:temporary`, `:left-inserting` or `:right-inserting`.
+If omitted, is copied from `point`."
   (copy-point-using-class (make-instance 'point)
                           point
                           (or kind (point-kind point))))
 
 (defun delete-point (point)
-  "`point`を削除します。
-`point-kind`が:temporaryの場合はこの関数を使う必要はありません。"
+  "Delete `point`.
+If `point-kind` is `:temporary` this is unnecessary."
   (unless (point-temporary-p point)
     (setf (line-points (point-line point))
           (delete point (line-points (point-line point))))

--- a/src/buffer/internal/var.lisp
+++ b/src/buffer/internal/var.lisp
@@ -18,7 +18,7 @@
                     (editor-variable-local-indicator
                      (get symbol 'editor-variable)))))
 
-(defmethod variable-value-aux ((var editor-variable) (kind (eql :default)) &optional (where nil wherep))
+(defmethod variable-value-aux ((var editor-variable) (scope (eql :default)) &optional (where nil wherep))
   (let* ((buffer (if wherep
                      (ensure-buffer where)
                      (current-buffer)))
@@ -30,7 +30,7 @@
         (editor-variable-value var)
         value)))
 
-(defmethod variable-value-aux ((var editor-variable) (kind (eql :buffer)) &optional (where nil wherep))
+(defmethod variable-value-aux ((var editor-variable) (scope (eql :buffer)) &optional (where nil wherep))
   (let ((buffer (if wherep
                     (ensure-buffer where)
                     (current-buffer))))
@@ -46,9 +46,9 @@
           value)))
 
 (defmethod (setf variable-value-aux)
-    (value (var editor-variable) (kind (eql :buffer)) &optional (where nil wherep))
+    (value (var editor-variable) (scope (eql :buffer)) &optional (where nil wherep))
   (set-variable-value-aux-default var value where wherep))
 
 (defmethod (setf variable-value-aux)
-    (value (var editor-variable) (kind (eql :default)) &optional (where nil wherep))
+    (value (var editor-variable) (scope (eql :default)) &optional (where nil wherep))
   (set-variable-value-aux-default var value where wherep))

--- a/src/buffer/internal/var.lisp
+++ b/src/buffer/internal/var.lisp
@@ -12,7 +12,7 @@
       (apply #'run-hooks (variable-value var :global) args))))
 
 (defun clear-editor-local-variables (buffer)
-  "`buffer`の全てのバッファローカルなエディタ変数を未束縛にします。"
+  "Unbind all buffer-local editor variables in `buffer`"
   (dolist (symbol (editor-variables))
     (buffer-unbound buffer
                     (editor-variable-local-indicator

--- a/src/common/var.lisp
+++ b/src/common/var.lisp
@@ -25,7 +25,7 @@
 (setf (documentation 'editor-variable 'type)
       "`editor-variable` is a variable used within the editor.
 It is used to manage variables with both local and global values.
-The scope of the local variable is decided by the optional `kind`
+The scope of the variable is decided by the optional `scope`
 Parameter to `variable-value`.
 The `changed-value-hook` is only called on a global change.")
 
@@ -54,45 +54,45 @@ The `changed-value-hook` is only called on a global change.")
   (unless (editor-variable-p (get symbol 'editor-variable))
     (editor-variable-error symbol)))
 
-(defgeneric variable-value-aux (var kind &optional where)
+(defgeneric variable-value-aux (var scope &optional where)
   (:documentation
    "Generic funtion to get the value of the editor-variable `var`.
-Can be specialized for differend `kind`s."))
-(defgeneric (setf variable-value-aux) (value var kind &optional where)
+Can be specialized for differend `scope`s."))
+(defgeneric (setf variable-value-aux) (value var scope &optional where)
   (:documentation
    "Generic function to set the value of the editor-variable `var`.
-Can be specialized for differend `kind`s."))
+Can be specialized for differend `scope`s"))
 
-(defmethod variable-value-aux ((var editor-variable) (kind (eql :global)) &optional (where nil wherep))
+(defmethod variable-value-aux ((var editor-variable) (scope (eql :global)) &optional (where nil wherep))
   (declare (ignore where wherep))
   (editor-variable-value var))
 
-(defun variable-value (symbol &optional (kind :default) (where nil wherep))
+(defun variable-value (symbol &optional (scope :default) (where nil wherep))
   "Get the value of the editor-variable `symbol`.
 See `variable-value-aux`."
   (let ((var (get symbol 'editor-variable)))
     (unless (editor-variable-p var)
       (editor-variable-error symbol))
     (if wherep
-        (variable-value-aux var kind where)
-        (variable-value-aux var kind))))
+        (variable-value-aux var scope where)
+        (variable-value-aux var scope))))
 
-(defmethod (setf variable-value-aux) (value (var editor-variable) (kind (eql :global)) &optional (where nil wherep))
+(defmethod (setf variable-value-aux) (value (var editor-variable) (scope (eql :global)) &optional (where nil wherep))
   (declare (ignore where wherep))
   (let ((fn (editor-variable-change-value-hook var)))
     (when fn
       (funcall fn value)))
   (setf (editor-variable-value var) value))
 
-(defun (setf variable-value) (value symbol &optional (kind :default) (where nil wherep))
+(defun (setf variable-value) (value symbol &optional (scope :default) (where nil wherep))
   "Set the value of the editor-variable `symbol`.
 See `setf variable-value-aux`."
   (let ((var (get symbol 'editor-variable)))
     (unless (editor-variable-p var)
       (editor-variable-error symbol))
     (if wherep
-        (setf (variable-value-aux var kind where) value)
-        (setf (variable-value-aux var kind) value))))
+        (setf (variable-value-aux var scope where) value)
+        (setf (variable-value-aux var scope) value))))
 
 (defun variable-documentation (symbol)
   "Returns the doc-string of the editor variable `symbol`."
@@ -106,7 +106,7 @@ See `setf variable-value-aux`."
   *editor-variables*)
 
 (defun find-editor-variable (var)
-  "Find the editor-variable with name `var`."
+  "Find the editor-variable with name (string) `var`."
   (find var (editor-variables) :test 'string-equal))
 
 

--- a/src/common/var.lisp
+++ b/src/common/var.lisp
@@ -55,13 +55,15 @@ The `changed-value-hook` is only called on a global change.")
     (editor-variable-error symbol)))
 
 (defgeneric variable-value-aux (var kind &optional where)
-  "Generic funtion to get the value of the editor-variable `var`.
-Can be specialized for differend `kind`s.")
-(defgeneric (setf variable-value-aux) (value var kind &optional where))
+  (:documentation
+   "Generic funtion to get the value of the editor-variable `var`.
+Can be specialized for differend `kind`s."))
+(defgeneric (setf variable-value-aux) (value var kind &optional where)
+  (:documentation
+   "Generic function to set the value of the editor-variable `var`.
+Can be specialized for differend `kind`s."))
 
 (defmethod variable-value-aux ((var editor-variable) (kind (eql :global)) &optional (where nil wherep))
-  "Generic function to get the value of the editor-variable `var`.
-Can be specialized for differend `kind`s."
   (declare (ignore where wherep))
   (editor-variable-value var))
 
@@ -76,8 +78,6 @@ See `variable-value-aux`."
         (variable-value-aux var kind))))
 
 (defmethod (setf variable-value-aux) (value (var editor-variable) (kind (eql :global)) &optional (where nil wherep))
-  "Generic function to set the value of the editor-variable `var`.
-Can be specialized for differend `kind`s."
   (declare (ignore where wherep))
   (let ((fn (editor-variable-change-value-hook var)))
     (when fn

--- a/src/common/var.lisp
+++ b/src/common/var.lisp
@@ -23,15 +23,14 @@
   change-value-hook)
 
 (setf (documentation 'editor-variable 'type)
-      "`editor-variable`はエディタ内で使われる変数です。
-バッファローカルな変数や大域的な値を管理するために使います。")
+      "`editor-variable` is a variable used within the editor.
+Used to manage local variables and global values.")
 
 (defmacro define-editor-variable (var &optional value documentation change-value-hook)
-  "エディタ変数`var`を定義します。
-`value`はそのエディタ変数に束縛されている大域的な値です。
-`documentation`はそのエディタ変数の文書文字列です。
-`change-value-hook`はそのエディタ変数の大域的な値が変更されるときに呼び出されるフック関数です。
-"
+  "Define editor-variable `var`
+`value` is the global value of the variable.
+`documentation` is the doc-string of the Variable
+`change-value-hook` is a hook function called when the global value changes"
   (check-type var symbol)
   `(eval-when (:compile-toplevel :load-toplevel :execute)
      (unless (get ',var 'editor-variable)
@@ -82,7 +81,7 @@
         (setf (variable-value-aux var kind) value))))
 
 (defun variable-documentation (symbol)
-  "エディタ変数`symbol`の文書文字列を返します。"
+  "Returns the doc-string of the editor variable `symbol`."
   (let ((var (get symbol 'editor-variable)))
     (unless (editor-variable-p var)
       (editor-variable-error symbol))

--- a/src/display/base.lisp
+++ b/src/display/base.lisp
@@ -17,8 +17,8 @@
   (:method (mode buffer point) nil))
 
 (defvar *in-redraw-display* nil
-  "この変数がTの場合、redraw-display関数で画面を描画中であることを表します。
-再帰的なredraw-displayの呼び出しを防ぐために用います。")
+  "T if the screen is currently being redrawn by `redraw-display`.
+Used to prevent recursive `redraw-display` calls.")
 
 (defgeneric window-redraw (window force)
   (:method (window force)


### PR DESCRIPTION
These are mostly machine translated, but I found them to still be helpful.\
If anyone has some better translation I'd be happy to include it.\
Especially the `editor-variable` doc-string is a little unclear to me, how do 'local variables' relate to 'global values'?