### PR TITLE
Fix and refactor kill whole line

### DIFF
--- a/src/commands/edit.lisp
+++ b/src/commands/edit.lisp
@@ -212,13 +212,17 @@
            (let ((end (current-point)))
              (kill-region start end))))))))
 
-(define-command kill-whole-line () ()
-  "Kill the entire line and the remaining whitespace"
-   (with-point ((start (current-point))
-                (end (current-point)))
-     (line-end end)
-     (kill-region start end))
-   (delete-previous-char))
+(define-command kill-whole-line (n) (:universal)
+  "If n is positive, kill n whole lines forward starting
+at the beginning of the current line.  If n is 0, do nothing.
+And if n is negative, kill n lines above without deleting
+anything the current line."
+  (cond ((zerop n) nil)
+        ((minusp n) (save-excursion
+                      (move-to-beginning-of-logical-line)
+                      (kill-line n)))
+        (t (progn (move-to-beginning-of-logical-line)
+                  (kill-line n)))))
 
 (defun yank-string (point string)
   (change-yank-start point

--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -83,6 +83,8 @@
 (define-key *global-keymap* "M-s p" 'isearch-prev-highlight)
 (define-key *global-keymap* "F3" 'isearch-next-highlight)
 (define-key *global-keymap* "Shift-F3" 'isearch-prev-highlight)
+(define-key *global-keymap* "M-s t" 'isearch-toggle-highlighting)
+(define-key *global-keymap* "M-s M-t" 'isearch-toggle-highlighting)
 (define-key *isearch-keymap* "C-M-n" 'isearch-add-cursor-to-next-match)
 
 (defun disable-hook ()

--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -305,6 +305,7 @@
           (subseq *isearch-string*
                   0
                   (1- (length *isearch-string*))))
+    (funcall *isearch-search-function* (current-point) *isearch-string*)
     (isearch-update-display)))
 
 (define-command isearch-raw-insert () ()
@@ -394,6 +395,7 @@
   (let ((str (yank-from-clipboard-or-killring)))
     (when str
       (setq *isearch-string* str)
+      (funcall *isearch-search-function* (current-point) *isearch-string*)
       (isearch-update-display))))
 
 (defun isearch-add-char (c)


### PR DESCRIPTION
sorry, again, about all the github trouble.  i'll study git in the next days so that my requests are not redundant.

at present, Lem's `kill-whole-line` kills the line and then does `delete-previous-char`, which seems wrong.  this patch makes `kill-whole-line`, one, kill the entire line, including the new line at the end of a line if indeed there is one, and, two, allow it to be prefixed.

|;; one one one
;; two two two
;; three three three
;; four four four
;; five five five

(| is point) if `5 kill-whole-line`, all lines are deleted.

;; one one one
;; two two two
;; three three |three
;; four four four
;; five five five

(| is point) if `0 kill-whole-line`, nothing happens.

;; one one one
;; two two two
;; three three |three
;; four four four
;; five five five

(| is point) if `-2 kill-whole-line`, ";; one one one" and ";; two two two" are deleted, and the point stays right before the last "three".  if you want to delete the previous "three"s, then you can use the `kill` command.  

i'm curious if others agree with me
