### PR TITLE
cw should be a synonym to ce

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -433,15 +433,18 @@ Move the cursor to the first non-blank character of the line."
   (when (point= beg end)
     (return-from vi-change))
   (let ((end-with-newline (char= (character-at end -1) #\Newline)))
-    (vi-delete beg end type)
-    (when (eq type :line)
-      (cond
-        (end-with-newline
-         (insert-character (current-point) #\Newline)
-         (character-offset (current-point) -1))
-        (t
-         (insert-character (current-point) #\Newline)))
-      (indent-line (current-point))))
+    (case type
+      (:line
+       (vi-delete beg end type)
+       (cond
+         (end-with-newline
+          (insert-character (current-point) #\Newline)
+          (character-offset (current-point) -1))
+         (t
+          (insert-character (current-point) #\Newline)))
+       (indent-line (current-point)))
+      (t (skip-whitespace-backward end)
+         (vi-delete beg end type))))
   (change-state 'insert))
 
 (define-operator vi-change-whole-line (beg end) ("<r>")

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -443,7 +443,8 @@ Move the cursor to the first non-blank character of the line."
          (t
           (insert-character (current-point) #\Newline)))
        (indent-line (current-point)))
-      (t (skip-whitespace-backward end)
+      (t (unless (eql (character-at (current-point)) #\Space)
+           (skip-whitespace-backward end))
          (vi-delete beg end type))))
   (change-state 'insert))
 


### PR DESCRIPTION
From the vim documentation on `word`:
> Special case: "cw" and "cW" are treated like "ce" and "cE" if the cursor is on a non-blank.  This is because "cw" is interpreted as change-word, and a word does not include the following white space (see also cw).