### PR TITLE
Expose modeline attributes, various theme fixes

### DIFF
--- a/extensions/lisp-mode/paren-coloring.lisp
+++ b/extensions/lisp-mode/paren-coloring.lisp
@@ -6,6 +6,12 @@
   (:export :paren-coloring
            :*paren-attribute*
            :*rainbow*
+           :paren-color-1
+           :paren-color-2
+           :paren-color-3
+           :paren-color-4
+           :paren-color-5
+           :paren-color-6
            :toggle-paren-coloring))
 (in-package :lem-lisp-mode/paren-coloring)
 
@@ -15,40 +21,25 @@
         (enable)
         (disable))))
 
-(defvar *default-rainbow-colors* #("red" "blue" "green" "sienna4" "dark cyan" "orange"))
+(define-attribute paren-color-1
+  (t :foreground "red"))
 
-(defun rainbow-color (index)
-  (let ((color-theme (find-color-theme (current-theme))))
-    (if color-theme
-        (get-color-theme-color color-theme
-                               (ecase index
-                                 (0 :base08)
-                                 (1 :base09)
-                                 (2 :base0a)
-                                 (3 :base0b)
-                                 (4 :base0c)
-                                 (5 :base0d)))
-        (aref *default-rainbow-colors* index))))
+(define-attribute paren-color-2
+  (t :foreground "blue"))
 
-(define-attribute color-1
-  (t :foreground (rainbow-color 0)))
+(define-attribute paren-color-3
+  (t :foreground "green"))
 
-(define-attribute color-2
-  (t :foreground (rainbow-color 1)))
+(define-attribute paren-color-4
+  (t :foreground "sienna4"))
 
-(define-attribute color-3
-  (t :foreground (rainbow-color 2)))
+(define-attribute paren-color-5
+  (t :foreground "dark cyan"))
 
-(define-attribute color-4
-  (t :foreground (rainbow-color 3)))
+(define-attribute paren-color-6
+  (t :foreground "orange"))
 
-(define-attribute color-5
-  (t :foreground (rainbow-color 4)))
-
-(define-attribute color-6
-  (t :foreground (rainbow-color 5)))
-
-(defparameter *rainbow-colors* #(color-1 color-2 color-3 color-4 color-5 color-6))
+(defparameter *rainbow-colors* #(paren-color-1 paren-color-2 paren-color-3 paren-color-4 paren-color-5 paren-color-6))
 
 (defvar *paren-attribute* (make-attribute :foreground "dim gray"))
 

--- a/src/color-theme.lisp
+++ b/src/color-theme.lisp
@@ -16,8 +16,6 @@
 
 (defvar *color-themes* (make-hash-table :test 'equal))
 
-(defvar *theme-load-hook* nil)
-
 (defun find-color-theme (name)
  "Takes the name of an existing color theme and returns a color-theme hashtable"
   (gethash name *color-themes*))
@@ -95,7 +93,6 @@
       (editor-error "undefined color theme: ~A" name))
     (apply-theme theme)
     (message nil)
-    (run-hooks *theme-load-hook* theme)
     (redraw-display :force t)
     (setf (current-theme) name)
     (when save-theme

--- a/src/ext/frame-multiplexer.lisp
+++ b/src/ext/frame-multiplexer.lisp
@@ -36,21 +36,6 @@
 (define-attribute frame-multiplexer-background-attribute
   (t :foreground "white" :background "#262626"))
 
-(add-hook lem-core:*theme-load-hook*
-          (lambda (theme)
-            (let ((lighter-background (get-color-theme-color theme :base01))
-                  (dark-foreground (get-color-theme-color theme :base04))
-                  (selected-background (get-color-theme-color theme :base0A)))
-              (unless (get-color-theme-color theme 'frame-multiplexer-active-frame-name-attribute)
-                (set-attribute 'frame-multiplexer-active-frame-name-attribute
-                               :foreground lighter-background :background selected-background :bold t))
-              (unless (get-color-theme-color theme 'frame-multiplexer-frame-name-attribute)
-                (set-attribute 'frame-multiplexer-frame-name-attribute
-                               :foreground lighter-background :background dark-foreground :bold t))
-              (unless (get-color-theme-color theme 'frame-multiplexer-background-attribute)
-                (set-attribute 'frame-multiplexer-background-attribute
-                               :foreground selected-background :background lighter-background)))))
-
 (define-editor-variable frame-multiplexer nil ""
   (lambda (value)
     (if value

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -594,7 +594,6 @@
    :define-color-theme
    :load-theme
    :current-theme
-   :*theme-load-hook*
    :find-color-theme
    :color-theme
    :get-color-theme-color)

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -366,6 +366,17 @@
    :modeline-mode-names
    :modeline-position
    :modeline-posline
+   :modeline-name-attribute
+   :modeline-major-mode-attribute
+   :inactive-modeline-major-mode-attribute
+   :modeline-minor-modes-attribute
+   :inactive-modeline-minor-modes-attribute
+   :modeline-position-attribute
+   :inactive-modeline-position-attribute
+   :modeline-posline-attribute
+   :inactive-modeline-position-attribute
+   :inactive-modeline-name-attribute
+   :inactive-modeline-posline-attribute
    :convert-modeline-element)
   ;; command.lisp
   (:export


### PR DESCRIPTION
This PR relies on: https://github.com/lem-project/lem-base16-themes/pull/2
(That one should get merged first, then we update qlfile.lock)

I've been adding base16 colors to parts of lem that were hardcoded, and I realized now that my efforts were a bit misguided. Instead of manually using base16 colors, which might not be present in some themes, the right way to do this is just to expose the appropriate attributes and modify the base16 theme generation code to use them (attached PR).

This PR exposes attributes where necessary (modeline/paren colors), and removes the functionality I had added for base16 colors, since it's no longer necessary. Also fixes a minor bug when selecting themes, where the colored parens wouldn't change with it immediately.

Now it looks right:
![image](https://github.com/user-attachments/assets/065bef88-7074-4020-8a02-fb007351d7a8)
