### PR TITLE
update point after `isearch-delete-char` and `isearch-yank`

### DIFF
--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -305,6 +305,7 @@
           (subseq *isearch-string*
                   0
                   (1- (length *isearch-string*))))
+    (funcall *isearch-search-function* (current-point) *isearch-string*)
     (isearch-update-display)))
 
 (define-command isearch-raw-insert () ()
@@ -394,6 +395,7 @@
   (let ((str (yank-from-clipboard-or-killring)))
     (when str
       (setq *isearch-string* str)
+      (funcall *isearch-search-function* (current-point) *isearch-string*)
       (isearch-update-display))))
 
 (defun isearch-add-char (c)


### PR DESCRIPTION
update point after backspacing and yanking when isearch is active

|
;; one test is what you need

(| is the point) with this patch, if you search for "ee" and then backspace, the point will move to the end of the word "one".   in Lem currently, if you search for "ee" and then backspace, the point will stay after "ee", when I feel it should be at the end of "one" since the search string has changed.  this patch also works when reverse searching 

|
;; one test is what you need

(| is the point) with this patch, if "one test" is the current kill string and you yank, the point will move to after "one test".  in Lem currently, the point will not move after yanking, which i don't think is natural