### PR TITLE
Add legit-log function (depends on cl-git)

### DIFF
--- a/extensions/lsp-mode/lsp-mode.lisp
+++ b/extensions/lsp-mode/lsp-mode.lisp
@@ -1772,7 +1772,8 @@
 
 ;;;
 (define-command lsp-restart-server () ()
-  (dispose-workspace (buffer-workspace (current-buffer)))
+  (when-let (workspace (buffer-workspace (current-buffer) nil))
+    (dispose-workspace workspace))
   ;; TODO:
   ;; 現在のバッファを開き直すだけでは不十分
   ;; buffer-listを全て見る必要がある


### PR DESCRIPTION
Add a command, `legit-log`, which displays history starting from the current `HEAD`.

I definitely could have implemented this agnostic of `cl-git` but... I didn't. The reasons for this are

1. git is what I'm interested in: I don't really care about `fossil` and `hg`

2, I've had a lot of trouble with `magit` slowness on large repos (linux, specifically). Personally I'm very interested in keeping `legit` fast for large repos, which I think will naturally involve using `libgit2`, doing things lazily, etc. Tbh I'm hoping to establish precent and ~~push~~ help move `legit` along in that direction

Anyways so that's my motivation, and should explain some of the ~shortcuts~ choices in the chain

----------------

Also, refactor some code along the way to remove the `*collector*` global variable.
