### PR TITLE
feature: add impl-source-read-only editor-variable

### DIFF
--- a/src/lem.lisp
+++ b/src/lem.lisp
@@ -303,3 +303,17 @@ See scripts/build-ncurses.lisp or scripts/build-sdl2.lisp"
                   (insert-string (buffer-point buffer) warning)
                   (insert-character (buffer-point buffer) #\newline))
                 (pop-to-buffer buffer)))))
+
+
+(defun impl-source-buffer-p (buffer)
+  (pathname-match-p (buffer-directory buffer)
+                    (second (assoc "SYS:SRC;**;*.*.*" (logical-pathname-translations "SYS") :test 'equal)))
+  )
+
+(add-hook *after-init-hook*
+          (lambda ()
+            (when (variable-value 'impl-source-read-only)
+              (add-hook *switch-to-buffer-hook* (lambda (buffer)
+                                                  (when (impl-source-buffer-p buffer)
+                                                    (setf (buffer-read-only-p buffer) t)))))
+            ))

--- a/src/window/window.lisp
+++ b/src/window/window.lisp
@@ -1,6 +1,7 @@
 (in-package :lem-core)
 
 (define-editor-variable line-wrap t)
+(define-editor-variable impl-source-read-only t)
 
 (defparameter *window-sufficient-width* 150)
 (defparameter *scroll-recenter-p* t)


### PR DESCRIPTION
To close issue: https://github.com/lem-project/lem/issues/1615

**This option is enabled by default**, to disable it, eval the form in `init.lisp`
```
(setf (lem:variable-value 'lem-core::impl-source-read-only :global) nil)
```

The typical value of source dir for `sbcl implementation` are:
- `/usr/share/sbcl-source/src/code/` (installed via `yay -S sbcl`)
- `~/.roswell/src/sbcl-2.4.10/src/code/` (installed via `roswell`)

There may be a better function to decide if `(current-directory)` is part of `implementation source directory`.

![image](https://github.com/user-attachments/assets/22730859-bd9f-47c4-b406-7bae4206e048)
