### PR TITLE
add `after-load-theme-hook`

### DIFF
--- a/src/color-theme.lisp
+++ b/src/color-theme.lisp
@@ -1,5 +1,9 @@
 (in-package :lem-core)
 
+(defvar *after-load-theme-hook* '()
+  "For functions that should run after a theme is loaded,
+for example, to maintain an attribute like CURSOR.")
+
 (defvar *current-theme* nil)
 
 (defun current-theme ()
@@ -96,7 +100,8 @@
     (redraw-display :force t)
     (setf (current-theme) name)
     (when save-theme
-      (setf (config :color-theme) (current-theme)))))
+      (setf (config :color-theme) (current-theme))))
+  (run-hooks *after-load-theme-hook*))
 
 (defun get-color-theme-color (color-theme key)
   (second (assoc key (color-theme-specs color-theme))))

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -622,6 +622,7 @@
   (:export
    :color-theme-names
    :define-color-theme
+   :*after-load-theme-hook*
    :load-theme
    :current-theme
    :find-color-theme


### PR DESCRIPTION
add `after-load-theme-hook` so that users may add functions that should run after a theme is loaded.  this could be useful in some cases.  in my specific case, it's to to maintain the color of the point since it is always very hard to see when the point is on an overlay like in search.