### PR TITLE
Revert "make `C-m` (`Return`)  `newline-and-indent` in language modes"

### DIFF
--- a/src/ext/language-mode.lisp
+++ b/src/ext/language-mode.lisp
@@ -83,7 +83,6 @@
 (define-key *language-mode-keymap* "C-M-a" 'beginning-of-defun)
 (define-key *language-mode-keymap* "C-M-e" 'end-of-defun)
 (define-key *language-mode-keymap* "Tab" 'indent-line-and-complete-symbol)
-(define-key *language-mode-keymap* "Return" 'newline-and-indent)
 (define-key *global-keymap* "C-j" 'newline-and-indent)
 (define-key *global-keymap* "M-j" 'newline-and-indent)
 (define-key *language-mode-keymap* "C-M-\\" 'indent-region)


### PR DESCRIPTION
Reverts lem-project/lem#1674.

created some problems with unnecessary indentation, like in markdown mode