### PR TITLE
feature: add option for highlight line-color.

### DIFF
--- a/src/highlight-line.lisp
+++ b/src/highlight-line.lisp
@@ -1,8 +1,14 @@
 (in-package :lem-core)
 
 (define-editor-variable highlight-line nil)
+(define-editor-variable highlight-line-color nil)
 
 (defun highlight-line-color ()
+  (alexandria:if-let ((color (variable-value 'highlight-line-color)))
+    color
+    (guess-highlight-line-color)))
+
+(defun guess-highlight-line-color ()
   (when (background-color)
     (let ((color (parse-color (background-color))))
       (multiple-value-bind (h s v)


### PR DESCRIPTION
To close issue: https://github.com/lem-project/lem/issues/1650

To configure the `line-color`, eval: 
```
(setf (lem:variable-value 'lem-core::highlight-line-color :global) "#000066")
```

The screen-shot:
![Screenshot_20241130_091135](https://github.com/user-attachments/assets/f86bc4cb-a0bd-4382-b5d6-c6d69d453cd2)