### PR TITLE
Add keybinds for `isearch-toggle-highlighting`

### DIFF
--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -83,6 +83,8 @@
 (define-key *global-keymap* "M-s p" 'isearch-prev-highlight)
 (define-key *global-keymap* "F3" 'isearch-next-highlight)
 (define-key *global-keymap* "Shift-F3" 'isearch-prev-highlight)
+(define-key *global-keymap* "M-s t" 'isearch-toggle-highlighting)
+(define-key *global-keymap* "M-s M-t" 'isearch-toggle-highlighting)
 (define-key *isearch-keymap* "C-M-n" 'isearch-add-cursor-to-next-match)
 
 (defun disable-hook ()


### PR DESCRIPTION
i hope it's okay to add dedicated keybinds for `isearch-toggle-highlighting`. the keybinds feel very natural, and having the command available to the user as a default keybind seems user-friendly to me.