### PR TITLE
make isearch-next|prev-highlight mimic isearch movement exactly

### DIFF
--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -443,7 +443,7 @@
                    (end point))
         (funcall search-fn end string)
         (funcall search-previous-fn (move-point start end) string)
-        (when (point<= start point)
+        (when (point< end point)
           (move-point point end)))
       (dotimes (_ (abs n) point)
         (unless (funcall search-fn point string)


### PR DESCRIPTION
with this modification, isearch-next|prev-highlight will mimic isearch movement exactly, which i feel is more intuitive for those who use isearch a lot

font-size: 16px;
...
font-size: 22px;
...
font-size: 16px:
...
font-size: 20px;
...
| (<-- point here)

you search for "font-size: ", and now it's highlighted.  maybe you want to change the 22px font size.  with the current code, if you go back with `Shift+F3` , then, when you press `F3`, you will jump forward to the next instance of font-size, which is not how isearch works.  

but, with this patch, if you press `F3`, you will go to end of the highlight instead of the next instance, which i find more logical for isearch and better in general because now you can `kill-line` and put in the new font-size value