### PR TITLE
Make 'terminal' command launch shell in buffer's current directory

### DIFF
--- a/extensions/terminal/terminal.c
+++ b/extensions/terminal/terminal.c
@@ -22,7 +22,7 @@ typedef struct {
   int fd;
 } run_shell_result;
 
-static run_shell_result run_shell(int rows, int cols, const char *program)
+static run_shell_result run_shell(int rows, int cols, const char *program, char* const argv[])
 {
   int fd;
   struct winsize win = { rows, cols, 0, 0 };
@@ -30,10 +30,6 @@ static run_shell_result run_shell(int rows, int cols, const char *program)
   assert(pid >= 0);
   if (pid == 0) {
     setenv("TERM", "xterm-256color", 1);
-    char **argv = malloc(sizeof(char *) * 2);
-    assert(argv != NULL);
-    argv[0] = strdup(program);
-    argv[1] = NULL;
     assert(execvp(program, argv) >= 0);
   }
 
@@ -147,6 +143,7 @@ struct terminal *terminal_new(int id,
                               int rows,
                               int cols,
                               const char *program,
+                              char* const argv[],
 			      void *cb_damage,
 			      void *cb_moverect,
 			      void *cb_movecursor,
@@ -156,7 +153,7 @@ struct terminal *terminal_new(int id,
 			      void *cb_sb_pushline,
                               void *cb_sb_popline)
 {
-  run_shell_result result = run_shell(rows, cols, program);
+  run_shell_result result = run_shell(rows, cols, program, argv);
 
   VTerm *vterm = vterm_new(rows, cols);
   vterm_set_utf8(vterm, 1);

--- a/extensions/terminal/terminal.lisp
+++ b/extensions/terminal/terminal.lisp
@@ -64,12 +64,16 @@
 
 (defun create (&key (rows (alexandria:required-argument :rows))
                     (cols (alexandria:required-argument :cols))
-                    (buffer (alexandria:required-argument :buffer)))
+                    (buffer (alexandria:required-argument :buffer))
+                    (directory (alexandria:required-argument :directory)))
+  (declare (type (string) directory)
+           (type (integer) rows)
+           (type (integer) cols))
   (let* ((id (generate-terminal-id))
          (terminal
            (make-instance 'terminal
                           :id id
-                          :viscus (ffi::terminal-new id rows cols)
+                          :viscus (ffi::terminal-new directory id rows cols)
                           :buffer buffer
                           :rows rows
                           :cols cols)))


### PR DESCRIPTION
I'm not totally sure if the `-c "cd directory"; $SHELL` approach is really the *right* thing to do, but it at least works on both bash and fish.

I haven't regenerated any .so files: I figure @cxxxr might want to do that themselves. Although we really shouldn't be keeping binary blobs in the repo in the first place.