### PR TITLE
fix verbose style in `compute-line`

### DIFF
--- a/src/ext/line-numbers.lisp
+++ b/src/ext/line-numbers.lisp
@@ -60,9 +60,7 @@ With a positive universal argument, use relative line numbers. Also obey the glo
             (line (line-number-at-point point))
             (custom-line (variable-value 'custom-current-line :default buffer)))
         (if (= cursor-line line)
-            (if custom-line
-                custom-line
-                line)
+            (or custom-line line)
             (abs (- cursor-line line))))
       (line-number-at-point point)))
 


### PR DESCRIPTION
fix verbose style in `compute-line`.  changes an `if` to an `or` for better readability and style