### PR TITLE
[DRAFT] add: the `:jumps` ex-command for vi-mode.

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -123,6 +123,7 @@
            :vi-append-line
            :vi-open-below
            :vi-open-above
+           :vi-jumps
            :vi-jump-back
            :vi-jump-next
            :vi-a-word
@@ -1014,6 +1015,11 @@ on the same line or at eol if there are none."
                                          (back-to-indentation p))
                                     (line-start p))))))
     (move-to-column (current-point) column t)))
+
+(define-command vi-jumps () ()
+  (line-end (current-point))
+  (lem:message (with-output-to-string (s)
+                 (lem-vi-mode/jumplist::print-jumplist (current-jumplist) s))))
 
 (define-command vi-jump-back (&optional (n 1)) (:universal)
   (dotimes (i n)

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -403,10 +403,10 @@ Move the cursor to the first non-blank character of the line."
                          (max 0
                               (min (1- (length (line-string (current-point)))) pos))))
         (:block
-         (move-to-line (current-point) (min (line-number-at-point start)
-                                            (line-number-at-point end)))
-         (move-to-column (current-point) (min column-start
-                                              column-end))))
+            (move-to-line (current-point) (min (line-number-at-point start)
+                                               (line-number-at-point end)))
+          (move-to-column (current-point) (min column-start
+                                               column-end))))
       ;; After 'dw' or 'dW', move to the first non-blank char
       (when (and (this-motion-command)
                  (member (command-name (this-motion-command))
@@ -507,10 +507,10 @@ Move the cursor to the first non-blank character of the line."
   (yank-region start end :type type)
   (case type
     (:block
-     (move-to-line (current-point) (min (line-number-at-point start)
-                                        (line-number-at-point end)))
-     (move-to-column (current-point) (min (point-column start)
-                                          (point-column end))))
+        (move-to-line (current-point) (min (line-number-at-point start)
+                                           (line-number-at-point end)))
+      (move-to-column (current-point) (min (point-column start)
+                                           (point-column end))))
     (:line
      (move-to-column start (point-charpos (current-point)))
      (move-point (current-point) start))
@@ -798,9 +798,9 @@ on the same line or at eol if there are none."
            (move-point point p)))
        (lambda (point regex &optional limit-point)
          (lem/isearch::search-forward-regexp
-               point
-               (ignore-errors (ppcre:create-scanner regex :case-insensitive-mode case-insensitive))
-               limit-point))
+          point
+          (ignore-errors (ppcre:create-scanner regex :case-insensitive-mode case-insensitive))
+          limit-point))
        (lambda (point regex &optional limit-point)
          (lem/isearch::search-backward-regexp
           point
@@ -925,7 +925,7 @@ on the same line or at eol if there are none."
                                         (string c)
                                         limit)
                   unless result
-                    do (return nil)
+                  do (return nil)
                   finally (return t))
         (character-offset p offset)
         (move-point (current-point) p)))))
@@ -1018,8 +1018,8 @@ on the same line or at eol if there are none."
 
 (define-command vi-jumps () ()
   (line-end (current-point))
-  (lem:message (with-output-to-string (s)
-                 (lem-vi-mode/jumplist::print-jumplist (current-jumplist) s))))
+  (lem:message-buffer (with-output-to-string (s)
+                        (lem-vi-mode/jumplist::print-jumplist (current-jumplist) s))))
 
 (define-command vi-jump-back (&optional (n 1)) (:universal)
   (dotimes (i n)

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -67,12 +67,12 @@
     (ex-write range filename t)))
 
 (define-ex-command "^bn$" (range argument)
-    (declare (ignore range argument))
-    (lem:next-buffer))
+  (declare (ignore range argument))
+  (lem:next-buffer))
 
 (define-ex-command "^bp$" (range argument)
-    (declare (ignore range argument))
-    (lem:previous-buffer))
+  (declare (ignore range argument))
+  (lem:previous-buffer))
 
 (define-ex-command "^wq$" (range filename)
   (ex-write-quit range filename nil t))
@@ -190,8 +190,8 @@
   (declare (ignore range))
   (lem:pipe-command
    (format nil "~A ~A"
-          (subseq lem-vi-mode/ex-core:*command* 1)
-          command)))
+           (subseq lem-vi-mode/ex-core:*command* 1)
+           command)))
 
 (define-ex-command "^(buffers|ls|files)$" (range argument)
   (declare (ignore range argument))
@@ -259,3 +259,7 @@
 (define-ex-command "^pwd?$" (range argument)
   (declare (ignore range argument))
   (lem:current-directory))
+
+(define-ex-command "^jumps?$" (range argument)
+  (declare (ignore range argument))
+  (lem-vi-mode/commands:vi-jumps))


### PR DESCRIPTION
The `:jumps` command for `vi-ex-mode`, which shows **current jumplist stack pointer** and the **jumplist**, useful to help people understand how the state of **jumplist**, and how it works.

I have checked that the current implementation of `jumplist` structure and the `print-jumplist` funciton does print **the same human readable string** as `vim`.


![image](https://github.com/user-attachments/assets/3039434a-6a9f-4f4a-9c7c-dbc82156ade1)
![image](https://github.com/user-attachments/assets/788b12d3-c326-425b-96ce-9aa67618d727)
