### PR TITLE
make `C-m` (`Return`)  `newline-and-indent` in language modes

### DIFF
--- a/src/ext/language-mode.lisp
+++ b/src/ext/language-mode.lisp
@@ -83,6 +83,7 @@
 (define-key *language-mode-keymap* "C-M-a" 'beginning-of-defun)
 (define-key *language-mode-keymap* "C-M-e" 'end-of-defun)
 (define-key *language-mode-keymap* "Tab" 'indent-line-and-complete-symbol)
+(define-key *language-mode-keymap* "Return" 'newline-and-indent)
 (define-key *global-keymap* "C-j" 'newline-and-indent)
 (define-key *global-keymap* "M-j" 'newline-and-indent)
 (define-key *language-mode-keymap* "C-M-\\" 'indent-region)


### PR DESCRIPTION
i always use `C-m` for `newline`, so i wanted to see if you would be okay making it also indent.  if the user wants a new line that is not indented, then they can use `C-q C-j` to get one.  this is for using other language modes other than lisp where it is the default