### PR TITLE
java-mode: Use c-mode indentation function to indent Java files

### DIFF
--- a/extensions/java-mode/java-mode.lisp
+++ b/extensions/java-mode/java-mode.lisp
@@ -76,6 +76,7 @@ see : https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html
      :mode-hook *java-mode-hook*)
   (setf (variable-value 'enable-syntax-highlight) t
         (variable-value 'indent-tabs-mode) nil
+        (variable-value 'calc-indent-function) 'lem-c-mode::calc-indent
         (variable-value 'tab-width) 2
         (variable-value 'line-comment) "//"))
 


### PR DESCRIPTION
I found Lem today. :) I saw that I can't indent Java files. It looked like it was missing an indent function, so I am using the one from c-mode.