### PR TITLE
Add `require-final-newline`

### DIFF
--- a/src/fundamental-mode.lisp
+++ b/src/fundamental-mode.lisp
@@ -1,7 +1,8 @@
 (in-package :lem-core)
 
 (define-major-mode lem/buffer/fundamental-mode:fundamental-mode nil
-    (:name "Fundamental"))
+    (:name "Fundamental"
+     :require-final-newline nil))
 
 (defvar *global-keymap* (make-keymap :name '*global-keymap*))
 

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -424,6 +424,7 @@
    :mode-syntax-table
    :mode-hook
    :mode-hook-variable
+   :mode-require-final-newline
    :mode-active-p
    :major-modes
    :minor-modes

--- a/src/mode.lisp
+++ b/src/mode.lisp
@@ -99,19 +99,15 @@
   (assert (not (null mode)))
   (mode-require-final-newline (get-mode-object mode)))
 
-(defun ensure-buffer-ends-with-newline (buffer)
-  (with-point ((p (buffer-point buffer)))
-    (buffer-end p)
-    (unless (start-line-p p)
-      (insert-character p #\Newline))))
+(defun ensure-final-newline (buffer)
+  "Inserts newline at the end of BUFFER if its major mode requires it."
+  (when (mode-require-final-newline (buffer-major-mode buffer))
+    (with-point ((p (buffer-point buffer)))
+      (buffer-end p)
+      (unless (start-line-p p)
+        (insert-character p #\Newline)))))
 
-(defun handle-after-save-hook (buffer)
-  (let* ((major-mode (buffer-major-mode buffer))
-         (require-final-newline (mode-require-final-newline major-mode)))
-    (when require-final-newline
-      (ensure-buffer-ends-with-newline buffer))))
-
-(add-hook (variable-value 'after-save-hook :global t) 'handle-after-save-hook)
+(add-hook (variable-value 'after-save-hook :global t) 'ensure-final-newline)
 
 (defun major-modes ()
   (mapcar #'mode-identifier-name (collect-modes #'major-mode-p)))


### PR DESCRIPTION
POSIX standard is that text files end in a newline. Currently, lem doesn't have a way of managing this behavior besides relying on a formatter and enabling `auto-format`. 

I think this behavior shouldn't be handled by the formatter given it's the standard for text files in general. There are a lot of ways to handle this but I came upon this one while playing around and thought I should push it up as a start...

Basically, I added a `require-final-newline` slot to `major-mode`, enabled by default. This way modes themselves dictate whether a file should end in a newline, instead of being a global toggle like in some other editors. I also disabled it for fundamental mode as a precaution in case you edit a binary file for whatever reason and save it.

Let me know what you guys think or if there are any (saveable) modes where this behavior should be disabled by default. Or maybe there's a better way of doing this.