### PR TITLE
Change default grep prompt to exclude binary files

### DIFF
--- a/src/ext/grep.lisp
+++ b/src/ext/grep.lisp
@@ -67,7 +67,7 @@
         (buffer-undo-boundary (point-buffer start)))))
   (lem/peek-source:show-matched-line))
 
-(defvar *last-query* "git grep -nH ")
+(defvar *last-query* "git grep -nHI ")
 (defvar *last-directory* nil)
 
 (define-command grep (query &optional (directory (buffer-directory)))


### PR DESCRIPTION
Adds the `-I` argument by default to exclude binary files. Safe to say most of the time we're not grepping through binary files, and it helps to get rid of editor errors like:

![image](https://github.com/user-attachments/assets/8f9e81ad-ee53-491b-a637-7c5fe96cbe62)
