### PR TITLE
feature: add `:new` ex-command for `vi-mode`

### DIFF
--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -259,3 +259,7 @@
 (define-ex-command "^pwd?$" (range argument)
   (declare (ignore range argument))
   (lem:current-directory))
+
+(define-ex-command "^new?$" (range argument)
+  (declare (ignore range argument))
+  (lem/frame-multiplexer:frame-multiplexer-create-with-new-buffer-list))


### PR DESCRIPTION
The `:new` command in `vi-ex mode` is used to create a new empty buffer.