### PR TITLE
Fix malformed eval background color

### DIFF
--- a/extensions/lisp-mode/eval.lisp
+++ b/extensions/lisp-mode/eval.lisp
@@ -83,8 +83,8 @@
       (multiple-value-bind (r g b)
           (hsv-to-rgb h
                       s
-                      (+ v 5))
-        (format nil "#~X~X~X" r g b)))))
+                      (+ v (if (< v 50) 5 -5)))
+        (format nil "#~2,'0X~2,'0X~2,'0X" r g b)))))
 
 (defun display-evaluated-message
     (start


### PR DESCRIPTION
Fixes `compute-evaluated-background-color` producing a malformed color string. 

Also makes the highlight color darken instead of lighten when evaluating on light light themes.

It appears that the `compute-evaluated-background-color` function worked only through luck because it seems okay on most themes. On my theme, however, which had a pitch-black background color, the evaluation highlight looked really bad:

![image](https://github.com/user-attachments/assets/736bbe36-4389-4090-a003-91cf6d99e4b0)

This PR corrects the issue, but it may be necessary to change the values used in the function in the future because now it probably won't look as it looked before on some themes.