### PR TITLE
Dynamic vertically-adjacent gravity

### DIFF
--- a/extensions/lisp-mode/completion.lisp
+++ b/extensions/lisp-mode/completion.lisp
@@ -4,14 +4,16 @@
            :eval-completions
            :make-completion-items
            :symbol-completion
-           :region-completion))
+           :region-completion
+           :*documentation-popup-gravity*))
 (in-package :lem-lisp-mode/completion)
 
-(defvar *documentation-popup-gravity* :vertically-adjacent-window-dynamic)
-(setf (documentation '*documentation-popup-gravity* 'variable)
-      (format nil "Set the gravity (position) of the documentation popup.~%Possibilities are:~%~s"
-              (handler-case (lem/popup-window::ensure-gravity nil)
-                (type-error (arg) (cdr (type-error-expected-type arg))))))
+(defvar *documentation-popup-gravity* :vertically-adjacent-window-dynamic
+  "The `gravity` (anchor position) used for documentation popup windows.
+To prevent the window from going off screen the default choice tries to place
+the window to the left of the completion window, unless the space is insuficient.
+Common coices are :VERTICALLY-ADJACENT-WINDOW, :VERTICALLY-ADJACENT-WINDOW-DYNAMIC,
+:HORIZONTALLY-ADJACENT-WINDOW, :HORIZONTALLY-ABOVE-WINDOW :CURSOR, :TOP or :BOTTOM.")
 
 (defun make-completions-form-string (string package-name)
   (format nil

--- a/extensions/lisp-mode/completion.lisp
+++ b/extensions/lisp-mode/completion.lisp
@@ -7,6 +7,8 @@
            :region-completion))
 (in-package :lem-lisp-mode/completion)
 
+(defvar *documentation-popup-gravity* :vertically-adjacent-window-dynamic)
+
 (defun make-completions-form-string (string package-name)
   (format nil
           "(micros/lsp-api:completions ~S ~S)"
@@ -32,7 +34,7 @@
      :focus-action (lambda (context)
                      (unless (alexandria:emptyp documentation)
                        (lem:show-message (lem/markdown-buffer:markdown-buffer documentation)
-                                         :style '(:gravity :vertically-adjacent-window-dynamic
+                                         :style `(:gravity ,*documentation-popup-gravity*
                                                   :offset-y -1
                                                   :offset-x 1)
                                          :source-window (lem/popup-menu::popup-menu-window

--- a/extensions/lisp-mode/completion.lisp
+++ b/extensions/lisp-mode/completion.lisp
@@ -32,7 +32,7 @@
      :focus-action (lambda (context)
                      (unless (alexandria:emptyp documentation)
                        (lem:show-message (lem/markdown-buffer:markdown-buffer documentation)
-                                         :style '(:gravity :vertically-adjacent-window
+                                         :style '(:gravity :vertically-adjacent-window-dynamic
                                                   :offset-y -1
                                                   :offset-x 1)
                                          :source-window (lem/popup-menu::popup-menu-window

--- a/extensions/lisp-mode/completion.lisp
+++ b/extensions/lisp-mode/completion.lisp
@@ -9,9 +9,9 @@
 
 (defvar *documentation-popup-gravity* :vertically-adjacent-window-dynamic)
 (setf (documentation '*documentation-popup-gravity* 'variable)
-      (format nil "Set the gravity (position) of the documentation popup. Possibilities are:~%~s"
+      (format nil "Set the gravity (position) of the documentation popup.~%Possibilities are:~%~s"
               (handler-case (lem/popup-window::ensure-gravity nil)
-                (condition (arg) (cdr (type-error-expected-type arg))))))
+                (type-error (arg) (cdr (type-error-expected-type arg))))))
 
 (defun make-completions-form-string (string package-name)
   (format nil

--- a/extensions/lisp-mode/completion.lisp
+++ b/extensions/lisp-mode/completion.lisp
@@ -11,7 +11,7 @@
 (defvar *documentation-popup-gravity* :vertically-adjacent-window-dynamic
   "The `gravity` (anchor position) used for documentation popup windows.
 To prevent the window from going off screen the default choice tries to place
-the window to the left of the completion window, unless the space is insuficient.
+the window to the right of the completion window, unless the space is insuficient.
 Common coices are :VERTICALLY-ADJACENT-WINDOW, :VERTICALLY-ADJACENT-WINDOW-DYNAMIC,
 :HORIZONTALLY-ADJACENT-WINDOW, :HORIZONTALLY-ABOVE-WINDOW :CURSOR, :TOP or :BOTTOM.")
 

--- a/extensions/lisp-mode/completion.lisp
+++ b/extensions/lisp-mode/completion.lisp
@@ -8,6 +8,10 @@
 (in-package :lem-lisp-mode/completion)
 
 (defvar *documentation-popup-gravity* :vertically-adjacent-window-dynamic)
+(setf (documentation '*documentation-popup-gravity* 'variable)
+      (format nil "Set the gravity (position) of the documentation popup. Possibilities are:~%~s"
+              (handler-case (lem/popup-window::ensure-gravity nil)
+                (condition (arg) (cdr (type-error-expected-type arg))))))
 
 (defun make-completions-form-string (string package-name)
   (format nil

--- a/src/ext/popup-window.lisp
+++ b/src/ext/popup-window.lisp
@@ -28,6 +28,7 @@
 (defclass gravity-follow-cursor (gravity-cursor) ())
 (defclass gravity-mouse-cursor (gravity) ())
 (defclass gravity-vertically-adjacent-window (gravity) ())
+(defclass gravity-vertically-adjacent-window-dynamic (gravity) ())
 (defclass gravity-horizontally-adjacent-window (gravity) ())
 (defclass gravity-horizontally-above-window (gravity) ())
 
@@ -64,6 +65,7 @@
         (:follow-cursor (make-instance 'gravity-follow-cursor))
         (:mouse-cursor (make-instance 'gravity-mouse-cursor))
         (:vertically-adjacent-window (make-instance 'gravity-vertically-adjacent-window))
+        (:vertically-adjacent-window-dynamic (make-instance 'gravity-vertically-adjacent-window-dynamic))
         (:horizontally-adjacent-window (make-instance 'gravity-horizontally-adjacent-window))
         (:horizontally-above-window (make-instance 'gravity-horizontally-above-window)))))
 
@@ -201,6 +203,19 @@
   (let ((x (+ (window-x source-window)
               (window-width source-window)))
         (y (window-y source-window)))
+    (list x y width height)))
+
+(defmethod compute-popup-window-rectangle ((gravity gravity-vertically-adjacent-window-dynamic)
+                                           &key source-window width height #+(or)border-size
+                                           &allow-other-keys)
+  (let ((x (+ (window-x source-window) (window-width source-window)))
+        (y (window-y source-window)))
+    (when (>= (+ x width) (display-width))
+      (setf (gravity-offset-x gravity) (- (gravity-offset-x gravity))
+            x (max 0 (- (window-x source-window) width 1))))
+    (when (>= (+ y height) (display-height))
+      (setf (gravity-offset-y gravity) 0
+            y (max 0 (- (display-height) height 2))))
     (list x y width height)))
 
 (defmethod compute-popup-window-rectangle ((gravity gravity-horizontally-adjacent-window)


### PR DESCRIPTION
Documentation popups going over the edge of the screen have been driving me mad recently.
This adds a new gravity `vertically-adjacent-window-dynamic`, that ensures the popup is visible, and sets it as the default gravity for documentation popups.
It also makes the gravity type for documentation popups configurable with `*documentation-popup-gravity*`

I thought about replacing `vertically-adjacent-window` but figure some people prefer the old way.
