### PR TITLE
fix: sdl2 should not disable the kwin compositor, which will cause the window effects invalid, including the window opacity.

### DIFF
--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -209,6 +209,9 @@
                      (if (lem:config :darwin-use-native-fullscreen) 1 0))
       ;; sdl2 should not install any signal handlers, since the lisp runtime already does so
       (sdl2:set-hint :no-signal-handlers 1)
+       ;; sdl2 should not disable the kwin compositor, since lem editor is not a game, and disable this will not bring noticeable performance improvement.
+      (sdl2:set-hint :video-x11-net-wm-bypass-compositor 0)
+
       (tmt:with-body-in-main-thread ()
         (sdl2:make-this-thread-main (lambda ()
                                       (handler-bind

--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -209,7 +209,7 @@
                      (if (lem:config :darwin-use-native-fullscreen) 1 0))
       ;; sdl2 should not install any signal handlers, since the lisp runtime already does so
       (sdl2:set-hint :no-signal-handlers 1)
-       ;; sdl2 should not disable the kwin compositor, since lem editor is not a game, and disable this will not bring noticeable performance improvement.
+      ;; sdl2 should not disable the kwin compositor, since lem editor is not a game, and disable it will not bring noticeale performance improvement.
       (sdl2:set-hint :video-x11-net-wm-bypass-compositor 0)
 
       (tmt:with-body-in-main-thread ()


### PR DESCRIPTION
To fix issue: https://github.com/lem-project/lem/issues/1617