### PR TITLE
Ban `mouse click event` in `popup-window` maded by `popup-message` function.

### DIFF
--- a/src/ext/popup-message.lisp
+++ b/src/ext/popup-message.lisp
@@ -33,6 +33,9 @@
                      :buffer buffer
                      :width width
                      :height height
+                     ;; NOTE: Simply ban the mouse-click event for a popup-window, to avoid the popup-window gain the mouse focus, being the only window as current-window in window-tree, causing lem unable to delete it.
+                     ;; However, since the popup-message is a window used to display string, you can still use mouse-scroll to scroll the text.
+                     :clickable nil
                      :style style)))
         (buffer-start (window-view-point window))
         (window-see window)

--- a/src/ext/popup-window.lisp
+++ b/src/ext/popup-window.lisp
@@ -308,6 +308,7 @@
                                (buffer (alexandria:required-argument :buffer))
                                (width (alexandria:required-argument :width))
                                (height (alexandria:required-argument :height))
+                               (clickable t)
                                style)
   (let* ((style (ensure-style style))
          (border-size (if (style-use-border style) +border-size+ 0))
@@ -335,6 +336,7 @@
                      :border-shape (style-shape style)
                      :background-color (style-background-color style)
                      :cursor-invisible (style-cursor-invisible style)
+                     :clickable clickable
                      :style style))))
 
 (defun update-popup-window (&key (source-window (alexandria:required-argument :source-window))

--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -178,7 +178,9 @@
            (focus-window-position (current-frame)
                                   (mouse-event-x mouse-event)
                                   (mouse-event-y mouse-event))
-         (when window
+         (when (and window
+                    ;; NOTE: Simply ban the mouse-click event for a popup-window, to avoid the popup-window gain the mouse focus, being the only window as current-window in window-tree, causing lem unable to delete it.
+                    (not (typep window 'lem/popup-window::popup-window)))
            (handle-mouse-button-down (window-buffer window)
                                      mouse-event
                                      :window window

--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -179,8 +179,7 @@
                                   (mouse-event-x mouse-event)
                                   (mouse-event-y mouse-event))
          (when (and window
-                    ;; NOTE: Simply ban the mouse-click event for a popup-window, to avoid the popup-window gain the mouse focus, being the only window as current-window in window-tree, causing lem unable to delete it.
-                    (not (typep window 'lem/popup-window::popup-window)))
+                    (window-clickable window))
            (handle-mouse-button-down (window-buffer window)
                                      mouse-event
                                      :window window

--- a/src/window/window.lisp
+++ b/src/window/window.lisp
@@ -105,6 +105,10 @@
    (deleted
     :initform nil
     :accessor window-deleted-p)
+   (clickable
+    :initarg :clickable
+    :initform t
+    :reader window-clickable)
    (parameters
     :initform nil
     :accessor window-parameters)))


### PR DESCRIPTION
To close issue: https://github.com/lem-project/lem/issues/1686

This commit does:
1. Add a new parameter `clickable` to `window`. (When `clickable = nil`, the `mouse clicking` event will be ignore for this window. However, thw `mouse hover event` and `mouse scrolling event` can still be received for that window)
2. Made the `popup-window` maded by `popup-message` now `un-clickable`.