### PR TITLE
Make lsp-restart-server proceed even when buffer-workspace fails

### DIFF
--- a/extensions/lsp-mode/lsp-mode.lisp
+++ b/extensions/lsp-mode/lsp-mode.lisp
@@ -1772,7 +1772,8 @@
 
 ;;;
 (define-command lsp-restart-server () ()
-  (dispose-workspace (buffer-workspace (current-buffer)))
+  (when-let (workspace (buffer-workspace (current-buffer) nil))
+    (dispose-workspace workspace))
   ;; TODO:
   ;; 現在のバッファを開き直すだけでは不十分
   ;; buffer-listを全て見る必要がある


### PR DESCRIPTION
I'm using this locally because my LSP server is refusing to come up, and I'm trying to debug/work through the problem by doing `lsp-restart-server`s.

However, those fail while deleting the workspace for the current buffer because... lsp initialization always fails, hence the `(buffer-workspace)` call always fails

Anyways, I *think* this actually makes sense as a general change: I'm not an expert in lem LSP internals so maybe there's some reason this can't be upstream, but to me `lsp-restart-server` should start a connection without erroring if there's no existing one