### PR TITLE
Fallback to asdf:load-system to create a micros server

### DIFF
--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -1067,6 +1067,7 @@
             (lem-process:run-process (uiop:split-string command)
                                      :directory directory
                                      :output-callback #'output-callback)))
+      (lem-process:process-send-input process (format nil "(require :asdf)~%"))
       process)))
 
 (defun send-swank-create-server (process port)

--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -287,23 +287,23 @@
   (lem-lisp-syntax:calc-indent point))
 
 (defun call-with-remote-eval (form continuation
-                               &key (connection (current-connection))
-                                    (thread (current-swank-thread))
-                                    (package (current-package))
-                                    request-id)
+                              &key (connection (current-connection))
+                                   (thread (current-swank-thread))
+                                   (package (current-package))
+                                   request-id)
   (remote-eval connection
-                form
-                :continuation continuation
-                :thread thread
-                :package package
-                :request-id request-id))
+               form
+               :continuation continuation
+               :thread thread
+               :package package
+               :request-id request-id))
 
 (defmacro with-remote-eval ((form &rest args
-                                   &key connection
-                                        thread
-                                        package
-                                        request-id)
-                             continuation)
+                                  &key connection
+                                       thread
+                                       package
+                                       request-id)
+                            continuation)
   (declare (ignore connection thread package request-id))
   `(call-with-remote-eval ,form ,continuation ,@args))
 
@@ -571,10 +571,10 @@
     (highlight-notes notes)
     (cond ((and loadp fastfile successp)
            (lisp-eval-async `(micros:load-file ,(convert-local-to-remote-file fastfile))
-                             (lambda (result)
-                               (declare (ignore result))
-                               (uiop:delete-file-if-exists
-                                (convert-remote-to-local-file fastfile)))))
+                            (lambda (result)
+                              (declare (ignore result))
+                              (uiop:delete-file-if-exists
+                               (convert-remote-to-local-file fastfile)))))
           (fastfile
            (uiop:delete-file-if-exists
             (convert-remote-to-local-file fastfile))))))
@@ -582,30 +582,30 @@
 (defun show-compile-result (notes secs successp)
   (display-message (format nil "~{~A~^ ~}"
                            (remove-if #'null
-                                       (list (if successp
-                                                 "Compilation finished"
-                                                 "Compilation failed")
-                                             (unless notes
-                                               "(No warnings)")
-                                             (when secs
-                                               (format nil "[~,2f secs]" secs)))))))
+                                      (list (if successp
+                                                "Compilation finished"
+                                                "Compilation failed")
+                                            (unless notes
+                                              "(No warnings)")
+                                            (when secs
+                                              (format nil "[~,2f secs]" secs)))))))
 
 (defun make-highlight-overlay (pos buffer message source-context)
   (with-point ((point (buffer-point buffer)))
     (move-to-position point pos)
     (skip-chars-backward point #'syntax-symbol-char-p)
     (let ((overlay (make-overlay point
-                                   (or (form-offset (copy-point point :temporary) 1)
-                                       (buffer-end-point buffer))
-                                   'compiler-note-attribute))
+                                 (or (form-offset (copy-point point :temporary) 1)
+                                     (buffer-end-point buffer))
+                                 'compiler-note-attribute))
           (message (with-output-to-string (out)
                      (write-string message out)
                      (when source-context
                        (terpri out)
                        (write-string source-context out)))))
       (set-hover-message overlay
-                          message
-                          :style '(:gravity :mouse-cursor :offset-y 1))
+                         message
+                         :style '(:gravity :mouse-cursor :offset-y 1))
       (overlay-put overlay 'message message)
       overlay)))
 
@@ -648,18 +648,18 @@
 
 (defun move-to-next-compilation-notes (point)
   (alexandria:when-let ((overlay (loop :for overlay :in (buffer-compilation-notes-overlays
-                                                           (point-buffer point))
-                                        :when (point< point (overlay-start overlay))
-                                        :return overlay)))
+                                                         (point-buffer point))
+                                       :when (point< point (overlay-start overlay))
+                                       :return overlay)))
     (move-point point (overlay-start overlay))))
 
 (defun move-to-previous-compilation-notes (point)
   (alexandria:when-let ((overlay (loop :for last-overlay := nil :then overlay
-                                        :for overlay :in (buffer-compilation-notes-overlays
-                                                           (point-buffer point))
-                                        :when (point<= point (overlay-start overlay))
-                                        :return last-overlay
-                                        :finally (return last-overlay))))
+                                       :for overlay :in (buffer-compilation-notes-overlays
+                                                         (point-buffer point))
+                                       :when (point<= point (overlay-start overlay))
+                                       :return last-overlay
+                                       :finally (return last-overlay))))
     (move-point point (overlay-start overlay))))
 
 (defun remove-compilation-notes-overlay-in-the-changed-point (point arg)
@@ -722,11 +722,11 @@
                      ,(point-charpos (current-point))))))
     (run-hooks (variable-value 'before-compile-functions) start end)
     (lisp-eval-async `(micros:compile-string-for-emacs ,string
-                                                        ,(buffer-name (current-buffer))
-                                                        ',position
-                                                        ,(buffer-filename (current-buffer))
-                                                        nil)
-                      #'compilation-finished)))
+                                                       ,(buffer-name (current-buffer))
+                                                       ',position
+                                                       ,(buffer-filename (current-buffer))
+                                                       nil)
+                     #'compilation-finished)))
 
 (define-command lisp-compile-defun () ()
   (check-connection)
@@ -798,8 +798,8 @@
   (let* ((name (or (symbol-string-at-point point)
                    (prompt-for-symbol-name "Edit uses of: ")))
          (data (lisp-eval `(micros:xrefs '(:calls :macroexpands :binds
-                                            :references :sets :specializes)
-                                          ,name))))
+                                           :references :sets :specializes)
+                                         ,name))))
     (display-xref-references
      (loop
        :for (type . definitions) :in data
@@ -894,9 +894,9 @@
                                     (when (message-waiting-p (current-connection) :timeout 1)
                                       (let ((barrior t))
                                         (send-event (lambda ()
-                                                       (unwind-protect (progn (pull-events)
-                                                                              (redraw-display))
-                                                         (setq barrior nil))))
+                                                      (unwind-protect (progn (pull-events)
+                                                                             (redraw-display))
+                                                        (setq barrior nil))))
                                         (loop
                                           (unless (connected-p)
                                             (return))
@@ -1074,9 +1074,11 @@
     (lem-process:process-send-input
      process
      (format nil "(asdf:load-asd ~S)" file)))
+  ;; Try to quickload micros, but fallback to asdf:load-system if ql not installed
   (lem-process:process-send-input
    process
-   "(ql:quickload :micros)")
+   "(handler-case (eval (read-from-string \"(ql:quickload :micros)\"))
+      (error (c) (asdf:load-system :micros)))")
   (lem-process:process-send-input
    process
    (format nil "(micros:create-server :port ~D :dont-close t)~%" port)))
@@ -1164,8 +1166,8 @@
   (loop :with end-time := (+ (get-internal-real-time)
                              (* second internal-time-units-per-second))
         :for e := (receive-event (float
-                                    (/ (- end-time (get-internal-real-time))
-                                       internal-time-units-per-second)))
+                                  (/ (- end-time (get-internal-real-time))
+                                     internal-time-units-per-second)))
         :while (key-p e)))
 
 (define-command slime-restart () ()


### PR DESCRIPTION
the function `send-swank-create-server` assumes the user has quicklisp installed and fails if they don't.

I have replaced
 ```lisp
  "(ql:quickload :micros)"
```
with
```lisp
   "(handler-case (eval (read-from-string \"(ql:quickload :micros)\"))
      (error (c) (asdf:load-system :micros)))"
```

so that it falls back to `asdf:load-system` if quicklisp is not available.

Catching a reader error like this is a bit hacky, maybe we should just always use `asdf:load-system`? I'm not sure, but this seems to work.

Also, auto-formatting.