### PR TITLE
Add SLIME's C-c ~ command (sync package) to lisp-mode

### DIFF
--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -473,14 +473,19 @@
 (define-command lisp-listen-in-current-package () ()
   (check-connection)
   (alexandria:when-let ((repl-buffer (repl-buffer))
-                        (package (buffer-package (current-buffer))))
+                        (package (buffer-package (current-buffer)))
+                        (original-buffer (current-buffer)))
     (save-excursion
-      (setf (current-buffer) repl-buffer)
-      (destructuring-bind (name prompt-string)
-          (lisp-eval `(micros:set-package ,package))
-        (new-package name prompt-string)))
-    (start-lisp-repl)
-    (buffer-end (buffer-point repl-buffer))))
+      (cond ((find-package package)
+             (setf (current-buffer) repl-buffer)
+             (destructuring-bind (name prompt-string)
+                 (lisp-eval `(micros:set-package ,package))
+               (new-package name prompt-string))
+             (start-lisp-repl)
+             (buffer-end (buffer-point repl-buffer)))
+            (t
+             (message "Package ~A not found" package)
+             (setf (current-buffer) original-buffer))))))
 
 (define-command lisp-current-directory () ()
   (message "Current directory: ~a"

--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -95,7 +95,7 @@
 (define-key *lisp-mode-keymap* "C-c C-q" 'lisp-quickload)
 (define-key *lisp-mode-keymap* "Return" 'newline-and-indent)
 (define-key *lisp-mode-keymap* "C-c C-j" 'lisp-eval-expression-in-repl)
-(define-key *lisp-mode-keymap* "C-c ~" 'lisp-sync-package)
+(define-key *lisp-mode-keymap* "C-c ~" 'lisp-listen-in-current-package)
 
 (defmethod convert-modeline-element ((element (eql 'lisp-mode)) window)
   (format nil "  ~A~A" (buffer-package (window-buffer window) "CL-USER")
@@ -748,16 +748,6 @@
       (scan-lists end 1 0)
       (send-string-to-listener (points-to-string start end)
                                (buffer-package (current-buffer))))))
-
-(define-command lisp-sync-package () ()
-  (check-connection)
-  (let ((package (buffer-package (current-buffer) "CL-USER")))
-    (if (find-package package)
-        (with-current-buffer (repl-buffer)
-          (with-current-window (get-repl-window)
-            (lisp-set-package package)
-            (move-to-end-of-buffer)))
-        (message "Cannot find package ~A" package))))
 
 (defun form-string-at-point ()
   (with-point ((point (current-point)))

--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -476,7 +476,7 @@
                         (package (buffer-package (current-buffer)))
                         (original-buffer (current-buffer)))
     (save-excursion
-      (cond ((find-package package)
+      (cond ((lisp-eval `(not (null (find-package package))))
              (setf (current-buffer) repl-buffer)
              (destructuring-bind (name prompt-string)
                  (lisp-eval `(micros:set-package ,package))

--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -95,6 +95,7 @@
 (define-key *lisp-mode-keymap* "C-c C-q" 'lisp-quickload)
 (define-key *lisp-mode-keymap* "Return" 'newline-and-indent)
 (define-key *lisp-mode-keymap* "C-c C-j" 'lisp-eval-expression-in-repl)
+(define-key *lisp-mode-keymap* "C-c ~" 'lisp-sync-package)
 
 (defmethod convert-modeline-element ((element (eql 'lisp-mode)) window)
   (format nil "  ~A~A" (buffer-package (window-buffer window) "CL-USER")
@@ -747,6 +748,16 @@
       (scan-lists end 1 0)
       (send-string-to-listener (points-to-string start end)
                                (buffer-package (current-buffer))))))
+
+(define-command lisp-sync-package () ()
+  (check-connection)
+  (let ((package (buffer-package (current-buffer) "CL-USER")))
+    (if (find-package package)
+        (with-current-buffer (repl-buffer)
+          (with-current-window (get-repl-window)
+            (lisp-set-package package)
+            (move-to-end-of-buffer)))
+        (message "Cannot find package ~A" package))))
 
 (defun form-string-at-point ()
   (with-point ((point (current-point)))

--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -476,7 +476,7 @@
                         (package (buffer-package (current-buffer)))
                         (original-buffer (current-buffer)))
     (save-excursion
-      (cond ((lisp-eval `(not (null (find-package package))))
+      (cond ((lisp-eval `(not (null (cl:find-package package))))
              (setf (current-buffer) repl-buffer)
              (destructuring-bind (name prompt-string)
                  (lisp-eval `(micros:set-package ,package))


### PR DESCRIPTION
In Emacs, pressing C-c ~ in a Lisp buffer with SLIME will cause the REPL's package to be switched to the buffer's active package. This change implements that functionality.

Note that it doesn't have the functionality of switching Lisp's current directory. This is partially because I found that behaviour janky in Lem, and partially because I don't like it doing that in Emacs either.