### PR TITLE
Change the target language function to be called in the markdown-mode code block

### DIFF
--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -246,7 +246,9 @@
 (defun buffer-package (buffer &optional default)
   (let ((package-name (buffer-value buffer "package" default)))
     (typecase package-name
-      (null default)
+      (null (alexandria:if-let (package-name (scan-current-package (buffer-point buffer)))
+              (string-upcase package-name)
+              default))
       ((or symbol string)
        (string-upcase package-name))
       ((cons (or symbol string))

--- a/extensions/markdown-mode/markdown-mode.lisp
+++ b/extensions/markdown-mode/markdown-mode.lisp
@@ -31,6 +31,10 @@
           (column (point-column point)))
       (+ column (- tab-width (rem column tab-width))))))
 
+(defmethod execute :around ((mode markdown-mode) command argument)
+  (with-major-mode (current-major-mode-at-point (current-point))
+    (call-next-method)))
+
 (define-command markdown-insert-link () ()
   (let ((url (prompt-for-string "URL: "
                                 :history-symbol 'mh-markdown-url))

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -403,7 +403,12 @@
    :enable-minor-mode
    :disable-minor-mode
    :current-global-mode
-   :get-syntax-table-by-mode-name)
+   :get-syntax-table-by-mode-name
+   :set-region-major-mode
+   :clear-region-major-mode
+   :major-mode-at-point
+   :current-major-mode-at-point
+   :with-major-mode)
   ;; keymap.lisp
   (:export
    :*keymaps*

--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -169,6 +169,9 @@ Example: (define-key *global-keymap* \"C-'\" 'list-modes)"
   (let* ((keymaps (compute-keymaps (current-global-mode)))
          (keymaps
            (append keymaps
+                   (alexandria:when-let* ((mode (major-mode-at-point (current-point)))
+                                          (keymap (mode-keymap mode)))
+                     (list keymap))
                    (loop :for mode :in (all-active-modes (current-buffer))
                          :when (mode-keymap mode)
                          :collect :it))))

--- a/src/mode.lisp
+++ b/src/mode.lisp
@@ -305,3 +305,29 @@
   (alexandria:when-let* ((mode (find-mode mode-name))
                          (syntax-table (mode-syntax-table mode)))
     syntax-table))
+
+;;;
+(defun clear-region-major-mode (start end)
+  (remove-text-property start end :mode))
+
+(defun set-region-major-mode (start end mode)
+  (put-text-property start end :mode mode))
+
+(defun major-mode-at-point (point)
+  (text-property-at point :mode))
+
+(defun current-major-mode-at-point (point)
+  (or (major-mode-at-point point)
+      (buffer-major-mode (point-buffer point))))
+
+(defun call-with-major-mode (buffer mode function)
+  (let ((previous-mode (buffer-major-mode buffer)))
+    (cond ((eq previous-mode mode)
+           (funcall function))
+          (t
+           (change-buffer-mode buffer mode)
+           (unwind-protect (funcall function)
+             (change-buffer-mode buffer previous-mode))))))
+
+(defmacro with-major-mode (mode &body body)
+  `(call-with-major-mode (current-buffer) ,mode (lambda () ,@body)))


### PR DESCRIPTION
This PR is an additional change to that PR. https://github.com/lem-project/lem/pull/1377
![demo](https://github.com/lem-project/lem/assets/13656378/404e60c5-b7ed-440a-bb41-b68e3b42196f)

## known issues
- execute method is not called (e.g. https://github.com/lem-project/lem/blob/main/extensions/lisp-mode/self-insert-hook.lisp)
- Indentation in c-mode does not work
