### PR TITLE
Add keybinds for isearch toggle highlighting

### DIFF
--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -83,6 +83,8 @@
 (define-key *global-keymap* "M-s p" 'isearch-prev-highlight)
 (define-key *global-keymap* "F3" 'isearch-next-highlight)
 (define-key *global-keymap* "Shift-F3" 'isearch-prev-highlight)
+(define-key *global-keymap* "M-s t" 'isearch-toggle-highlighting)
+(define-key *global-keymap* "M-s M-t" 'isearch-toggle-highlighting)
 (define-key *isearch-keymap* "C-M-n" 'isearch-add-cursor-to-next-match)
 
 (defun disable-hook ()

--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -305,6 +305,7 @@
           (subseq *isearch-string*
                   0
                   (1- (length *isearch-string*))))
+    (funcall *isearch-search-function* (current-point) *isearch-string*)
     (isearch-update-display)))
 
 (define-command isearch-raw-insert () ()
@@ -394,6 +395,7 @@
   (let ((str (yank-from-clipboard-or-killring)))
     (when str
       (setq *isearch-string* str)
+      (funcall *isearch-search-function* (current-point) *isearch-string*)
       (isearch-update-display))))
 
 (defun isearch-add-char (c)


### PR DESCRIPTION
i hope it's okay to add dedicated keybinds for `isearch-toggle-highlighting`.  the keybinds feel very natural, and having the command available to the user as a default keybind seems user-friendly to me.

i apologize for not knowing git and if this creates conflicts in case you don't accept my previous pull requests involving updating the point during isearch on backspace and yank.  i'm a pure beginner with git, but i will continue to get better at it