### PR TITLE
Add document attributes

### DIFF
--- a/src/attribute.lisp
+++ b/src/attribute.lisp
@@ -233,7 +233,72 @@
 (define-attribute syntax-builtin-attribute
   (t :foreground "#FF87FF"))
 
-
+(define-attribute document-header1-attribute
+  (:light :foreground "#000000" :bold t)
+  (:dark :foreground "#FFFFFF" :bold t))
+
+(define-attribute document-header2-attribute
+  (:light :foreground "#005A9C" :bold t)
+  (:dark :foreground "#87CEFA" :bold t))
+
+(define-attribute document-header3-attribute
+  (:light :foreground "#0000FF" :bold t)
+  (:dark :foreground "#ADD8E6" :bold t))
+
+(define-attribute document-header4-attribute
+  (:light :foreground "#8B008B" :bold t)
+  (:dark :foreground "#DDA0DD" :bold t))
+
+(define-attribute document-header5-attribute
+  (:light :foreground "#A0522D" :bold t)
+  (:dark :foreground "#F4A460" :bold t))
+
+(define-attribute document-header6-attribute
+  (:light :foreground "#2E8B57" :bold t)
+  (:dark :foreground "#98FB98" :bold t))
+
+(define-attribute document-bold-attribute
+  (t :bold t))
+
+(define-attribute document-italic-attribute
+  (:light :foreground "#8B4513")
+  (:dark :foreground "#DEB887"))
+
+(define-attribute document-underline-attribute
+  (t :underline t))
+
+(define-attribute document-link-attribute
+  (:light :foreground "#0000EE" :underline t)
+  (:dark :foreground "#87CEFA" :underline t))
+
+(define-attribute document-list-attribute
+  (:light :foreground "#8B4513")
+  (:dark :foreground "#DEB887"))
+
+(define-attribute document-code-block-attribute
+  (:light :background "#F0F0F0" :foreground "#000000")
+  (:dark :background "#2F4F4F" :foreground "#E0FFFF"))
+
+(define-attribute document-inline-code-attribute
+  (:light :background "#F0F0F0" :foreground "#8B008B")
+  (:dark :background "#2F4F4F" :foreground "#FF69B4"))
+
+(define-attribute document-blockquote-attribute
+  (:light :foreground "#696969")
+  (:dark :foreground "#D3D3D3"))
+
+(define-attribute document-table-attribute
+  (:light :foreground "#000000" :background "#E6E6FA")
+  (:dark :foreground "#FFFFFF" :background "#4B0082"))
+
+(define-attribute document-task-list-attribute
+  (:light :foreground "#228B22")
+  (:dark :foreground "#98FB98"))
+
+(define-attribute document-metadata-attribute
+  (:light :foreground "#4682B4")
+  (:dark :foreground "#87CEEB"))
+
 (defun attribute-value* (attribute key)
   (let ((attribute (ensure-attribute attribute nil)))
     (when attribute

--- a/src/ext/themes.lisp
+++ b/src/ext/themes.lisp
@@ -70,9 +70,25 @@
 
   (lem/frame-multiplexer:frame-multiplexer-active-frame-name-attribute
    :foreground "white" :background "CornflowerBlue" :bold t)
-
   (lem/frame-multiplexer:frame-multiplexer-frame-name-attribute
    :foreground "black" :background "dark gray" :bold t)
-
   (lem/frame-multiplexer:frame-multiplexer-background-attribute
-   :foreground "white" :background "#262626"))
+   :foreground "white" :background "#262626")
+  
+  (document-header1-attribute :foreground "#ffffff" :bold t)
+  (document-header2-attribute :foreground "#90bee1" :bold t)
+  (document-header3-attribute :foreground "#bed6ff" :bold t)
+  (document-header4-attribute :foreground "#efb3f7" :bold t)
+  (document-header5-attribute :foreground "#ffbf70" :bold t)
+  (document-header6-attribute :foreground "#beda78" :bold t)
+  (document-bold-attribute :bold t)
+  (document-italic-attribute :foreground "#ffbf70")
+  (document-underline-attribute :underline t)
+  (document-link-attribute :foreground "#90bee1" :underline t)
+  (document-list-attribute :foreground "#ffbf70")
+  (document-code-block-attribute :background "#393939" :foreground "#e0e0e0")
+  (document-inline-code-attribute :background "#393939" :foreground "#ff93b3")
+  (document-blockquote-attribute :foreground "#b4b7b4")
+  (document-table-attribute :foreground "#ffffff" :background "#515151")
+  (document-task-list-attribute :foreground "#beda78")
+  (document-metadata-attribute :foreground "#90bee1"))

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -145,6 +145,23 @@
    :syntax-variable-attribute
    :syntax-type-attribute
    :syntax-builtin-attribute
+   :document-header1-attribute
+   :document-header2-attribute
+   :document-header3-attribute
+   :document-header4-attribute
+   :document-header5-attribute
+   :document-header6-attribute
+   :document-bold-attribute
+   :document-italic-attribute
+   :document-underline-attribute
+   :document-link-attribute
+   :document-list-attribute
+   :document-code-block-attribute
+   :document-inline-code-attribute
+   :document-blockquote-attribute
+   :document-table-attribute
+   :document-task-list-attribute
+   :document-metadata-attribute
    :completion-attribute
    :non-focus-completion-attribute
    :attribute-image


### PR DESCRIPTION
Closes #1468

This PR adds document attributes we can use with markup/document views (e.g. org mode, markdown, legit, etc.) and sets some working colors for the default lem theme. I'll push up a separate PR moving `markdown-mode` over to these alongside changes to the default theme ones if they don't work too well.