### PR TITLE
Use theme colors for rainbow parens

### DIFF
--- a/extensions/lisp-mode/paren-coloring.lisp
+++ b/extensions/lisp-mode/paren-coloring.lisp
@@ -15,27 +15,40 @@
         (enable)
         (disable))))
 
+(defvar *default-rainbow-colors* #("red" "blue" "green" "sienna4" "dark cyan" "orange"))
+
+(defun rainbow-color (index)
+  (let ((color-theme (find-color-theme (current-theme))))
+    (if color-theme
+        (second (assoc (ecase index
+                         (0 :base08)
+                         (1 :base09)
+                         (2 :base0a)
+                         (3 :base0b)
+                         (4 :base0c)
+                         (5 :base0d))
+                       (color-theme-specs color-theme)))
+        (aref *default-rainbow-colors* index))))
+
 (define-attribute color-1
-   (t :foreground "red"))
+  (t :foreground (rainbow-color 0)))
 
 (define-attribute color-2
-  (:dark :foreground "royalblue")
-  (:light :foreground "blue"))
+  (t :foreground (rainbow-color 1)))
 
 (define-attribute color-3
-  (:dark :foreground "green")
-  (:light :foreground "dark green"))
+  (t :foreground (rainbow-color 2)))
 
 (define-attribute color-4
-  (t :foreground "sienna4"))
+  (t :foreground (rainbow-color 3)))
 
 (define-attribute color-5
-  (t :foreground "dark cyan"))
+  (t :foreground (rainbow-color 4)))
 
 (define-attribute color-6
-  (t :foreground "orange"))
+  (t :foreground (rainbow-color 5)))
 
-(defvar *rainbow-colors* #(color-1 color-2 color-3 color-4 color-5 color-6))
+(defparameter *rainbow-colors* #(color-1 color-2 color-3 color-4 color-5 color-6))
 
 (defvar *paren-attribute* (make-attribute :foreground "dim gray"))
 

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -573,7 +573,12 @@
   (:export
    :color-theme-names
    :define-color-theme
-   :load-theme)
+   :load-theme
+   :current-theme
+   :find-color-theme
+   :color-theme
+   :color-theme-specs
+   :color-theme-parent)
   ;; region.lisp
   (:export
    :check-marked-using-global-mode


### PR DESCRIPTION
As it stands, `paren-coloring` colors are hardcoded, which can look jarring when using a theme. This PR makes it so that it just uses  `8`-`0d` of the current base16 [palette](https://github.com/chriskempson/base16/blob/main/styling.md). I tried it on a few themes and it seems to be working fine.

![image](https://github.com/lem-project/lem/assets/56184947/01f57626-ac7f-4110-a92c-c4ba6069f1b0)

PS: I'm new to CL, so I might have done something dumb. Feel free to make whatever changes you see fit.