### PR TITLE
Update isearch.lisp

### DIFF
--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -450,7 +450,9 @@
           (return nil))))))
 
 (define-command isearch-next-highlight (n) (:universal)
-  (search-next-matched (current-point) n))
+  (cond ((zerop n) nil)
+        ((minusp n) (search-next-matched (current-point) (1+ n)))
+        (t (search-next-matched (current-point) n))))
 
 (define-command isearch-prev-highlight (n) (:universal)
   (isearch-next-highlight (- n)))


### PR DESCRIPTION
fix `isearch-next-highlight` and `isearch-prev-highlight` so that numeric prefixes work correctly.  

in the original code, Shift+F3 skips a highlight, a prefix argument of 0 (zero) goes to the previous highlight with `prev-highlight` and `next-highlight`, and prefix arguments don't work properly when the point is going backwards because they skip a highlight