### PR TITLE
Use `call-with-current-project` when opening unstaged files/directories in legit status

### DIFF
--- a/extensions/legit/README.md
+++ b/extensions/legit/README.md
@@ -199,7 +199,7 @@ For example:
 
 ~~~lisp
 (defun hg-project-p ()
-  "Return t if we find a .hg/ directory in the current directory (which should be the project root. Use `lem/legit::with-current-project`)."
+  "Return t if we find a .hg/ directory in the current directory (which should be the project root. Use `lem/porcelain:with-current-project`)."
   (values (uiop:directory-exists-p ".hg")
           :hg))
 ~~~

--- a/extensions/legit/legit-commit.lisp
+++ b/extensions/legit/legit-commit.lisp
@@ -92,7 +92,7 @@ two
       ((str:blankp cleaned-message)
        (message "No commit message, do nothing."))
       (t
-       (with-current-project ()
+       (lem/porcelain:with-current-project ()
          (run-function (lambda ()
                          (lem/porcelain::commit cleaned-message))
                        :message "commited")

--- a/extensions/legit/legit-rebase.lisp
+++ b/extensions/legit/legit-rebase.lisp
@@ -72,20 +72,20 @@ and
 (define-key *legit-rebase-mode-keymap* "C-x ?" 'rebase-help)
 
 (define-command rebase-abort () ()
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (run-function #'lem/porcelain:rebase-abort)
     (when (get-buffer "git-rebase-todo")
       (kill-buffer "git-rebase-todo"))
     (message "rebase aborted.")))
 
 (define-command rebase-continue () ()
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (run-function #'lem/porcelain:rebase-continue)
     (when (get-buffer "git-rebase-todo")
       (kill-buffer "git-rebase-todo"))))
 
 (define-command rebase-skip () ()
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (run-function #'lem/porcelain:rebase-skip)
     (when (get-buffer "git-rebase-todo")
       (kill-buffer "git-rebase-todo"))))

--- a/extensions/legit/legit.lisp
+++ b/extensions/legit/legit.lisp
@@ -3,7 +3,8 @@
    :lem)
   (:export :legit-status
            :*prompt-for-commit-abort-p*
-           :*ignore-all-space*)
+           :*ignore-all-space*
+           :call-with-current-project)
   (:documentation "Display version control data of the current project in an interactive two-panes window.
 
   This package in particular defines the right window of the legit interface and the user-level commands.

--- a/extensions/legit/legit.lisp
+++ b/extensions/legit/legit.lisp
@@ -3,8 +3,7 @@
    :lem)
   (:export :legit-status
            :*prompt-for-commit-abort-p*
-           :*ignore-all-space*
-           :call-with-current-project)
+           :*ignore-all-space*)
   (:documentation "Display version control data of the current project in an interactive two-panes window.
 
   This package in particular defines the right window of the legit interface and the user-level commands.
@@ -127,37 +126,6 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 (defun last-character (s)
   (subseq s (- (length s) 2) (- (length s) 1)))
 
-(defun call-with-porcelain-error (function)
-  (handler-bind ((lem/porcelain:porcelain-error
-                   (lambda (c)
-                     (lem:editor-error (slot-value c 'lem/porcelain::message)))))
-      (funcall function)))
-
-(defmacro with-porcelain-error (&body body)
-  "Handle porcelain errors and turn them into a lem:editor-error."
-  ;; This helps avoiding tight coupling.
-  `(call-with-porcelain-error (lambda () ,@body)))
-
-(defun call-with-current-project (function)
-  (with-porcelain-error ()
-    (let ((root (lem-core/commands/project:find-root (buffer-directory))))
-      (uiop:with-current-directory (root)
-        (multiple-value-bind (root vcs)
-            (lem/porcelain:vcs-project-p)
-          (if root
-              (let ((lem/porcelain:*vcs* vcs))
-                (progn
-                  (funcall function)))
-              (message "Not inside a version-controlled project?")))))))
-
-(defmacro with-current-project (&body body)
-  "Execute body with the current working directory changed to the project's root,
-  find and set the VCS system for this operation.
-
-  If no Git directory (or other supported VCS system) are found, message the user."
-  `(call-with-current-project (lambda () ,@body)))
-
-
 ;;; Git commands
 ;;; that operate on files.
 ;;;
@@ -181,7 +149,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 
 (defun make-diff-function (file &key cached type)
   (lambda ()
-    (with-current-project ()
+    (lem/porcelain:with-current-project ()
       (cond
         ((eq type :deleted)
          (show-diff (format nil "File ~A has been deleted." file)))
@@ -220,20 +188,20 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 ;; show commit.
 (defun make-show-commit-function (ref)
   (lambda ()
-    (with-current-project ()
+    (lem/porcelain:with-current-project ()
       (show-diff (lem/porcelain:show-commit-diff ref :ignore-all-space *ignore-all-space*)))))
 
 ;; stage
 (defun make-stage-function (file)
   (lambda ()
-    (with-current-project ()
+    (lem/porcelain:with-current-project ()
       (lem/porcelain:stage file)
       t)))
 
 ;; unstage
 (defun make-unstage-function (file &key already-unstaged)
   (lambda ()
-    (with-current-project ()
+    (lem/porcelain:with-current-project ()
       (if already-unstaged
           (message "Already unstaged")
           (lem/porcelain:unstage file)))))
@@ -248,7 +216,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
       (is-staged
        (message "Unstage the file first"))
       (t
-       (with-current-project ()
+       (lem/porcelain:with-current-project ()
          (when (prompt-for-y-or-n-p  (format nil "Discard unstaged changes in ~a?" file))
            (lem/porcelain:discard-file file)))))))
 
@@ -359,7 +327,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
    - error output (string)
    - exit code (integer)
 
-  Use with-current-project in the caller too.
+  Use lem/porcelain:with-current-project in the caller too.
   Typicaly used to run an external process in the context of a diff buffer command."
   (multiple-value-bind (output error-output exit-code)
       (funcall fn)
@@ -373,13 +341,13 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
          (pop-up-message error-output))))))
 
 (define-command legit-stage-hunk () ()
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (run-function (lambda ()
                     (lem/porcelain:apply-patch (%current-hunk)))
                   :message "Staged hunk")))
 
 (define-command legit-unstage-hunk () ()
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (run-function (lambda ()
                     (lem/porcelain:apply-patch (%current-hunk) :reverse t))
                   :message "Unstaged hunk")))
@@ -431,7 +399,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
                                    (parse-integer start-line :junk-allowed t) 
                                    lem/porcelain:*diff-context-lines*))))
               (if (and relative-file target-line)
-                  (with-current-project ()
+                  (lem/porcelain:with-current-project ()
                     (let ((absolute-file (merge-pathnames relative-file (uiop:getcwd))))
                       (lem/peek-legit:quit)
                       (find-file (namestring absolute-file))
@@ -484,7 +452,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 
 (define-command legit-status () ()
   "Show changes and untracked files."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (multiple-value-bind (untracked-files unstaged-files staged-files)
         (lem/porcelain:components)
 
@@ -616,7 +584,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 
 (define-command legit-branch-checkout () ()
   "Choose a branch to checkout."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (let ((branch (prompt-for-branch))
           (current-branch (lem/porcelain:current-branch)))
       (when (equal branch current-branch)
@@ -630,7 +598,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 
 (define-command legit-branch-create () ()
   "Create and checkout a new branch."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (let ((new (prompt-for-string "New branch name: "
                                   :history-symbol '*new-branch-name-history*))
           (base (prompt-for-branch :prompt "Base branch: " :initial-value "")))
@@ -642,19 +610,19 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 
 (define-command legit-pull () ()
   "Pull changes, update HEAD."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (run-function #'lem/porcelain:pull)))
 
 (define-command legit-push () ()
   "Push changes to the current remote."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (run-function #'lem/porcelain:push)))
 
 (define-command legit-rebase-interactive () ()
   "Rebase interactively, from the commit the point is on.
 
   Austostash pending changes, to enable the rebase and find the changes back afterwards."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
 
     ;; Find the commit hash the point is on: mandatory.
     (let ((commit-hash (text-property-at (current-point) :commit-hash)))
@@ -682,7 +650,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 
 (define-command legit-commits-log () ()
   "List commits on a new buffer."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (display-commits-log 0)))
 
 (defun display-commits-log (offset)
@@ -722,7 +690,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 
 (define-command legit-commits-log-next-page () ()
   "Show the next page of the commits log."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (let* ((buffer (current-buffer))
            (window-height (window-height (current-window)))
            (current-offset (or (buffer-value buffer 'commits-offset) 0))
@@ -735,7 +703,7 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 
 (define-command legit-commits-log-previous-page () ()
   "Show the previous page of the commits log."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (let* ((buffer (current-buffer))
            (window-height (window-height (current-window)))
            (current-offset (or (buffer-value buffer 'commits-offset) 0))
@@ -744,12 +712,12 @@ Currently Git-only. Concretely, this calls Git with the -w option.")
 
 (define-command legit-commits-log-first-page () ()
   "Go to the first page of the commit log."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (display-commits-log 0)))
 
 (define-command legit-commits-log-last-page () ()
   "Go to the last page of the commit log."
-  (with-current-project ()
+  (lem/porcelain:with-current-project ()
     (let* ((commits-per-page lem/porcelain:*commits-log-page-size*)
            (last-page-offset (* (floor (/ (1- (lem/porcelain:commit-count)) commits-per-page))
                                 commits-per-page)))

--- a/extensions/legit/peek-legit.lisp
+++ b/extensions/legit/peek-legit.lisp
@@ -349,17 +349,14 @@ Notes:
 
 
 (define-command peek-legit-select () ()
-  (alexandria:when-let ((file (get-matched-file)))
+  (alexandria:when-let ((path (get-matched-file)))
     (quit)
-    (alexandria:if-let
-        ((buffer (or (and (uiop:file-exists-p file)
-                          (find-file-buffer file))
-                     (find-file-buffer
-                      (merge-pathnames
-                       (lem-core/commands/project:find-root (buffer-filename))
-                       file)))))
-      (switch-to-buffer buffer)
-      (editor-error "File ~a doesn't exist." file))))
+    (uiop:symbol-call :lem/legit :call-with-current-project
+                      (lambda () (let ((full-path (merge-pathnames path (uiop:getcwd))))
+                                   (if (or (uiop:file-exists-p full-path)
+                                           (uiop:directory-exists-p full-path))
+                                       (find-file (namestring full-path))
+                                       (editor-error "Path ~a doesn't exist." full-path)))))))
 
 (define-command peek-legit-next () ()
   (next-move-point (current-point)))

--- a/extensions/legit/peek-legit.lisp
+++ b/extensions/legit/peek-legit.lisp
@@ -351,12 +351,12 @@ Notes:
 (define-command peek-legit-select () ()
   (alexandria:when-let ((path (get-matched-file)))
     (quit)
-    (uiop:symbol-call :lem/legit :call-with-current-project
-                      (lambda () (let ((full-path (merge-pathnames path (uiop:getcwd))))
-                                   (if (or (uiop:file-exists-p full-path)
-                                           (uiop:directory-exists-p full-path))
-                                       (find-file (namestring full-path))
-                                       (editor-error "Path ~a doesn't exist." full-path)))))))
+    (lem/porcelain:with-current-project ()
+      (let ((full-path (merge-pathnames path (uiop:getcwd))))
+        (if (or (uiop:file-exists-p full-path)
+                (uiop:directory-exists-p full-path))
+            (find-file (namestring full-path))
+            (editor-error "Path ~a doesn't exist." full-path))))))
 
 (define-command peek-legit-next () ()
   (next-move-point (current-point)))


### PR DESCRIPTION
Opening files/directories in legit status can sometimes yield an error if you don't have a buffer in the current project open. This changes it so we run `call-with-current-project` before so we have the right context.