### PR TITLE
Re-enable super key support in SDL2

### DIFF
--- a/frontends/sdl2/keyboard.lisp
+++ b/frontends/sdl2/keyboard.lisp
@@ -260,7 +260,7 @@
     (loop :for c :across text
           :do (let ((key (make-key :ctrl (modifier-ctrl *modifier*)
                                    :meta (modifier-meta *modifier*)
-                                   ;; :super (modifier-super *modifier*)
+                                   :super (modifier-super *modifier*)
                                    :shift nil
                                    :sym (convert-to-sym (char-code c)))))
                 (send-key-event key)))))
@@ -275,11 +275,12 @@
                    (or (not text-input-p)
                        (modifier-ctrl modifier)
                        (modifier-meta modifier)
+                       (modifier-super modifier)
                        (< 256 code)))
           (let ((key (make-key-with-shift-careful :shift (modifier-shift modifier)
                                                   :ctrl (modifier-ctrl modifier)
                                                   :meta (modifier-meta modifier)
-                                                  ;; :super (modifier-super modifier)
+                                                  :super (modifier-super modifier)
                                                   :sym sym)))
             (send-key-event key)))))))
 


### PR DESCRIPTION
The super key seems to be working properly on my M1 MacBook Pro 16'  running on macOS 14.5 (23F79). Not sure if the reason behind remove/disabling it is still valid: 292d2dad5489d255749b5e6d3b9b4e3e62ef5d55