### PR TITLE
fix: ignore errors during the process of creating regex scanner for vi-search-{forward/backward}

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -642,7 +642,7 @@ Move the cursor to the first non-blank character of the line."
 
 (define-command vi-swapcase-and-forward-char () ()
   (with-point ((start (current-point))
-                            (end (current-point)))
+               (end (current-point)))
     (character-offset end 1)
     (vi-swapcase start end (current-state)))
   (vi-forward-char))
@@ -788,18 +788,18 @@ on the same line or at eol if there are none."
        (lambda (point string)
          (alexandria:when-let (p (lem/isearch::search-forward-regexp
                                   (copy-point lem/isearch::*isearch-start-point* :temporary)
-                                  (ppcre:create-scanner string :case-insensitive-mode case-insensitive)))
+                                  (ignore-errors (ppcre:create-scanner string :case-insensitive-mode case-insensitive))))
            (character-offset p (- (length string)))
            (move-point point p)))
        (lambda (point regex &optional limit-point)
          (lem/isearch::search-forward-regexp
-          point
-          (ppcre:create-scanner regex :case-insensitive-mode case-insensitive)
-          limit-point))
+               point
+               (ignore-errors (ppcre:create-scanner regex :case-insensitive-mode case-insensitive))
+               limit-point))
        (lambda (point regex &optional limit-point)
          (lem/isearch::search-backward-regexp
           point
-          (ppcre:create-scanner regex :case-insensitive-mode case-insensitive)
+          (ignore-errors (ppcre:create-scanner regex :case-insensitive-mode case-insensitive))
           limit-point))
        ""))))
 


### PR DESCRIPTION
To close: https://github.com/lem-project/lem/issues/1649

Maybe there should be a helper-macro to wrap the call to `ppcre:create-scanner`.
We know there are many matching tokens in regex language, so we should not try to create the regex-scanner immediately after each-character typed. Take the regex `(\w)` for example, if we create the sacnner at once, it will throw an error after the input of `(` due to the `not matched parenthesis error thrown by ppcre`.