### PR TITLE
feature: ignore-case for git-grep command by default

### DIFF
--- a/src/ext/grep.lisp
+++ b/src/ext/grep.lisp
@@ -72,7 +72,7 @@
   (lem/peek-source:show-matched-line))
 
 (defvar *grep-command* "git grep")
-(defvar *grep-args* "-nHI")
+(defvar *grep-args* "-niHI")
 (defvar *last-query* (str:concat *grep-command* " " *grep-args* " "))
 (defvar *last-directory* nil)
 


### PR DESCRIPTION
For a `wide-scope grep` like `project-grep` or `directory-grep`, it's **more useful** to ignore-case in most of cases.

The search scope is large, it may be annoy to **miss some search result item** just because the case is sensitive.