### PR TITLE
fix: make the ctrl-[ the sym key to escape key.

### DIFF
--- a/frontends/sdl2/keyboard.lisp
+++ b/frontends/sdl2/keyboard.lisp
@@ -59,6 +59,12 @@
                        :super super
                        :shift shift
                        :sym "Tab"))
+        ((and ctrl (equal sym "["))
+         (lem:make-key :ctrl nil
+                       :meta meta
+                       :super super
+                       :shift shift
+                       :sym "Escape"))
         ((and ctrl (equal sym "m"))
          (lem:make-key :ctrl nil
                        :meta meta


### PR DESCRIPTION
This is a historical problem of `terminal`.

Just like the `C-i` is a sym of `Tab` key.
The `C-[` is a sym of `Escape` key.

The `vim` can't disguish the `C-i` from `Tab` key, and the `C-[` from the `Escape` key.

Since lem has `ncurses` as terminal frontend, so the `sdl2` version should also follow this sym rule.

Also, it will be convenient to have `C-[` as another way to press `Escape` key.

Discuss:
https://susam.net/control-escape-meta-tricks.html
https://vi.stackexchange.com/questions/24852/how-to-remove-the-mapping-from-ctrl-to-escape
https://unix.stackexchange.com/questions/721179/why-do-ctrl-and-esc-both-produce