### PR TITLE
fix: the `vi-paste-before` command in `line-mode` at `the last line` should open a newline before current line.

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -568,7 +568,11 @@ Move the cursor to the first non-blank character of the line."
          (insert-character (current-point) #\Newline)))
       (t
        (when (eq type :line)
-         (line-start (current-point)))))
+         (if (last-line-p (current-point))
+             (progn
+               (line-start (current-point))
+               (open-line 1))
+             (line-start (current-point))))))
     (paste-yank string type :before)))
 
 (defun read-key-to-replace ()

--- a/extensions/vi-mode/tests/commands.lisp
+++ b/extensions/vi-mode/tests/commands.lisp
@@ -69,6 +69,16 @@
         (ok (buf= #?"abcd\nefgh\n[a]bcd\n"))
         (cmd "P")
         (ok (buf= #?"abcd\nefgh\n[a]bcd\nabcd\n"))))
+    (testing "paste line before - not at last line"
+      (with-vi-buffer (#?"first\nsecond\nthird1 th[i]rd2 third3\nend")
+        (cmd "yy")
+        (cmd "P")
+        (ok (buf= #?"first\nsecond\n[t]hird1 third2 third3\nthird1 third2 third3\nend"))))
+    (testing "paste line before - at last line"
+      (with-vi-buffer (#?"first\nsecond\nthird1 th[i]rd2 third3")
+        (cmd "yy")
+        (cmd "P")
+        (ok (buf= #?"first\nsecond\n[t]hird1 third2 third3\nthird1 third2 third3"))))
     (testing "paste block"
       (with-vi-buffer (#?"a[b]cd\nefgh\n")
         (cmd "<C-v>jly")


### PR DESCRIPTION
This commit fix the `edge case` when vi-paste a line before at the last line.

Taken this example buffer
```
first
second
third1 th[i]rd2 third 3
```

If current-line is **at the last line**, then the `vi-paste-before` command in `line-mode` should `open a new line` above `current-line`.

---
The keypoint is that: **The last line** doesn't contains the **line-break character**, so it's an edge-case.