### PR TITLE
fix and refactor `kill-whole-line`

### DIFF
--- a/src/commands/edit.lisp
+++ b/src/commands/edit.lisp
@@ -212,13 +212,17 @@
            (let ((end (current-point)))
              (kill-region start end))))))))
 
-(define-command kill-whole-line () ()
-  "Kill the entire line and the remaining whitespace"
-   (with-point ((start (current-point))
-                (end (current-point)))
-     (line-end end)
-     (kill-region start end))
-   (delete-previous-char))
+(define-command kill-whole-line (&optional (n 1)) (:universal)
+  "If n is positive, kill n whole lines forward starting at the
+beginning of the current line.  If n is 0, do nothing.  And if n
+is negative, kill n lines above without deleting anything on the 
+current line."
+  (cond ((zerop n) nil)
+        ((minusp n) (save-excursion
+                      (move-to-beginning-of-logical-line)
+                      (kill-line n)))
+        (t (progn (move-to-beginning-of-logical-line)
+                  (kill-line n)))))
 
 (defun yank-string (point string)
   (change-yank-start point


### PR DESCRIPTION
this patch makes `kill-whole-line`, one, kill the entire line, including the new line at the end of a line if indeed it is there, and, two, allow for prefixes

|;; one one one
;; two two two
;; three three three
;; four four four
;; five five five

(| is point) if `5 kill-whole-line`, all lines are deleted.

;; one one one
;; two two two
;; three three |three
;; four four four
;; five five five

(| is point) if `0 kill-whole-line`, nothing happens.

;; one one one
;; two two two
;; three three |three
;; four four four
;; five five five

(| is point) if `-2 kill-whole-line`, ";; one one one" and ";; two two two" are deleted, and the point stays right before the last "three".  if you want to delete the previous "three"s, then you can use the `kill` command.

i'm curious if others agree with me