### PR TITLE
Add Makefile hierarchy for extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,53 +35,14 @@ update:
 	git pull
 	qlot install
 
+ext:
+# linux is hardcoded because I tried copy-pasting other detection
+# stuff from StackOverflow and somehow it didn't work.
+	LEM_OS=linux make -C extensions/
+
+clean:
+	make -C extensions/ clean
+
 lint:
 	.qlot/bin/sblint lem.asd
-	.qlot/bin/sblint extensions/asciidoc-mode/lem-asciidoc-mode.asd
-	.qlot/bin/sblint extensions/asm-mode/lem-asm-mode.asd
-	.qlot/bin/sblint extensions/c-mode/lem-c-mode.asd
-	.qlot/bin/sblint extensions/color-preview/lem-color-preview.asd
-	.qlot/bin/sblint extensions/css-mode/lem-css-mode.asd
-	.qlot/bin/sblint extensions/dart-mode/lem-dart-mode.asd
-	.qlot/bin/sblint extensions/documentation-mode/lem-documentation-mode.asd
-	.qlot/bin/sblint extensions/dot-mode/lem-dot-mode.asd
-	.qlot/bin/sblint extensions/elisp-mode/lem-elisp-mode.asd
-	.qlot/bin/sblint extensions/elixir-mode/lem-elixir-mode.asd
-#	.qlot/bin/sblint extensions/encodings/lem-encodings.asd
-	.qlot/bin/sblint extensions/erlang-mode/lem-erlang-mode.asd
-	.qlot/bin/sblint extensions/go-mode/lem-go-mode.asd
-	.qlot/bin/sblint extensions/haskell-mode/lem-haskell-mode.asd
-	.qlot/bin/sblint extensions/html-mode/lem-html-mode.asd
-	.qlot/bin/sblint extensions/java-mode/lem-java-mode.asd
-	.qlot/bin/sblint extensions/js-mode/lem-js-mode.asd
-	.qlot/bin/sblint extensions/json-mode/lem-json-mode.asd
-	.qlot/bin/sblint extensions/language-client/lem-language-client.asd
-	.qlot/bin/sblint extensions/language-server/lem-language-server.asd
-	.qlot/bin/sblint extensions/legit/lem-legit.asd
-	.qlot/bin/sblint extensions/lisp-mode/lem-lisp-mode.asd
-	.qlot/bin/sblint extensions/lisp-syntax/lem-lisp-syntax.asd
-	.qlot/bin/sblint extensions/lsp-base/lem-lsp-base.asd
-	.qlot/bin/sblint extensions/lsp-mode/lem-lsp-mode.asd
-	.qlot/bin/sblint extensions/lua-mode/lem-lua-mode.asd
-	.qlot/bin/sblint extensions/makefile-mode/lem-makefile-mode.asd
-	.qlot/bin/sblint extensions/markdown-mode/lem-markdown-mode.asd
-	.qlot/bin/sblint extensions/nim-mode/lem-nim-mode.asd
-	.qlot/bin/sblint extensions/ocaml-mode/lem-ocaml-mode.asd
-	.qlot/bin/sblint extensions/paredit-mode/lem-paredit-mode.asd
-	.qlot/bin/sblint extensions/patch-mode/lem-patch-mode.asd
-	.qlot/bin/sblint extensions/posix-shell-mode/lem-posix-shell-mode.asd
-	.qlot/bin/sblint extensions/process/lem-process.asd
-	.qlot/bin/sblint extensions/python-mode/lem-python-mode.asd
-	.qlot/bin/sblint extensions/review-mode/lem-review-mode.asd
-	.qlot/bin/sblint extensions/rust-mode/lem-rust-mode.asd
-	.qlot/bin/sblint extensions/scala-mode/lem-scala-mode.asd
-	.qlot/bin/sblint extensions/scheme-mode/lem-scheme-mode.asd
-	.qlot/bin/sblint extensions/shell-mode/lem-shell-mode.asd
-	.qlot/bin/sblint extensions/sql-mode/lem-sql-mode.asd
-	.qlot/bin/sblint extensions/swift-mode/lem-swift-mode.asd
-	.qlot/bin/sblint extensions/terminal/lem-terminal.asd
-	.qlot/bin/sblint extensions/typescript-mode/lem-typescript-mode.asd
-	.qlot/bin/sblint extensions/vi-mode/lem-vi-mode.asd
-	.qlot/bin/sblint extensions/welcome/lem-welcome.asd
-	.qlot/bin/sblint extensions/xml-mode/lem-xml-mode.asd
-	.qlot/bin/sblint extensions/yaml-mode/lem-yaml-mode.asd
+	make -C extensions/ lint

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -1,0 +1,58 @@
+# TODO Should loop over the extension directories somehow so as not to have
+# to hardcode all of this.
+SBLINT = "../.qlot/bin/sblint"
+
+default:
+	make -C terminal/
+
+clean:
+	make -C terminal/ clean
+
+lint:
+	${SBLINT} asciidoc-mode/lem-asciidoc-mode.asd
+	${SBLINT} asm-mode/lem-asm-mode.asd
+	${SBLINT} c-mode/lem-c-mode.asd
+	${SBLINT} color-preview/lem-color-preview.asd
+	${SBLINT} css-mode/lem-css-mode.asd
+	${SBLINT} dart-mode/lem-dart-mode.asd
+	${SBLINT} documentation-mode/lem-documentation-mode.asd
+	${SBLINT} dot-mode/lem-dot-mode.asd
+	${SBLINT} elisp-mode/lem-elisp-mode.asd
+	${SBLINT} elixir-mode/lem-elixir-mode.asd
+	${SBLINT} erlang-mode/lem-erlang-mode.asd
+	${SBLINT} go-mode/lem-go-mode.asd
+	${SBLINT} haskell-mode/lem-haskell-mode.asd
+	${SBLINT} html-mode/lem-html-mode.asd
+	${SBLINT} java-mode/lem-java-mode.asd
+	${SBLINT} js-mode/lem-js-mode.asd
+	${SBLINT} json-mode/lem-json-mode.asd
+	${SBLINT} language-client/lem-language-client.asd
+	${SBLINT} language-server/lem-language-server.asd
+	${SBLINT} legit/lem-legit.asd
+	${SBLINT} lisp-mode/lem-lisp-mode.asd
+	${SBLINT} lisp-syntax/lem-lisp-syntax.asd
+	${SBLINT} lsp-base/lem-lsp-base.asd
+	${SBLINT} lsp-mode/lem-lsp-mode.asd
+	${SBLINT} lua-mode/lem-lua-mode.asd
+	${SBLINT} makefile-mode/lem-makefile-mode.asd
+	${SBLINT} markdown-mode/lem-markdown-mode.asd
+	${SBLINT} nim-mode/lem-nim-mode.asd
+	${SBLINT} ocaml-mode/lem-ocaml-mode.asd
+	${SBLINT} paredit-mode/lem-paredit-mode.asd
+	${SBLINT} patch-mode/lem-patch-mode.asd
+	${SBLINT} posix-shell-mode/lem-posix-shell-mode.asd
+	${SBLINT} process/lem-process.asd
+	${SBLINT} python-mode/lem-python-mode.asd
+	${SBLINT} review-mode/lem-review-mode.asd
+	${SBLINT} rust-mode/lem-rust-mode.asd
+	${SBLINT} scala-mode/lem-scala-mode.asd
+	${SBLINT} scheme-mode/lem-scheme-mode.asd
+	${SBLINT} shell-mode/lem-shell-mode.asd
+	${SBLINT} sql-mode/lem-sql-mode.asd
+	${SBLINT} swift-mode/lem-swift-mode.asd
+	${SBLINT} terminal/lem-terminal.asd
+	${SBLINT} typescript-mode/lem-typescript-mode.asd
+	${SBLINT} vi-mode/lem-vi-mode.asd
+	${SBLINT} welcome/lem-welcome.asd
+	${SBLINT} xml-mode/lem-xml-mode.asd
+	${SBLINT} yaml-mode/lem-yaml-mode.asd

--- a/extensions/terminal/Makefile
+++ b/extensions/terminal/Makefile
@@ -1,0 +1,19 @@
+OUTPUT_FILE = "terminal.so"
+
+default:
+	make ${LEM_OS}
+
+linux: terminal.c
+	OUT_DIR = "lib/linux/x64"
+	mkdir -p ${OUT_DIR}
+	gcc terminal.c -Wl,-Bstatic -lvterm -Wl,-Bdynamic -o ${OUTPUT_FILE} -shared -fPIC
+	mv -f ${OUTPUT_FILE} ${OUT_DIR}
+
+osx: terminal.c
+	OUT_DIR = "lib/macosx/arm64"
+	mkdir -p ${OUT_DIR}
+	gcc terminal.c -I/opt/homebrew/include -L/opt/homebrew/lib -lvterm -o ${OUTPUT_FILE} -shared -fPIC
+	mv -f ${OUTPUT_FILE} ${OUT_DIR}
+
+clean:
+	rm -rf lib


### PR DESCRIPTION
This is half-baked, admittedly. extensions/Makefile should be looping over its subdirectories somehow to avoid the big hardcoded string, and "make ext" only works on linux.

Also, the hardcoded paths in the Makefile are not great, but I'd like to change this before merge. Ideally instead of having a lib/linux and lib/macosx both with shared objects (and in-tree), we'd just have a lib/ (or build/, which I think is a bit better) which "make ext" can just fill with the right .so

We'd have to update the github releases to distribute (and generate) independent osx and linux packages, but that seems like a fair price for eliminating the blobs from the tree

Also: I'm not sure where the relevant docs (so that I can specify that that libvterm 3.3+ is required) are: seems the sources for https://lem-project.github.io/installation/ncurses/linux/ aren't actually in this repo?