### PR TITLE
Create lispy aliases for color names with spaces.

### DIFF
--- a/src/common/color.lisp
+++ b/src/common/color.lisp
@@ -771,7 +771,8 @@
 144 238 144  LightGreen
 ")
 
-(defvar *color-names* (make-hash-table :test 'equal))
+;; Size includes aliases
+(defvar *color-names* (make-hash-table :size 848 :test 'equal))
 
 (defun parse-rgb-txt ()
   (alexandria:alist-hash-table


### PR DESCRIPTION
This change adds "lispy" aliases for color names, in which spaces are replaced with dashes.
This is done with lower cased names only: "dark-gray", not "Dark-Gray".
Emacs does not do this.
I don't know if this is even useful, although it does make the hash table of colors available as a variable.