### PR TITLE
Fix lisp completion current argument highlighting

### DIFF
--- a/extensions/lisp-mode/ext/autodoc.lisp
+++ b/extensions/lisp-mode/ext/autodoc.lisp
@@ -40,6 +40,7 @@
                 (erase-buffer buffer)
                 (change-buffer-mode buffer 'lisp-mode)
                 (insert-string point doc)
+                (change-buffer-mode buffer 'lem/buffer/fundamental-mode:fundamental-mode)
                 (setf (variable-value 'line-wrap :buffer buffer) nil)
                 (highlighting-marker point)
                 (funcall function buffer))))))))))


### PR DESCRIPTION
Fix highlighting the current argument:

![image](https://github.com/user-attachments/assets/3960656a-5e5a-43cb-b466-b54cbc0eb79f)

`(change-buffer-mode buffer 'lisp-mode)` was overriding the attribute, so I set it back to fundamental mode before we apply the highlight.