### PR TITLE
fix(flake): Update outputHash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
               dontFixup = true;
               outputHashMode = "recursive";
               outputHash =
-                "sha256-Ya1f0GcDBIRuJDgIC03Mp325ns393zwQ9DNGlbAhqOY=";
+                "sha256-NtCSBxEo/4uuhlLc9Xqlq+PM1fAbDfRBH64imMLvKYE=";
             };
 
             configurePhase = ''


### PR DESCRIPTION
Update output hash after commit 86d9f36a.
86d9f36a changed versions in qlfile.lock, which of course broke the Nix flake.
This change sets the new hash.