### PR TITLE
feature: sync mark region for vi-mode.

### DIFF
--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -215,6 +215,15 @@
     (funcall callback window point)
     t))
 
+(defun sync-mark-start-point-for-vi-mode (start-point)
+  (when (typep (lem-core:current-global-mode) 'lem-vi-mode:vi-mode)
+    ;; Ensure current main state is visual-char.
+    (unless (lem-vi-mode/visual:visual-char-p)
+      (lem-vi-mode/commands::vi-visual-char))
+    ;; Override the *start-point* in vi-visual mode.
+    (setf lem-vi-mode/visual::*start-point* start-point)
+    ))
+
 (defmethod handle-mouse-hover (buffer mouse-event &key window x y)
   (case (mouse-event-button mouse-event)
     ((nil)
@@ -224,6 +233,8 @@
            (handle-mouse-unhover-buffer window point))))
     (:button-1
      (when (window-last-mouse-button-down-point window)
+       (sync-mark-start-point-for-vi-mode (window-last-mouse-button-down-point window))
+       
        (move-current-point-to-x-y-position window x y)
        (set-current-mark (window-last-mouse-button-down-point window))))))
 
@@ -310,6 +321,8 @@
   (multiple-value-bind (start end)
       (get-select-expression-points (current-point))
     (when start
+      (sync-mark-start-point-for-vi-mode start) 
+      
       (set-current-mark start)
       (move-point (current-point) end))))
 


### PR DESCRIPTION
Related issue: https://github.com/lem-project/lem/issues/1590

To sync the mark-region between `vi-mode` and `mouse-clicking`:
1. Ensure the `vi-visual-char` mode is entered, when selecting a region using mouse.
2. Sync the `*start-point*` for `vi-visual-mode`.

This pr contains some cons:
1. The `visual-overlay` may not be cleared correctly: The `visual-overlay` will be cleared after you pressed `y` key in `vi-visaul mode`, if `(current-point)` > `*start-point*` (In right-side). It will not be cleared if `(current-point)` < `*start-point*` (In left-side).
2. Press `v` key again in `vi-visual-char` mode will not clear the `visual-overlay` selected by mouse.

Anyway, this pr:
1. Ensure the vi-mode will be `vi-visual-char` mode, if you use mouse to select a mark region.
2. Press `y` key in `vi-visual-char` mode can copy the `correct string` into `clip-board`. (Though it will not ensure the `visual-overlay` be synced.)

