### PR TITLE
Nix: use qlot bundle instead of manual tracking

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729880355,
-        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
@@ -52,14 +52,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1727825735,
-        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,190 +11,157 @@
   };
 
   # cribbing a lot from https://github.com/dariof4/lem-flake
+  #            and from https://github.com/eriedaberrie/my-nix-packages
   outputs = inputs:
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems =
         [ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ];
-      perSystem = { self', pkgs, lib, system, ... }:
+      perSystem = { self', pkgs, lib, ... }:
         let
-          cl-charms = pkgs.sbclPackages.cl-charms.overrideLispAttrs
-            (oldAttrs: { nativeLibs = [ pkgs.ncurses ]; });
-          jsonrpc = pkgs.sbclPackages.jsonrpc.overrideLispAttrs (oldAttrs: {
-            src = pkgs.fetchFromGitHub {
-              owner = "cxxxr";
-              repo = "jsonrpc";
-              rev = "2af1e0fad429ee8c706b86c4a853248cdd1be933";
-              hash = "sha256-N3j9eFS+jj390cjYltRCq9HyyTNUIukAJEzTqR0opU0=";
-            };
-            systems =
-              [ "jsonrpc" "jsonrpc/transport/stdio" "jsonrpc/transport/tcp" ];
-            lispLibs = with pkgs.sbclPackages;
-              oldAttrs.lispLibs ++ [ cl_plus_ssl quri fast-io trivial-utf-8 ];
-          });
-          queues = pkgs.sbclPackages.queues.overrideLispAttrs (oldAttrs: {
-            systems = [
-              "queues"
-              "queues.priority-cqueue"
-              "queues.priority-queue"
-              "queues.simple-cqueue"
-              "queues.simple-queue"
-            ];
-            lispLibs = oldAttrs.lispLibs
-              ++ (with pkgs.sbclPackages; [ bordeaux-threads ]);
-          });
-          micros = pkgs.sbcl.buildASDFSystem {
-            pname = "micros";
-            version = "unstable-2024-10-01";
-            src = pkgs.fetchFromGitHub {
-              owner = "lem-project";
-              repo = "micros";
-              rev = "af94fe5d6688f67a092f604765fb706ebae44e99";
-              hash = "sha256-XmKTMJy+8xt2ImlGXSyXdXsLOUFFB0W45ROD4OIvyPY=";
-            };
-          };
-          lem-mailbox = pkgs.sbcl.buildASDFSystem {
-            pname = "lem-mailbox";
-            version = "unstable-2023-09-10";
-            src = pkgs.fetchFromGitHub {
-              owner = "lem-project";
-              repo = "lem-mailbox";
-              rev = "12d629541da440fadf771b0225a051ae65fa342a";
-              hash = "sha256-hb6GSWA7vUuvSSPSmfZ80aBuvSVyg74qveoCPRP2CeI=";
-            };
-            lispLibs = with pkgs.sbcl.pkgs; [
-              bordeaux-threads
-              bt-semaphore
-              queues
-            ];
-          };
-          sdl2 = pkgs.sbclPackages.sdl2.overrideLispAttrs (oldAttrs: {
-            src = pkgs.fetchFromGitHub {
-              owner = "lem-project";
-              repo = "cl-sdl2";
-              rev = "24dd7f238f99065b0ae35266b71cce7783e89fa7";
-              hash = "sha256-ewMDcM3byCIprCvluEPgHD4hLv3tnUV8fjqOkVrFZSE=";
-            };
-            lispLibs = oldAttrs.lispLibs
-              ++ lib.optional pkgs.stdenv.isDarwin pkgs.sbclPackages.cl-glut;
-          });
-          sdl2-ttf = pkgs.sbclPackages.sdl2-ttf.overrideLispAttrs (oldAttrs: {
-            src = pkgs.fetchFromGitHub {
-              owner = "lem-project";
-              repo = "cl-sdl2-ttf";
-              rev = "f43344efe89cf9ce509e6ce4f7303ebb2ff14434";
-              hash = "sha256-1b0SMUipVaLq7WdDgaR9ZZhs0/c1/wyRkULsrBfTvEU=";
-            };
-            lispLibs = [
-              pkgs.sbclPackages.alexandria
-              pkgs.sbclPackages.defpackage-plus
-              pkgs.sbclPackages.cl-autowrap
-              pkgs.sbclPackages.cffi-libffi
-              pkgs.sbclPackages.trivial-garbage
-              sdl2
-            ];
-          });
-          sdl2-image = pkgs.sbclPackages.sdl2-image.overrideLispAttrs
-            (oldAttrs: {
-              src = pkgs.fetchFromGitHub {
-                owner = "lem-project";
-                repo = "cl-sdl2-image";
-                rev = "8734b0e24de9ca390c9f763d9d7cd501546d17d4";
-                hash = "sha256-TNcPOBKlB5eTlHtDAW/hpkWDMZZ/sFCHnm7dapMm5lg=";
-              };
-              lispLibs = [
-                pkgs.sbclPackages.alexandria
-                pkgs.sbclPackages.defpackage-plus
-                pkgs.sbclPackages.cl-autowrap
-                sdl2
-              ];
-            });
-          async-process = pkgs.sbclPackages.async-process.overrideLispAttrs
-            (oldAttrs: {
-              pname = "async-process";
-              version = "unstable-20241027";
-              src = pkgs.fetchFromGitHub {
-                owner = "lem-project";
-                repo = "async-process";
-                rev = "3b16b91d417530dac03559980fb5703206e20c55";
-                hash = "sha256-5J3+gc7r/LhrKPXeHGwfghKaXB+AoaXhjS8b4lida3o=";
-              };
-            });
-          lem = pkgs.sbcl.buildASDFSystem {
+          lem = pkgs.sbcl.buildASDFSystem rec {
             pname = "lem";
             version = "unstable";
+            systems = [ "lem-fake-interface" ];
             src = ./.;
-            systems = [ "lem" "lem/extensions" ];
-            lispLibs = [ async-process jsonrpc lem-mailbox micros ]
-              ++ (with pkgs.sbcl.pkgs; [ # for lem
-                alexandria
-                trivial-gray-streams
-                trivial-types
-                cl-ppcre
-                inquisitor
-                babel
-                bordeaux-threads
-                yason
-                log4cl
-                split-sequence
-                dexador
-                iterate
-                closer-mop
-                trivia
-                str
-                parse-number
-                trivial-clipboard
-                cl-setlocale
-                cl-package-locks
-                trivial-utf-8
-                async-process
-                cl-change-case
-                swank
-                esrap
-                bt-semaphore
-              ]) ++ (with pkgs.sbcl.pkgs; [ # for lem/extensions
-                _3bmd
-                _3bmd-ext-code-blocks
-                lisp-preprocessor
-                trivial-ws
-                trivial-open-browser
-              ]);
-          };
-          lem-exec = lem.overrideLispAttrs (oldAttrs: {
-            nativeBuildInputs = [ pkgs.openssl pkgs.makeBinaryWrapper ];
+
+            nativeBuildInputs = with pkgs; [
+              autoconf
+              automake
+              libffi
+              libtool
+              makeBinaryWrapper
+              pkg-config
+            ];
+
+            nativeLibs = with pkgs; [ libffi openssl ];
+
+            qlBundleLibs = pkgs.stdenvNoCC.mkDerivation {
+              pname = "${pname}-qlot-bundle";
+              inherit src version;
+
+              nativeBuildInputs = with pkgs; [
+                sbcl.pkgs.qlot-cli
+                which
+                git
+                cacert
+              ];
+
+              installPhase = ''
+                runHook preInstall
+
+                export HOME=$(mktemp -d)
+                qlot install --jobs $NIX_BUILD_CORES --no-deps --no-color
+                qlot bundle --no-color
+
+                # Unnecessary and also platform-dependent file
+                rm .bundle-libs/bundle-info.sexp
+
+                # Remove vendored .so files
+                find .bundle-libs \
+                  -type f '(' -name '*.so' -o -name '*.dll' ')' -exec rm '{}' ';'
+
+                cp -r .bundle-libs $out
+
+                runHook postInstall
+              '';
+
+              dontBuild = true;
+              dontFixup = true;
+              outputHashMode = "recursive";
+              outputHash =
+                "sha256-wRK5dU+mieajaA55cXbLoH2hvgP3wp61PN1pdooXD7o=";
+            };
+
+            configurePhase = ''
+              runHook preConfigure
+              mkdir -p $out/share/lem
+              pushd $out/share/lem
+                cp -r $qlBundleLibs .bundle-libs
+                chmod -R +w .bundle-libs
+
+                # build async-process native part
+                pushd .bundle-libs/software/async-process-*
+                  chmod +x bootstrap
+                  ./bootstrap
+                popd
+
+                # nixpkgs patch to fix cffi build on darwin
+                pushd .bundle-libs/software/cffi-*
+                  patch -p1 <${inputs.nixpkgs}/pkgs/development/lisp-modules/patches/cffi-libffi-darwin-ffi-h.patch
+                popd
+              popd
+
+              source ${inputs.nixpkgs}/pkgs/development/lisp-modules/setup-hook.sh
+              buildAsdfPath
+
+              runHook postConfigure
+            '';
+
             buildScript = pkgs.writeText "build-lem.lisp" ''
-              (load (concatenate 'string (sb-ext:posix-getenv "asdfFasl") "/asdf.fasl"))
-              (dolist (s (uiop:split-string (uiop:getenv "systems") :separator " "))
-                 (asdf:load-system s))
-              (sb-ext:save-lisp-and-die
+              (defpackage :nix-cl-user
+                (:use :cl))
+
+              (in-package :nix-cl-user)
+              (load "${lem.asdfFasl}/asdf.${lem.faslExt}")
+
+              ;; Avoid writing to the global fasl cache
+              (asdf:initialize-output-translations
+                '(:output-translations :disable-cache
+                                       :inherit-configuration))
+
+              (defvar *systems* (uiop:split-string (uiop:getenv "systems")))
+              (defvar *out-path* (uiop:getenv "out"))
+              (defvar *share-path* (concatenate 'string
+                                    *out-path*
+                                    "/share/lem"))
+              (defvar *bundle-path* (concatenate 'string
+                                    *share-path*
+                                    "/.bundle-libs/bundle.lisp"))
+
+              ;; Initial load
+              (let ((asdf:*system-definition-search-functions*
+                       (copy-list asdf:*system-definition-search-functions*)))
+                (load *bundle-path*)
+                (loop :for system :in *systems*
+                      :do (asdf:load-system system)))
+
+              ;; Load the bundle on every startup
+              (uiop:register-image-restore-hook
+                (lambda ()
+                  (load *bundle-path*))
+                   nil)
+
+              (setf uiop:*image-entry-point* #'lem:main)
+              (uiop:dump-image
                 "lem"
                 :executable t
-                :purify t
-                #+sb-core-compression :compression
-                #+sb-core-compression t
-                :toplevel #'lem:main)
+                :compression t)
             '';
             installPhase = ''
-              mkdir -p $out/bin
-              cp -v lem $out/bin
+              runHook preInstall
+
+              mkdir -p $out/bin $out/share/lem
+              mv lem $out/bin
               wrapProgram $out/bin/lem \
                 --prefix LD_LIBRARY_PATH : "$LD_LIBRARY_PATH" \
-                --prefix DYLD_LIBRARY_PATH : "$DYLD_LIBRARY_PATH" \
+                --prefix DYLD_LIBRARY_PATH : "$DYLD_LIBRARY_PATH"
+
+              cp -r . $out/share/lem
+
+              runHook postInstall
             '';
-          });
+          };
         in {
-          packages.lem-ncurses = lem-exec.overrideLispAttrs (oldAttrs: {
+          packages.lem-ncurses = lem.overrideLispAttrs (o: {
+            pname = "lem-ncurses";
             systems = [ "lem-ncurses" ];
-            lispLibs = oldAttrs.lispLibs ++ [ cl-charms ];
+            nativeLibs = with pkgs; o.nativeLibs ++ [ ncurses ];
           });
-          packages.lem-sdl2 = lem-exec.overrideLispAttrs (oldAttrs: {
+          packages.lem-sdl2 = lem.overrideLispAttrs (o: {
+            pname = "lem-sdl2";
             systems = [ "lem-sdl2" ];
-            lispLibs = oldAttrs.lispLibs ++ [
-              sdl2
-              sdl2-ttf
-              sdl2-image
-              pkgs.sbclPackages.trivial-main-thread
-            ];
-            nativeLibs = [ pkgs.SDL2 pkgs.SDL2_ttf pkgs.SDL2_image ];
+            nativeLibs = with pkgs;
+              o.nativeLibs ++ [ SDL2 SDL2_ttf SDL2_image ];
           });
 
           packages.default = self'.packages.lem-ncurses;

--- a/flake.nix
+++ b/flake.nix
@@ -67,9 +67,6 @@
 
               dontBuild = true;
               dontFixup = true;
-              outputHashMode = "recursive";
-              outputHash =
-                "sha256-wRK5dU+mieajaA55cXbLoH2hvgP3wp61PN1pdooXD7o=";
             };
 
             configurePhase = ''


### PR DESCRIPTION
This PR replaces the manual dependency pinning with a build process that uses `qlot bundle` to handle downloading dependencies based on the `qllock` file.