### PR TITLE
Move side init recursive load to a named directory

### DIFF
--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -596,7 +596,11 @@
    :*auto-format*
    :register-formatter
    :register-formatters
-   :format-buffer))
+   :format-buffer)
+  ;; site-init.lisp
+  (:export
+   :*inits-directory-name*
+   :load-site-init))
 #+sbcl
 (sb-ext:lock-package :lem-core)
 


### PR DESCRIPTION
So, the site-init functionality is lookinf or asd files recursively, this can be problematic when a package manager is introduce (like https://github.com/lem-project/lem-extension-manager). As it may load undesired libraries/files from other directories.

The idea of this change is to isolate the look for asd files for site-init functionality to a "lisp" folder on the ".lem" directory (it can also be modified by the user).