### PR TITLE
Enable fractional scaling on all platforms

### DIFF
--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -152,15 +152,15 @@
            (sdl2:with-window (window :title "Lem"
                                      :w window-width
                                      :h window-height
-                                     :flags '(:shown :resizable #+darwin :allow-highdpi))
+                                     :flags '(:shown :resizable :allow-highdpi))
              (init-application-icon window)
              (sdl2:with-renderer (renderer window :index -1 :flags '(:accelerated))
-               (let* (#+darwin (renderer-size (multiple-value-list
+               (let* ((renderer-size (multiple-value-list
                                                (sdl2:get-renderer-output-size renderer)))
-                      #+darwin (renderer-width (first renderer-size))
-                      #+darwin(renderer-height (second renderer-size))
-                      (scale-x #-darwin 1 #+darwin (/ renderer-width window-width))
-                      (scale-y #-darwin 1 #+darwin (/ renderer-height window-height))
+                      (renderer-width (first renderer-size))
+                      (renderer-height (second renderer-size))
+                      (scale-x (/ renderer-width window-width))
+                      (scale-y (/ renderer-height window-height))
                       (texture (lem-sdl2/utils:create-texture renderer
                                                               (* scale-x window-width)
                                                               (* scale-y window-height)))
@@ -174,7 +174,6 @@
                                               :char-height (font-char-height font)
                                               :scale (list scale-x scale-y))))
                  (setf (display:current-display) display)
-                 #+darwin
                  (display:adapt-high-dpi-font-size display)
                  (sdl2:start-text-input)
                  (funcall function)


### PR DESCRIPTION
HiDPI support for MacOS was enabled via #799. 
This PR just removes the `#+darwin` restriction.

It seems that the original concern (https://github.com/lem-project/lem/pull/799#issuecomment-1614346368) is no longer a problem.

Tested on Linux KDE Plasma 6.2.2
- [X] no change when running on the default X backend
- [X] no more blurry text when running on wayland backend with SDL_VIDEODRIVER=wayland

