### PR TITLE
add: the missing `vi-jump-previous` command and binding.

### DIFF
--- a/extensions/vi-mode/binds.lisp
+++ b/extensions/vi-mode/binds.lisp
@@ -96,6 +96,7 @@
 (define-key *motion-keymap* "C-w C-j" 'undefined-key)
 (define-key *motion-keymap* "C-o" 'vi-jump-back)
 (define-key *motion-keymap* "C-i" 'vi-jump-next)
+(define-key *motion-keymap* "' '" 'vi-jump-previous)
 (define-key *motion-keymap* ":" 'vi-ex)
 
 (define-key *motion-keymap* "v" 'vi-visual-char)

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -126,6 +126,7 @@
            :vi-jumps
            :vi-jump-back
            :vi-jump-next
+           :vi-jump-previous
            :vi-a-word
            :vi-a-word
            :vi-a-broad-word
@@ -1028,6 +1029,10 @@ on the same line or at eol if there are none."
 (define-command vi-jump-next (&optional (n 1)) (:universal)
   (dotimes (i n)
     (jump-next)))
+
+(define-motion vi-jump-previous () ()
+    (:jump t)
+  (jump-back))
 
 (define-command vi-repeat (n) (:universal-nil)
   (when *last-repeat-keys*

--- a/extensions/vi-mode/tests/jumplist.lisp
+++ b/extensions/vi-mode/tests/jumplist.lisp
@@ -174,3 +174,60 @@
                           "> 0: (7, 0)  NIL"
                           "  1: (1, 0)  NIL")))))))
 
+
+(deftest jumplist-go-previous-only-once
+  (with-fake-interface ()
+    (with-vi-buffer (#?"second-location\n[s]tart\n\nfirst-location\n\n\nthird-location")
+      (let ((jumplist (current-jumplist)))
+        (cmd "2gg")
+        (cmd "4gg")
+        (cmd "gg")
+        (cmd "G")
+        (cmd "gg")
+        (cmd "''")
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  4: (2, 0)  NIL"
+                          "  3: (4, 0)  NIL"
+                          "  2: (7, 0)  NIL"
+                          "  1: (1, 0)  NIL"
+                          "> 0: NIL")))))))
+
+(deftest jumplist-go-previous-twice
+  (with-fake-interface ()
+    (with-vi-buffer (#?"second-location\n[s]tart\n\nfirst-location\n\n\nthird-location")
+      (let ((jumplist (current-jumplist)))
+        (cmd "2gg")
+        (cmd "4gg")
+        (cmd "gg")
+        (cmd "G")
+        (cmd "gg")
+        (cmd "''")
+        (cmd "''")
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  4: (2, 0)  NIL"
+                          "  3: (4, 0)  NIL"
+                          "  2: (1, 0)  NIL"
+                          "  1: (7, 0)  NIL"
+                          "> 0: NIL")))))))
+
+(deftest jumplist-go-previous-while-navigating-history
+  (with-fake-interface ()
+    (with-vi-buffer (#?"second-location\n[s]tart\n\nfirst-location\n\n\nthird-location")
+      (let ((jumplist (current-jumplist)))
+        (cmd "2gg")
+        (cmd "4gg")
+        (cmd "gg")
+        (cmd "G")
+        (cmd "gg")
+        (cmd "<C-o>")
+        (cmd "<C-o>")
+        (cmd "''")
+        (ok (equal (with-output-to-string (s)
+                     (print-jumplist jumplist s))
+                   (lines "  4: (2, 0)  NIL"
+                          "  3: (7, 0)  NIL"
+                          "  2: (1, 0)  NIL"
+                          "  1: (4, 0)  NIL"
+                          "> 0: NIL")))))))


### PR DESCRIPTION
The `vi-jump-previous` command is a useful command, to **jump between current point, and previous point**. 

A use-case: you are writing a function `b`, which calls the function `a`, you need to jump between the definition of `a` and `b`. Just **double pressed the ' key**, it will works.


---
The implementaion is easy: We can **compose** the `vi-jump-back command`  and `define-motion`.
The effect is to define a new motion-command, its function is `vi-jump-back`. 
But because it is a `motion-command`, so the `vi jumplist facility` will save `current-point` for us automatically.

