### PR TITLE
add convenient keybinds for LEM's multiplexer.

### DIFF
--- a/src/ext/frame-multiplexer.lisp
+++ b/src/ext/frame-multiplexer.lisp
@@ -62,6 +62,18 @@
 (define-key *keymap* "p" 'frame-multiplexer-prev)
 (define-key *keymap* "n" 'frame-multiplexer-next)
 (define-key *keymap* "r" 'frame-multiplexer-rename)
+(define-key *keymap* "C-z" 'frame-multiplexer-recent)
+(define-key *keymap* "z" 'frame-multiplexer-recent)
+(define-key *keymap* "0" 'frame-multiplexer-switch-0)
+(define-key *keymap* "1" 'frame-multiplexer-switch-1)
+(define-key *keymap* "2" 'frame-multiplexer-switch-2)
+(define-key *keymap* "3" 'frame-multiplexer-switch-3)
+(define-key *keymap* "4" 'frame-multiplexer-switch-4)
+(define-key *keymap* "5" 'frame-multiplexer-switch-5)
+(define-key *keymap* "6" 'frame-multiplexer-switch-6)
+(define-key *keymap* "7" 'frame-multiplexer-switch-7)
+(define-key *keymap* "8" 'frame-multiplexer-switch-8)
+(define-key *keymap* "9" 'frame-multiplexer-switch-9)
 (define-key *global-keymap* "C-z" *keymap*)
 
 (defstruct tab


### PR DESCRIPTION
`C-z C-z` and `C-z z` are frame-multiplexer-recent, very helpful to switch between frames quickly. if you are constantly switching between two frames, `C-z C-z` is super easy and fast to press

`C-z N` (where N is number between 0 and 9) to go to the Nth frame directly.  very logical and intuitive.  tmux also uses the same system