### PR TITLE
fix: the vi jumplist-history-push should not destroy jumplist-history elements above the jumplist-index, when a new element is pushed.

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -123,6 +123,7 @@
            :vi-append-line
            :vi-open-below
            :vi-open-above
+           :vi-jumps
            :vi-jump-back
            :vi-jump-next
            :vi-a-word
@@ -1014,6 +1015,11 @@ on the same line or at eol if there are none."
                                          (back-to-indentation p))
                                     (line-start p))))))
     (move-to-column (current-point) column t)))
+
+(define-command vi-jumps () ()
+  (line-end (current-point))
+  (lem:message-buffer (with-output-to-string (s)
+                        (lem-vi-mode/jumplist::print-jumplist (current-jumplist) s))))
 
 (define-command vi-jump-back (&optional (n 1)) (:universal)
   (dotimes (i n)

--- a/extensions/vi-mode/ex-command.lisp
+++ b/extensions/vi-mode/ex-command.lisp
@@ -67,12 +67,12 @@
     (ex-write range filename t)))
 
 (define-ex-command "^bn$" (range argument)
-    (declare (ignore range argument))
-    (lem:next-buffer))
+  (declare (ignore range argument))
+  (lem:next-buffer))
 
 (define-ex-command "^bp$" (range argument)
-    (declare (ignore range argument))
-    (lem:previous-buffer))
+  (declare (ignore range argument))
+  (lem:previous-buffer))
 
 (define-ex-command "^wq$" (range filename)
   (ex-write-quit range filename nil t))
@@ -190,8 +190,8 @@
   (declare (ignore range))
   (lem:pipe-command
    (format nil "~A ~A"
-          (subseq lem-vi-mode/ex-core:*command* 1)
-          command)))
+           (subseq lem-vi-mode/ex-core:*command* 1)
+           command)))
 
 (define-ex-command "^(buffers|ls|files)$" (range argument)
   (declare (ignore range argument))
@@ -259,3 +259,7 @@
 (define-ex-command "^pwd?$" (range argument)
   (declare (ignore range argument))
   (lem:current-directory))
+
+(define-ex-command "^jumps?$" (range argument)
+  (declare (ignore range argument))
+  (lem-vi-mode/commands:vi-jumps))

--- a/extensions/vi-mode/tests/jumplist.lisp
+++ b/extensions/vi-mode/tests/jumplist.lisp
@@ -83,7 +83,7 @@
                    (lines "  3: (1, 0)  NIL"
                           "  2: (2, 0)  NIL"
                           "  1: (3, 0)  NIL"
-                          "> 0: NIL")))
+                          "> 0: (4, 0)  NIL")))
         (ok (not (signals (jumplist-history-next jumplist))))))))
 
 (deftest jumplist-delete-newer-history
@@ -107,8 +107,10 @@
         (jumplist-history-push jumplist (copy-point (buffer-end-point (current-buffer))))
         (ok (equal (with-output-to-string (s)
                      (print-jumplist jumplist s))
-                   (lines "  3: (1, 0)  NIL"
-                          "  2: (2, 0)  NIL"
+                   (lines "  5: (1, 0)  NIL"
+                          "  4: (2, 0)  NIL"
+                          "  3: (3, 0)  NIL"
+                          "  2: (4, 0)  NIL"
                           "  1: (6, 0)  NIL"
                           "> 0: NIL")))))))
 
@@ -147,3 +149,28 @@
                      (lines "  2: (2, 0)  NIL"
                             "  1: (3, 0)  NIL"
                             "> 0: NIL"))))))))
+
+(deftest jumplist-push-current-point-into-jumplist-before-jump-history-back
+  (with-fake-interface ()
+    (with-vi-buffer (#?"second-location\n[s]tart\n\nfirst-location\n\n\nthird-location")
+      (let ((jumplist (current-jumplist)))
+        (cmd "2gg")
+        (cmd "4gg")
+        (cmd "gg")
+        (cmd "G")
+        (cmd "gg")
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  4: (2, 0)  NIL"
+                          "  3: (4, 0)  NIL"
+                          "  2: (1, 0)  NIL"
+                          "  1: (7, 0)  NIL"
+                          "> 0: NIL")))
+        (cmd "<C-o>")
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  2: (2, 0)  NIL"
+                          "  1: (4, 0)  NIL"
+                          "> 0: (7, 0)  NIL"
+                          "  1: (1, 0)  NIL")))))))
+


### PR DESCRIPTION
Things started when i found a `test-case` that differs the `jumplist implementation` between `lem` and `vim`.

Taken this test-case buffer
```
second-location
start

first-location

third-location
```
And input the key-sequence `2gg 4gg gg G gg <C-o>`, and type in `:jumps`, see the difference.
![Screenshot_20241204_101825](https://github.com/user-attachments/assets/9e2f995e-bfb5-4d20-a76c-4612232a2181)

In this screen-shot, we can see that `vim` implementation: turning the `2 4 1 7` into `2 4 7 1`, and `jumplist-current points to line 7`.

Actually, there are 2 bugs in this screen-shot:
1. When push a new jumplist-history element, we should not destory all elements above jumplist-index. (Vim delete the point, and re-push it into the top of jumplist-history.)
2. The jumplist formatter function prints the wrong format (it should not print the `1: (1, 14) common-lisp/lem/test-file-1.lisp`), the jumplist-history entry are `2 4 1 7` if you use an inspector to inspect the value in memory.

---

I also fix 2 related test-case, whose the `expected-result` is wrong.

![Screenshot_20241204_143008](https://github.com/user-attachments/assets/5ea20827-f61b-462d-8fc2-81fe8215091d)
![Screenshot_20241204_143404](https://github.com/user-attachments/assets/904197ea-ecb8-488d-a006-e467a83041f0)

The `left red box` is `the original lem implementaion`.
The `middle red box` is `the fixed lem implementaion`.
The `right red box` is `the vim implementation`.
