### PR TITLE
Legit `status` deleted file support, minor UI overhaul

### DIFF
--- a/extensions/legit/legit.lisp
+++ b/extensions/legit/legit.lisp
@@ -499,7 +499,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
                                       (format nil "~10a ~a" 
                                               (case type
                                                 (:modified "modified")
-                                                (:added "new file")
+                                                (:added "created")
                                                 (:deleted "deleted")
                                                 (t ""))
                                               file)

--- a/extensions/legit/porcelain.lisp
+++ b/extensions/legit/porcelain.lisp
@@ -43,9 +43,7 @@ Supported version control systems:
 - Fossil: preliminary support
 - Mercurial: preliminary support
 
-TODOs:
-
-- show missing files.
+TODOs: 
 
 Mercurial:
 


### PR DESCRIPTION
This PR adds support for deleted files in Legit. It also incidentally overhauls a bit of the status UI.

Here's the before/after:
![image](https://github.com/lem-project/lem/assets/56184947/bb214e26-ab93-4f00-9fd3-b3d5ef564245)

Change summary:
- Deleted files now show up under staged/unstaged
- Untracked files now have a diff preview
- Number of files per section are now listed
- Modifications now have their type listed to the left, similar to Magit (created/modified/deleted)

Deleted files don't have a diff preview as of right now, instead there's just a message stating the file has been deleted. Should probably be revisited at some point to have the deleted file's contents show up.

Also, I'm unfamiliar with Mercurial and Fossil. I attempted to keep it compatible, but I was unable to test properly on Fossil (couldn't commit with/without my changes). Mercurial is mostly fine, the only gripe is that while deleted files show fine in the UI, trying to stage them does nothing. If I had to guess the issue is probably here:

```lisp
(defun hg-stage (file)
  (run-hg (list "add" file)))
```

Feel free to suggest or just make any changes!