### PR TITLE
feature: add vi-swapcase-and-forward-char command for vi-mode

### DIFF
--- a/extensions/vi-mode/binds.lisp
+++ b/extensions/vi-mode/binds.lisp
@@ -128,6 +128,7 @@
 (define-key *normal-keymap* "g U" 'vi-upcase)
 (define-key *normal-keymap* "g u" 'vi-downcase)
 (define-key *normal-keymap* "g ~" 'vi-swapcase)
+(define-key *normal-keymap* "~" 'vi-swapcase-and-forward-char)
 (define-key *normal-keymap* "u" 'vi-undo)
 (define-key *normal-keymap* "C-r" 'vi-redo)
 (define-key *motion-keymap* 'delete-previous-char 'vi-backward-char)

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -90,6 +90,7 @@
            :vi-upcase
            :vi-downcase
            :vi-swapcase
+           :vi-swapcase-and-forward-char
            :vi-undo
            :vi-redo
            :vi-record-macro
@@ -638,6 +639,12 @@ Move the cursor to the first non-blank character of the line."
     (if (eq type :block)
         (apply-visual-range #'swapcase-region)
         (swapcase-region start end))))
+
+(define-command vi-swapcase-and-forward-char () ()
+  (let*  ((start (copy-point (current-point)))
+          (end (character-offset (current-point) 1)))
+    (vi-swapcase start end (current-state)))
+  (vi-forward-char))
 
 (define-command vi-undo (&optional (n 1)) (:universal)
   (undo n))

--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -215,6 +215,15 @@
     (funcall callback window point)
     t))
 
+(defun sync-mark-start-point-for-vi-mode (start-point)
+  (when (typep (lem:current-global-mode) 'lem-vi-mode:vi-mode)
+    ;; Ensure current main state is visual-char.
+    (unless (lem-vi-mode/visual:visual-char-p)
+      (lem-vi-mode/commands::vi-visual-char))
+    ;; Override the *start-point* in vi-visual mode.
+    (setf lem-vi-mode/visual::*start-point* start-point)
+    ))
+
 (defmethod handle-mouse-hover (buffer mouse-event &key window x y)
   (case (mouse-event-button mouse-event)
     ((nil)
@@ -224,6 +233,8 @@
            (handle-mouse-unhover-buffer window point))))
     (:button-1
      (when (window-last-mouse-button-down-point window)
+       (sync-mark-start-point-for-vi-mode (window-last-mouse-button-down-point window))
+       
        (move-current-point-to-x-y-position window x y)
        (set-current-mark (window-last-mouse-button-down-point window))))))
 
@@ -310,6 +321,8 @@
   (multiple-value-bind (start end)
       (get-select-expression-points (current-point))
     (when start
+      (sync-mark-start-point-for-vi-mode start) 
+      
       (set-current-mark start)
       (move-point (current-point) end))))
 


### PR DESCRIPTION
To close the issue: https://github.com/lem-project/lem/issues/1621

The command `vi-swapcase-and-forward-char` is used as a **shortcut** to swap-case on cursor and forward char in **vi-normal mode**.
The `vi-swapcase` is an **vi-operator**, which requires an extract **motion action**, to decide the region of swap-case, which may be an over-kill for some simple-case.

If you only want to swapcase for consecutive characters, just simply press the `~` key, and this new command will swap the case of character, move the cursor to forward character, repeatly.