### PR TITLE
fix: the *fill-width* option should not cause the prompt window in listener-mode out of window

### DIFF
--- a/extensions/lisp-mode/repl.lisp
+++ b/extensions/lisp-mode/repl.lisp
@@ -522,7 +522,8 @@
 (defvar *lisp-repl-shortcuts* '())
 
 (defmacro with-repl-prompt (() &body body)
-  `(let ((lem/prompt-window:*prompt-completion-window-shape* nil))
+  `(let ((lem/prompt-window:*prompt-completion-window-shape* nil)
+         (lem/prompt-window::*fill-width* nil))
      ,@body))
 
 (defun repl-prompt-for-string (prompt &rest args)

--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -348,7 +348,7 @@
           (*history-matched-string* nil)
           (*listener-window* (current-window)))
       (unwind-protect
-           (progn
+           (let ((lem/prompt-window::*fill-width* nil))
              (prompt-for-string
               "(reverse-i-search) "
               :special-keymap *history-isearch-keymap*


### PR DESCRIPTION
To close issue: https://github.com/lem-project/lem/issues/1654

Just like the special variables for `pprint` control, use the `let` binding form to modify the **special variable** `*fill-width*`, to avoid modifying the signature of functions in the call stack.

Screen-shots:
![image](https://github.com/user-attachments/assets/b9321d4a-b2fb-4fe0-bfb8-7f94046caf16)
![image](https://github.com/user-attachments/assets/979a4b77-120d-4ac4-827a-e92587f1462f)
