### PR TITLE
nix: readd output hash for qlot bundle

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,9 @@
 
               dontBuild = true;
               dontFixup = true;
+              outputHashMode = "recursive";
+              outputHash =
+                "sha256-wRK5dU+mieajaA55cXbLoH2hvgP3wp61PN1pdooXD7o=";
             };
 
             configurePhase = ''


### PR DESCRIPTION
I removed the bundle hash from the last PR (#1593) and that ended up not being the right thing to do. This PR reverts that particular change.