### PR TITLE
Make define-command accept more verbose/understandable argument-descriptors

### DIFF
--- a/src/defcommand.lisp
+++ b/src/defcommand.lisp
@@ -40,7 +40,7 @@ Descriptors (old char in parenthesis):
                            ((:universal :universal-1) `(list (or ,universal-argument 1)))
                            (:universal-nil `(list ,universal-argument))
                            (:string `(list (prompt-for-string ,(second arg-descriptor))))
-                           ((:num :number)
+                           (:number
                             `(list (prompt-for-integer ,(second arg-descriptor))))
                            (:buffer
                             `(list (prompt-for-buffer

--- a/src/defcommand.lisp
+++ b/src/defcommand.lisp
@@ -4,61 +4,68 @@
   (defun parse-arg-descriptors (arg-descriptors universal-argument)
     "Parse arg descriptors given to define-command.
 
-   Descriptors:
+Descriptors (old char in parenthesis):
 
-   #\p -> universal argument, defaults to 1. Don't prompt for anything.
-   #\P -> universal argument
-   #\s -> prompt for string
-   #\n -> prompt for integer
-   #\b -> prompt for a buffer, defaults to the current-buffer's name
-   #\B -> prompt for buffer, defaults to the other buffer's name
-   #\f -> prompt for a file, defaults to the buffer directory
-   #\F -> prompt for a file, defaults to the buffer directory, must not be existing
-   #\r -> operate on the region."
+:universal (p) -> universal argument, defaults to 1. Don't prompt for anything.
+:universal-nil (P) -> universal argument
+:string (s) -> prompt for string
+:number (n) -> prompt for integer
+:buffer (b) -> prompt for a buffer, defaults to the current-buffer's name
+:other-buffer (B) -> prompt for buffer, defaults to the other buffer's name
+:file (f) -> prompt for a file, defaults to the buffer directory
+:new-file (F) -> prompt for a file, defaults to the buffer directory, must not be existing
+:region (r) -> operate on the region.
+:splice -> splice in your own code returning a list of values"
     (let* ((pre-forms '())
            (forms
              (mapcar (lambda (arg-descriptor)
-                       (cond ((and (stringp arg-descriptor)
-                                   (< 0 (length arg-descriptor)))
-                              (ecase (char arg-descriptor 0)
-                                (#\p
-                                 `(list (or ,universal-argument 1)))
-                                (#\P
-                                 `(list ,universal-argument))
-                                (#\s
-                                 `(list (prompt-for-string ,(subseq arg-descriptor 1))))
-                                (#\n
-                                 `(list (prompt-for-integer ,(subseq arg-descriptor 1))))
-                                (#\b
-                                 `(list (prompt-for-buffer ,(subseq arg-descriptor 1)
-                                                           :default (buffer-name (current-buffer))
-                                                           :existing t)))
-                                (#\B
-                                 `(list (prompt-for-buffer ,(subseq arg-descriptor 1)
-                                                           :default (buffer-name (other-buffer))
-                                                           :existing nil)))
-                                (#\f
-                                 `(list (prompt-for-file
-                                         ,(subseq arg-descriptor 1)
-                                         :directory (buffer-directory)
-                                         :default nil
-                                         :existing t)))
-                                (#\F
-                                 `(list (prompt-for-file
-                                         ,(subseq arg-descriptor 1)
-                                         :directory (buffer-directory)
-                                         :default nil
-                                         :existing nil)))
-                                (#\r
-                                 (push '(check-marked) pre-forms)
-                                 '(list (region-beginning-using-global-mode (current-global-mode))
-                                   (region-end-using-global-mode (current-global-mode))))))
-                             ((and (consp arg-descriptor)
-                                   (eq :splice (first arg-descriptor)))
+                       (setf arg-descriptor (cond ((and (stringp arg-descriptor)
+                                                        (< 0 (length arg-descriptor)))
+                                                   (list (ecase (char arg-descriptor 0)
+                                                           (#\p :universal) (#\P :universal-nil)
+                                                           (#\s :string) (#\n :number)
+                                                           (#\b :buffer) (#\B :other-buffer)
+                                                           (#\f :file) (#\F :new-file)
+                                                           (#\r :region))
+                                                         (subseq arg-descriptor 1)))
+                                                  ((symbolp arg-descriptor)
+                                                   (list arg-descriptor))
+                                                  (t arg-descriptor)))
+                       (if (consp arg-descriptor)
+                           (ecase (first arg-descriptor)
+                             (:splice 
                               (assert (alexandria:length= arg-descriptor 2))
                               (second arg-descriptor))
-                             (t
-                              `(multiple-value-list ,arg-descriptor))))
+                             ((:universal :universal-1) `(list (or ,universal-argument 1)))
+                             (:universal-nil `(list ,universal-argument))
+                             (:string `(list (prompt-for-string ,(second arg-descriptor))))
+                             ((:num :number)
+                              `(list (prompt-for-integer ,(second arg-descriptor))))
+                             (:buffer
+                              `(list (prompt-for-buffer ,(second arg-descriptor)
+                                                        :default (buffer-name (current-buffer))
+                                                        :existing t)))
+                             (:other-buffer
+                              `(list (prompt-for-buffer ,(second arg-descriptor)
+                                                        :default (buffer-name (other-buffer))
+                                                        :existing nil)))
+                             (:file
+                              `(list (prompt-for-file
+                                      ,(second arg-descriptor)
+                                      :directory (buffer-directory)
+                                      :default nil
+                                      :existing t)))
+                             (:new-file
+                              `(list (prompt-for-file
+                                      ,(second arg-descriptor)
+                                      :directory (buffer-directory)
+                                      :default nil
+                                      :existing nil)))
+                             (:region
+                              (push '(check-marked) pre-forms)
+                              '(list (region-beginning-using-global-mode (current-global-mode))
+                                (region-end-using-global-mode (current-global-mode)))))
+                           `(multiple-value-list ,arg-descriptor)))
                      arg-descriptors)))
       (if (null pre-forms)
           `(append ,@forms)
@@ -88,7 +95,7 @@
 
 (defun register-command (command &key mode-name command-name)
   (when mode-name
-     (associate-command-with-mode mode-name command))
+    (associate-command-with-mode mode-name command))
   (add-command command-name command))
 
 (defmacro define-command (name-and-options params (&rest arg-descriptors) &body body)
@@ -99,27 +106,32 @@ Example:
 (define-command write-hello () ()
   (insert-string (current-point) \"hello\"))
 
-A command can accept an universal argument. Use the \"p\" descriptor and add a parameter.
+A command can accept an universal argument. Use the :universal or \"p\" descriptor and add a parameter.
 
 Example:
 
-(define-command write-hellos (n) (\"p\")
+(define-command write-hellos (n) (:universal)
   (dotimes (i n)
     (insert-string (current-point) \"hello \")))
 
 and call it with C-u 3 M-x write-hellos RET.
 
-With \"p\" the argument defaults to 1. \"P\" is similar and defaults to nil.
+With :universal the argument defaults to 1, while :universal-nil (\"P\") is
+similar and defaults to nil.
 
-Other argument descriptors are available:
+Other argument descriptors are available (old-style char in parenthesis):
 
-   s -> prompt for a string. Use \"sMy prompt: \" to give a custom prompt.
-   n -> prompt for an integer.
-   b -> prompt for a buffer, defaults to the current-buffer's name.
-   B -> prompt for buffer, defaults to the other buffer's name.
-   f -> prompt for a file, defaults to the buffer directory.
-   F -> prompt for a file, defaults to the buffer directory, must not be existing.
-   r -> operate on the region. Needs two arguments, the `start` and `end` positions of the region."
+   :string (s) -> prompt for a string. Use (:string \"My prompt\") or
+                  \"sMy prompt: \" to give a custom prompt.
+   :number (n) -> prompt for an integer.
+   :buffer (b) -> prompt for a buffer, defaults to the current-buffer's name.
+   :other-buffer (B) -> prompt for buffer, defaults to the other buffer's name.
+   :file (f) -> prompt for a file, defaults to the buffer directory.
+   :new-file (F) -> prompt for a file, defaults to the buffer directory, must
+                    not be existing.
+   :region (r) -> operate on the region. Needs two arguments, the `start` and
+                  `end` positions of the region.
+   :splice -> splice in your own code returning a list of values."
   (destructuring-bind (name . options) (uiop:ensure-list name-and-options)
     (let ((advice-classes (alexandria:assoc-value options :advice-classes))
           (class-name (alexandria:if-let (elt (assoc :class options))
@@ -142,9 +154,11 @@ Other argument descriptors are available:
                                           #-sbcl nil)
 
            (defun ,name ,params
-             ;; コマンドではなく直接この関数を呼び出した場合
-             ;; - *this-command*が束縛されない
-             ;; - executeのフックが使えない
+             ,(format nil "Underlying function for the `~a` command.
+If you call it directly instead of using `call-command`:
+  - *this-command* will not be bound
+  - the execute-hook will not be called"
+                      name)
              ,@body)
 
            (register-command-class ',name ',class-name)
@@ -169,12 +183,12 @@ Other argument descriptors are available:
 (defclass foo-advice () ())
 
 (define-command (foo-1 (:advice-classes foo-advice)) (p) ("p")
-  ...body)
+...body)
 
 (define-command (foo-2 (:advice-classes foo-advice)) (s) ("sInput: ")
-  ...body)
+...body)
 
 (defmethod execute (mode (command foo-advice) argument)
-  ;; :advice-classesをfoo-adviceにしたfoo-1とfoo-2コマンドだけが呼び出される
-  )
+;; :advice-classesをfoo-adviceにしたfoo-1とfoo-2コマンドだけが呼び出される
+)
 |#


### PR DESCRIPTION
A comment on discord mentioned that strings as argument-descriptors are sub optimal, to which I agree.
This merge-request overhauls the `define-command` macro so that it accepts both old-style string descriptors, as well as list argument-descriptors.

The following descriptors were added:
`:universal`, `:universal-1`, `:universal-nil`, `:string`, `:number`, ~`:num`,~ `:buffer`, `:other-buffer`, `:file`, `:new-file` and `:region`
with `:universal-1` ~and `:num`~ being aliases of `:universal` ~and `:number`~ respectively.


I also added some documentation to the existing `:splice` descriptor and exposed the extremely helpful comment in the command-function as a doc-string.