### PR TITLE
fix: the self-insert command in vi-mode should not insert un-printable char while flushing the pending-keys

### DIFF
--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -77,7 +77,10 @@
     (when (and
            (typep command 'self-insert)
            pending-keys)
-      (dolist (key pending-keys) (self-insert 1 (key-to-char key))))
+      (loop :for key :in pending-keys
+            :until (named-key-sym-p (key-sym key))
+            :do 
+               (self-insert 1 (key-to-char key))))
     
     (when *enable-repeat-recording*
       (unless (or (and (typep command 'vi-command)

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -76,20 +76,23 @@
     ;;   a. If `<second-key>` is print-able-key, taken `e` key for example, then will self-insert `j` and self-insert `e`.
     ;;   b. If `<second-key>` is un-print-able-key, taken `Backspace` key for example, then will cancel the self-insert `j` and remain in vi-insert-mode.
     
-    ;; FIXME: In `lem` impl, the `2.b` case will not cancel the self-insert of `j` key, because the code is written in post-command-hook, we have no change to cancel the executing of `self-insert` command for the first-key.
-    
-    ;; For the command `self-insert`, the `this-command-keys` is typically only 1 key. (pending-keys = nil)
-    ;; If pending-keys is NOT nil, then these keys are used to disguish the keys between `self-insert` command and other commands. 
-    ;; For other commands, we can simply ignore the pending-keys.
-    ;; For self-insert command, we should also flusthese pending-keys.
+    ;; FIXME: In `lem` impl, the `2.b` case will not cancel the self-insert of `j` key, because the code is written in post-command-hook, we have no chance to cancel the executing of `self-insert` command for the first-key.
+    ;;
+    ;;
+    ;;
+    ;; For self-insert command, we should also flush the pending-keys.
+    ;; 1. Typically, the length of`this-command-keys` is only 1 key. (pending-keys = nil)
+    ;; 2. If the length of `this-command-keys` > 1 key (pending-keys is not nil, they are used to disguish `self-insert` command and other commands), we need to flush `pending-keys`.
     (when (and
            (typep command 'self-insert)
            pending-keys)
       (loop :for key :in pending-keys
-            ;; FIXME: the `named-key` is no identical to `print-able-key`. (Taken `Tab` key for example)
+            ;; FIXME: the `named-key` is not identical to `print-able-key`. (Taken `Tab` key for example)
             :until (named-key-sym-p (key-sym key))
             :do 
                (self-insert 1 (key-to-char key))))
+    
+    
     
     (when *enable-repeat-recording*
       (unless (or (and (typep command 'vi-command)

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -70,7 +70,15 @@
          (this-command-keys (vi-this-command-keys))
          (pending-keys (cdr this-command-keys)))
     
-    ;; For the command `self-insert`, the `this-command-keys` is typically only 1 char. (pending-keys = nil)
+    ;; NOTE: In `vim`, if you define `jk` as `Escape` in insert-mode. The effect is:
+    ;; 1. In vi-insert-mode, press `j` and `k` will escape from insert-mode to normal-mode.
+    ;; 2. In vi-insert-mode, press `j` and `<second-key>` will:
+    ;;   a. If `<second-key>` is print-able-key, taken `e` key for example, then will self-insert `j` and self-insert `e`.
+    ;;   b. If `<second-key>` is un-print-able-key, taken `Backspace` key for example, then will cancel the self-insert `j` and remain in vi-insert-mode.
+    
+    ;; FIXME: In `lem` impl, the `2.b` case will not cancel the self-insert of `j` key, because the code is written in post-command-hook, we have no change to cancel the executing of `self-insert` command for the first-key.
+    
+    ;; For the command `self-insert`, the `this-command-keys` is typically only 1 key. (pending-keys = nil)
     ;; If pending-keys is NOT nil, then these keys are used to disguish the keys between `self-insert` command and other commands. 
     ;; For other commands, we can simply ignore the pending-keys.
     ;; For self-insert command, we should also flusthese pending-keys.
@@ -78,6 +86,7 @@
            (typep command 'self-insert)
            pending-keys)
       (loop :for key :in pending-keys
+            ;; FIXME: the `named-key` is no identical to `print-able-key`. (Taken `Tab` key for example)
             :until (named-key-sym-p (key-sym key))
             :do 
                (self-insert 1 (key-to-char key))))


### PR DESCRIPTION
In pr: https://github.com/lem-project/lem/pull/1691, we flush the `pending-keys` for `self-insert` command in `vi-insert-mode`, so that we can define keymap like `(define-key lem-vi-mode:*insert-keymap* "j k" 'lem-vi-mode/commands:vi-normal)`.

The `effect` of this `define-key` is:
1. Press `j k` in `vi-insert-mode` will the `lem-vi-mode/commands:vi-normal` command.
2. Press `j <second-key>` in `vi-insert-mode` will self-insert `j` and self-insert `<second-key>`.

However, in the `vim` editor, if the `<second-key>` is NOT print-able key, then it will `quit the key pending state`, and will not self-insert the `<second-key>`.

**A case is: press `j` and `Backspace`.**
This pr fix this edge-case.

---
NOTE: 
This pr has some minor difference from the `vim`. The `named-key` is not identical to `print-able-key`, taken `Tab` for example.
I didn't add the function `printable-key-sym-p` or `un-printable-key-sym-p`, because it is hard to decide whether a key is print-able or not.

The difference is minor, and sufficient in daily use.