### PR TITLE
fix: adjust the cursor-type to underline for vi-operator + the color of vi-insert cursor now respects the default cursor color

### DIFF
--- a/extensions/vi-mode/states.lisp
+++ b/extensions/vi-mode/states.lisp
@@ -70,7 +70,6 @@
 (define-state insert () ()
   (:default-initargs
    :name "INSERT"
-   :cursor-color "IndianRed"
    :cursor-type :bar
    :modeline-color 'state-modeline-aqua
    :keymaps (list *insert-keymap*)))
@@ -89,6 +88,7 @@
 
 (define-state operator (normal) ()
   (:default-initargs
+   :cursor-type :underline
    :keymaps (list *operator-keymap* *normal-keymap*)))
 
 ;;


### PR DESCRIPTION
Solve part of the issue: https://github.com/lem-project/lem/issues/1648

This commit contains changes:
- The color of cursor in vi-insert-mode should respect the set default cursor color.
- The cursor-type for `vi-operator` should be `underline`, e.g. the `ciw` command.

---
It will be better, after the bug of drawing of `underline` and `bar` cursor type in `sdl2 version` is fixed. The `underline` and `bar` cursor tpe is drawn well in `ncursrs version`.

In `sdl2 version`:
1. The `underline` cursor-type will over-draw the character under caret.
2. The `bar` cursor-type will over-draw the character under caret in some cases, taken `"LEM"` string for example.