### PR TITLE
feature: highlight caught warning and error in repl

### DIFF
--- a/extensions/lisp-mode/repl.lisp
+++ b/extensions/lisp-mode/repl.lisp
@@ -16,7 +16,11 @@
                                          (list (make-tm-region
                                                 "^WARNING:"
                                                 "$"
-                                                :name 'warning-attribute))))
+                                                :name 'warning-attribute)
+                                               (make-tm-match "^; caught WARNING:"
+                                                              :name 'warning-attribute)
+                                               (make-tm-match "^; caught ERROR:"
+                                                              :name 'warning-attribute))))
 
 (define-major-mode lisp-repl-mode lisp-mode
     (:name "REPL"


### PR DESCRIPTION
To close issue: https://github.com/lem-project/lem/issues/1688

This commit adds the syntax to highlight `caught WARNING` and `caught ERROR` in repl.

![image](https://github.com/user-attachments/assets/564557a7-3ec4-407f-aca2-601bd68a8f21)
