### PR TITLE
add `editor-variable-universal-argument-function`

### DIFF
--- a/src/ext/universal-argument.lisp
+++ b/src/ext/universal-argument.lisp
@@ -2,8 +2,8 @@
   (:use :cl :lem)
   (:import-from :lem-core
                 :*universal-argument*)
-  (:export :*base*
-           :*universal-argument-keymap*
+  (:export :*universal-argument-keymap*
+           :universal-argument-function
            :universal-argument
            :universal-argument-0
            :universal-argument-1
@@ -22,22 +22,27 @@
   (:lock t))
 (in-package :lem/universal-argument)
 
-(defparameter *base* 4)
-
 (defstruct arg-state
   (type nil)
   (u 1)
   (n '()))
 
 (defvar *argument* (make-arg-state))
+
 (defvar *universal-argument-keymap*
   (make-keymap :name '*universal-argument-keymap*
                :undef-hook 'universal-argument-default))
 
+(define-editor-variable universal-argument-function
+  (lambda (x) (expt 4 x))
+  "Set function to be called when UNIVERSAL-ARGUMENT is
+invoked, which will receive an argument of 1 on the first
+call, increasing thereafter by 1 on each successive call.")
+
 (defun to-integer (arg-state)
   (case (arg-state-type arg-state)
     ((nil)
-     (expt *base* (arg-state-u arg-state)))
+     (funcall (variable-value 'universal-argument-function) (arg-state-u arg-state)))
     ((t)
      (if (equal (arg-state-n arg-state) '(#\-))
          -1


### PR DESCRIPTION
add `editor-variable-universal-argument-function` so that users can define their own incrementing patterns to `universal-argument`.  for example :

```
(setf (variable-value 'lem/universal-argument:universal-argument-function :global)
      (lambda (x) (* 4 x)))
```

in this case, `C-u` is much more granular.  the default `C-u` jumps too much for me, going from 4 to 16.  but going from 4 to 8 and then 12 is much better for me

the default is kept at exponent of 4 : `(lambda (x) (expt 4 x))`