### PR TITLE
Add variables for git command and args.

### DIFF
--- a/src/ext/grep.lisp
+++ b/src/ext/grep.lisp
@@ -1,7 +1,10 @@
 (defpackage :lem/grep
   (:use :cl
         :lem)
-  (:export :grep)
+  (:export
+   :grep
+   :*grep-command*
+   :*grep-args*)
   #+sbcl
   (:lock t))
 (in-package :lem/grep)
@@ -67,7 +70,9 @@
         (buffer-undo-boundary (point-buffer start)))))
   (lem/peek-source:show-matched-line))
 
-(defvar *last-query* "git grep -nHI ")
+(defvar *grep-command* "git grep")
+(defvar *grep-args* "-nHI")
+(defvar *last-query* (str:concat *grep-command* " " *grep-args* " "))
 (defvar *last-directory* nil)
 
 (define-command grep (query &optional (directory (buffer-directory)))


### PR DESCRIPTION
I have added *grep-command* and *grep-args* for customizing the grep command.  This is useful for windows, which doesn't have grep by default.  I exported the variables, not sure if that's desired.

An alternative would be to rename *last-query* to *grep-command* and put the entire command in there.  Let me know if you would prefer that.

I have added the following to my init.lisp:
#+win32
(setq *grep-command* "c:/cygwin64/bin/grep.exe")
