### PR TITLE
Asynchronously run external commands with find-file

### DIFF
--- a/src/commands/file.lisp
+++ b/src/commands/file.lisp
@@ -94,7 +94,7 @@
           (setf buffer (execute-find-file *find-file-executor*
                                           (get-file-mode pathname)
                                           pathname)))
-        (when buffer
+        (when (bufferp buffer)
           (switch-to-buffer buffer t nil))))))
 
 (defmethod execute-find-file :before (executor mode pathname)

--- a/src/system.lisp
+++ b/src/system.lisp
@@ -29,8 +29,8 @@
 
 (defun open-external-file (pathname)
   #+linux
-  (uiop:run-program (list "xdg-open" (namestring pathname)))
+  (uiop:launch-program (list "xdg-open" (namestring pathname)))
   #+darwin
-  (uiop:run-program (list "open" (namestring pathname)))
+  (uiop:launch-program (list "open" (namestring pathname)))
   #+windows
-  (uiop:run-program (list "explorer" (namestring pathname)) :ignore-error-status t))
+  (uiop:launch-program (list "explorer" (namestring pathname)) :ignore-error-status t))


### PR DESCRIPTION
First off, thank you creating Lem. I earnestly believe it could be the future of Emacs like text editors. I use it everyday.

The goal of this commit is to run external programs asynchronously by simply switching from uiop:run-program to uiop:launch-program. This in consequence changes the return value to a uiop:process-info object.

As far as I know, the find-file command is the only function reliant on the uiop:run-program return value. To remedy this, I added bufferp check in it. 

