### PR TITLE
lsp-mode: update client-capabilities.json for code actions

### DIFF
--- a/extensions/lsp-mode/client-capabilities.json
+++ b/extensions/lsp-mode/client-capabilities.json
@@ -44,6 +44,20 @@
       "hierarchicalDocumentSymbolSupport":true
     },
     "codeAction":{
+        "codeActionLiteralSupport": {
+          "codeActionKind": {
+            "valueSet": [
+              "",
+              "quickfix",
+              "refactor",
+              "refactor.extract",
+              "refactor.inline",
+              "refactor.rewrite",
+              "source",
+              "source.organizeImports"
+            ]
+          }
+        }
     },
     "formatting":{
     },


### PR DESCRIPTION
Rust analyzer will not return any code actions unless `codeActionLiteralSupport` is enabled.

This adds it to the default client capabilities, based on what is configured in emacs lsp-mode, see

https://github.com/emacs-lsp/lsp-mode/blob/c36b95be6625dac5a37d3874a1a738e0c84ac39f/lsp-mode.el#L3731-L3738

With this change, they do show up provided you run `M-x lsp-code-action` when in a valid location.