### PR TITLE
Add `move-to-top` to history, use with file history

### DIFF
--- a/src/commands/file.lisp
+++ b/src/commands/file.lisp
@@ -415,7 +415,8 @@ Supported modes include: c-mode with clang-format, go-mode with gofmt, js-mode a
     (when filename
       (lem/common/history:add-history (file-history) 
                                       (namestring filename)
-                                      :allow-duplicates nil)
+                                      :allow-duplicates nil
+                                      :move-to-top t)
       (lem/common/history:save-file (file-history)))))
 
 (add-hook *find-file-hook* 'add-to-file-history)

--- a/src/common/history.lisp
+++ b/src/common/history.lisp
@@ -57,30 +57,45 @@
     (aref (history-data history)
           (1- (length (history-data history))))))
 
-(defun add-history (history input &key (allow-duplicates t) (test #'equal))
-  "Add this input to the history.
+(defun add-history (history input &key (allow-duplicates t) (test #'equal) move-to-top)
+  "Add this INPUT to the HISTORY.
 
-  Don't add the same input as the previous one.
-  If allow-duplicates is non t, don't add duplicates at all.
-  If limit is set, overwrite oldest entry when reached."
-  (when (or allow-duplicates
-            (not (find input (history-data history) :test test)))
-    (when (require-additions-to-history-p input (last-history history))
-      (let ((limit (history-limit history)))
-        (cond
-          ((and limit (>= (length (history-data history)) limit))
-           ;; Shift by 1, overwriting the oldest
-           (replace (history-data history)
-                    (history-data history)
-                    :start1 0 
-                    :start2 1
-                    :end2 limit)
-           (setf (aref (history-data history) (1- limit)) input))
-          (t
-           ;; Add new element normally
-           (vector-push-extend input (history-data history)))))
-      (setf (history-index history)
-            (length (history-data history)))))
+  Doesn't add the same INPUT as the previous one.
+  If ALLOW-DUPLICATES is non T, don't add duplicates at all.
+  If LIMIT is set, overwrite oldest entry when reached.
+  If MOVE-TO-TOP is T, move the entry to the top of the stack if it already exists."
+  (let ((existing-position (position input (history-data history) :test test)))
+    (cond
+      ((and existing-position move-to-top)
+       (let ((item (aref (history-data history) existing-position)))
+         ;; Remove the item from its current position
+         (replace (history-data history)
+                  (history-data history)
+                  :start1 existing-position
+                  :start2 (1+ existing-position))
+         (decf (fill-pointer (history-data history)))
+         ;; Add the item to the top
+         (vector-push-extend item (history-data history))))
+      ((and (not existing-position)
+            (require-additions-to-history-p input (last-history history)))
+       (let ((limit (history-limit history)))
+         (cond
+           ((and limit (>= (length (history-data history)) limit))
+            ;; Shift by 1, overwriting the oldest
+            (replace (history-data history)
+                     (history-data history)
+                     :start1 0 
+                     :start2 1
+                     :end2 limit)
+            (setf (aref (history-data history) (1- limit)) input))
+           (t
+            ;; Add new element normally
+            (vector-push-extend input (history-data history))))))
+      (allow-duplicates
+       ;; If duplicates are allowed, add the input
+       (vector-push-extend input (history-data history))))
+    (setf (history-index history)
+          (length (history-data history))))
   input)
 
 (defun remove-history (history input)

--- a/tests/common/history.lisp
+++ b/tests/common/history.lisp
@@ -18,3 +18,31 @@
     (testing "next-history"
       (ok (equal '("bar" t) (multiple-value-list (next-history history))))
       (ok (null (next-history history))))))
+
+(deftest add-history-test
+  (let ((history (make-history)))
+    (testing "basic add-history"
+             (add-history history "first")
+             (add-history history "second")
+             (ok (equal '("first" "second") (history-data-list history))))
+    
+    (testing "without allow-duplicates"
+             (add-history history "third" :allow-duplicates nil)
+             (add-history history "second" :allow-duplicates nil)
+             (ok (equal '("first" "second" "third") (history-data-list history))))
+    
+    (testing "with allow-duplicates"
+             (add-history history "second" :allow-duplicates t)
+             (ok (equal '("first" "second" "third" "second") (history-data-list history))))
+    
+    (testing "with move-to-top"
+             (add-history history "first" :move-to-top t)
+             (ok (equal '("second" "third" "second" "first") (history-data-list history))))
+    
+    (testing "limit functionality"
+             (let ((limited-history (make-history :limit 3)))
+               (add-history limited-history "one")
+               (add-history limited-history "two")
+               (add-history limited-history "three")
+               (add-history limited-history "four")
+               (ok (equal '("two" "three" "four") (history-data-list limited-history)))))))


### PR DESCRIPTION
Adds `move-to-top` to `add-history`, which moves the entry to the top of the stack if it already exists. Then uses it with `file-history` to re-order the most recent entry if it's already in the history.