### PR TITLE
Add welcome text to REPL and display of current connection

### DIFF
--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -189,7 +189,16 @@
   (when (current-connection)
     (abort-all (current-connection) "change connection")
     (notify-change-connection-to-wait-message-thread))
-  (setf (current-connection) connection))
+  (setf (current-connection) connection)
+  (write-string-to-repl
+   (if (self-connection-p connection)
+       (format nil
+               "~%; changed connection (self connection)")
+       (format nil
+               "~%; changed connection (~A ~A)"
+               (connection-implementation-name connection)
+               (connection-implementation-version connection)))
+   :attribute 'syntax-comment-attribute))
 
 (defmethod switch-connection ((connection connection))
   (change-current-connection connection))
@@ -1106,7 +1115,7 @@
   (let* ((port (lem/common/socket:random-available-port))
          (process (run-lisp :command command :directory directory :port port)))
     (send-swank-create-server process port)
-    (start-lisp-repl)
+    (start-lisp-repl-internal :new-process t)
     (let ((spinner
             (start-loading-spinner :modeline
                                    :buffer (repl-buffer)


### PR DESCRIPTION
When REPL is started with `M-x start-lisp-repl`, if it is a self connection, a message is displayed.

```common-lisp
;; Welcome to the REPL!
;;
;; The current REPL is running in the same process as the editor.
;; If you don't need to hack the editor,
;; please start a new process with `M-x slime`.

CL-USER> 
```

When another process is started with `M-x slime` and the connection is switched, a message is displayed in the REPL.

```common-lisp
;; Welcome to the REPL!
;;
;; The current REPL is running in the same process as the editor.
;; If you don't need to hack the editor,
;; please start a new process with `M-x slime`.

CL-USER> 

; changed connection (sbcl 2.4.6)
CL-USER> 
```

Also, if you return to self connection, it will display a message to that effect.

```common-lisp
;; Welcome to the REPL!
;;
;; The current REPL is running in the same process as the editor.
;; If you don't need to hack the editor,
;; please start a new process with `M-x slime`.

CL-USER> 

; changed connection (sbcl 2.4.6)
CL-USER> 

; changed connection (self connection)
CL-USER> 
```