### PR TITLE
Add :bn and :bp vi commands

### DIFF
--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -53,6 +53,14 @@
   (when (lem:buffer-modified-p (lem:current-buffer))
     (ex-write range filename t)))
 
+(define-ex-command "^bn$" (range argument)
+    (declare (ignore range argument))
+    (lem:next-buffer))
+
+(define-ex-command "^bp$" (range argument)
+    (declare (ignore range argument))
+    (lem:previous-buffer))
+
 (define-ex-command "^wq$" (range filename)
   (ex-write-quit range filename nil t))
 


### PR DESCRIPTION
There are some vim users that expect to be able to cycle through their next buffer and previous buffers by using the commands:

`:bn` and `:bp`

This just simply adds those commands to the `ex-command.lisp`