### PR TITLE
tabbar does not display properly (SDL2)

### DIFF
--- a/src/ext/tabbar.lisp
+++ b/src/ext/tabbar.lisp
@@ -35,6 +35,13 @@
 
 (defun tabbar-init ()
   (let ((buffer (make-buffer "*tabbar*" :enable-undo-p nil :temporary t)))
+    (when (display-light-p)
+      (set-attribute-foreground 'tabbar-active-tab-attribute (foreground-color))
+      (set-attribute-foreground 'tabbar-attribute (foreground-color)))
+    (when (display-dark-p)
+      (set-attribute-foreground 'tabbar-active-tab-attribute (foreground-color))
+      (set-attribute-background 'tabbar-active-tab-attribute "light gray")
+      (set-attribute-foreground 'tabbar-attribute (foreground-color)))
     (setf (variable-value 'line-wrap :buffer buffer) nil)
     (setf *tabbar* (make-instance 'tabbar-window :buffer buffer))))
 

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -169,7 +169,9 @@
    :attribute-height
    :attribute-font
    :cursor-attribute-p
-   :set-cursor-attribute)
+   :set-cursor-attribute
+   :display-dark-p
+   :display-light-p)
   ;; clipboard.lisp
   (:export
    :wsl-p
@@ -604,7 +606,8 @@
    :attribute-background-color
    :attribute-foreground-with-reverse
    :attribute-background-with-reverse
-   :cursor-type)
+   :cursor-type
+   :display-background-mode)
   ;; color-theme.lisp
   (:export
    :color-theme-names
@@ -613,7 +616,9 @@
    :current-theme
    :find-color-theme
    :color-theme
-   :get-color-theme-color)
+   :get-color-theme-color
+   :foreground-color
+   :background-color)
   ;; region.lisp
   (:export
    :check-marked-using-global-mode


### PR DESCRIPTION
Easy to reproduce with "lem -Q" and the M-x toggle-tabbar.   There are flashes when a tab is clicked.

I originally thought that it was because my theme had a dark background, so I made the included change to select the tabbar foreground color based on a light or dark background.   It does not fix the problem, but I think it is correct.  I exported functions related to light/dark background queries.

Also, I wonder if "lem -Q" should load ~/..lem/config.lisp.  I did not expect my theme to be loaded with "lem -Q".
