### PR TITLE
fix typo in file-conversion.lisp

### DIFF
--- a/extensions/lisp-mode/file-conversion.lisp
+++ b/extensions/lisp-mode/file-conversion.lisp
@@ -1,7 +1,7 @@
 (in-package :lem-lisp-mode/internal)
 
 (defvar *file-conversion-map* '()
-  "This variable is a alist for converting remote file names to local file names.
+  "This variable is an alist for converting remote file names to local file names.
 Uses include mapping files in docker to files in the local environment.
 
 For example, set the following.


### PR DESCRIPTION
fix typo in file-conversion.lisp. change "a" to "an" because it's in front of "alist"