### PR TITLE
disable setting clipboard when pasting in visual mode

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -18,7 +18,8 @@
   (:import-from :lem-vi-mode/commands/utils
                 :visual-region)
   (:import-from :lem/common/killring
-                :peek-killring-item)
+                :peek-killring-item
+                :rotate-killring)
   (:import-from :lem-vi-mode/window
                 :move-to-window-top
                 :move-to-window-middle
@@ -505,9 +506,11 @@ Move the cursor to the first non-blank character of the line."
     (cond
       ((visual-p)
        (let ((visual-line (visual-line-p)))
-         (multiple-value-bind (beg end type)
-             (visual-region)
-           (vi-delete beg end type))
+         (lem-core::with-enable-clipboard nil
+           (multiple-value-bind (beg end type)
+               (visual-region)
+             (vi-delete beg end type))
+           (rotate-killring (current-killring)))
          (when (and (not visual-line)
                     (eq type :line))
            (insert-character (current-point) #\Newline))))
@@ -526,9 +529,11 @@ Move the cursor to the first non-blank character of the line."
       (vi-yank-from-clipboard-or-killring)
     (cond
       ((visual-p)
-       (multiple-value-bind (beg end type)
-           (visual-region)
-         (vi-delete beg end type))
+       (lem-core::with-enable-clipboard nil
+         (multiple-value-bind (beg end type)
+             (visual-region)
+           (vi-delete beg end type))
+         (rotate-killring (current-killring)))
        (when (eq type :line)
          (insert-character (current-point) #\Newline)))
       (t


### PR DESCRIPTION
This is intended to fix [issue 1221](https://github.com/lem-project/lem/issues/1221)

This prevents the clipboard from being set inside of the call to `delete-region`, and it rotates the killring back to the original selection after the call to `delete-region`.