### PR TITLE
add `nullify-last-flags` function to interp

### DIFF
--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -492,6 +492,7 @@
    :exit-editor
    :interactive-p
    :continue-flag
+   :nullify-last-flags
    :pop-up-backtrace
    :call-background-job
    :command-loop-counter

--- a/src/interp.lisp
+++ b/src/interp.lisp
@@ -50,6 +50,13 @@
     (push (cons flag t) *last-flags*)
     (push (cons flag t) *curr-flags*)))
 
+(defun nullify-last-flags (flag &rest more-flags)
+  "Set FLAG and FLAGS to nil in *LAST-FLAGS*."
+  (push (cons flag nil) *last-flags*)
+  (when more-flags
+    (dotimes (i (length more-flags))
+      (push (cons (nth i more-flags) nil) *last-flags*))))
+
 (defmacro do-command-loop ((&key interactive) &body body)
   (alexandria:once-only (interactive)
     `(loop :for *last-flags* := nil :then *curr-flags*


### PR DESCRIPTION
i have a command that duplicates a line, but because it uses `copy-region` or `kill-whole-line`, it behaves unexpectedly when it is repeated.  with `nullify-last-flags`, the command works as intended when it is repeated