### PR TITLE
Completion ranking

### DIFF
--- a/src/commands/file.lisp
+++ b/src/commands/file.lisp
@@ -210,7 +210,7 @@
     (let ((candidates (get-files-recursively-with-timeout (find-program))))
       (prompt-for-string
        "File: "
-       :completion-function (lambda (x) (completion-strings x candidates))
+       :completion-function (lambda (x) (completion-strings x candidates :files t))
        :test-function (lambda (name) (member name candidates :test #'string=))))))
 
 (define-command find-file-recursively (arg) (:universal)

--- a/src/completion.lisp
+++ b/src/completion.lisp
@@ -28,6 +28,8 @@
               :while pos))))
 
 (defun completion (name elements &key (test #'search) separator key rank)
+  "Perform completion on ELEMENTS matching NAME. Returns matching elements, 
+   optionally sorted by RANK function."
   (labels ((apply-key (elt) (if key (funcall key elt) elt))
            (test-with-separator (elt)
              (let* ((elt (apply-key elt))
@@ -48,18 +50,22 @@
           (sort filtered-elements #'< :key (lambda (elt) (funcall rank name (apply-key elt))))
           filtered-elements))))
 
-(defun file-completion-rank (name elt)
+(defun string-completion-rank (name elt)
   (cond
-    ((string= name elt) 0)  ; Exact match
-    ((str:starts-with-p name elt) (length name))  ; Prefix match
-    ((search name elt) 2)  ; Substring match anywhere
-    (t (length elt))))  ; Fuzzy match, rank by length
+    ; Exact match
+    ((string= name elt) 0)
+    ; Prefix match
+    ((str:starts-with-p name elt) (length name))
+    ; Substring match anywhere
+    ((search name elt) 2)
+    ; Fuzzy match, rank by length
+    (t (length elt))))
 
 (defun completion-strings (str strings &key key)
   (completion str strings 
               :test #'fuzzy-match-p
               :key key
-              :rank #'file-completion-rank))
+              :rank #'string-completion-rank))
 
 (defun completion-hyphen (name elements &key key)
   (completion name elements :test #'completion-test :separator "-" :key key))

--- a/src/completion.lisp
+++ b/src/completion.lisp
@@ -61,11 +61,27 @@
     ; Fuzzy match, rank by length
     (t (length elt))))
 
-(defun completion-strings (str strings &key key)
+(defun file-completion-rank (name elt)
+  (let ((file-name (file-namestring elt)))
+    (cond
+      ; Exact match
+      ((string= name elt) 0)
+      ; Prefix match in file name
+      ((str:starts-with-p name file-name) 1)
+      ; Substring match in file name
+      ((search name file-name) 2)
+      ; Prefix match in full path
+      ((str:starts-with-p name elt) 3)
+      ; Substring match in full path
+      ((search name elt) 4)
+      ; Fuzzy match, rank by length
+      (t (length elt)))))
+
+(defun completion-strings (str strings &key key files)
   (completion str strings 
               :test #'fuzzy-match-p
               :key key
-              :rank #'string-completion-rank))
+              :rank (if files #'file-completion-rank #'string-completion-rank)))
 
 (defun completion-hyphen (name elements &key key)
   (completion name elements :test #'completion-test :separator "-" :key key))


### PR DESCRIPTION
This PR adds basic ranking capabilities to `completion`. Currently only active in a couple of places, mainly `C-x p f` / `prompt-for-files-recursively`.

I wasn't quite satisfied with how project file completion worked, since the fuzzy finding pretty much only looked at matching characters, meaning you'd end up having to type most of the name a lot of the time (and sometimes the full name wasn't enough):

![image](https://github.com/user-attachments/assets/57b2aa9f-850e-4c84-b665-5985e622d695)

This adds optional ranking rules, enabled for `string-completions`:

![image](https://github.com/user-attachments/assets/a40ca129-c9e3-45e0-8c77-06eb1d010650)

For files the ranking rules go: 

exact match > prefix match (file) > substring match (file) > prefix match (dir/path) > substring match (dir/path) > fuzzy match

This sorts the filtered test results once after calculating the rank so it might introduce a bit of overhead. That being said I haven't felt any in difference in the projects I've tried (e.g. Linux kernel). If you guys feel any let me know, I tried a few different ways of doing this and this one ended up being the most straightforward.