### PR TITLE
feature: the paredit-wrap-around now support to select sexp at point without the need to move point to the beginning of sexp

### DIFF
--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -583,8 +583,10 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
       (with-point ((start (current-point))
                    (end (current-point)))
         (unless (in-string-or-comment-p start)
-          ;; Forward sexp to select the end.
-          (forward-sexp)
+          ;; Forward sexp to select the end, unless current-point it not at end-char. 
+          (unless (equal (character-at (current-point))
+                         end-char)
+            (forward-sexp))
           (setf end (copy-point (current-point) :temporary))
 
           ;; Backward sexp to select the start.

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -562,7 +562,7 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 
 
 (defun %paredit-wrap (begin-char end-char)
-  ;; FIXME: the buffer-mark-p always be nil for marks that set by vi-mode. (The mark state in vi-mode and emacs-mode is not set.
+  ;; FIXME: the buffer-mark-p always be nil for marks that set by vi-mode. (The mark state in vi-mode and emacs-mode is not synced.)
   (if (buffer-mark-p (current-buffer))
       (with-point ((begin (region-beginning (current-buffer)))
                    (end (region-end (current-buffer))))

--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -592,13 +592,15 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
           (setf start (copy-point (current-point) :temporary))
 
           ;; Insert the one `open-char` before `start`.
+          (insert-character start #\Space)
           (insert-character start begin-char)
 
-          ;; Because we have inserted the one `open-char`, the `end` should + 1.
-          (character-offset end 1)
+          ;; Because we have inserted the one `space` and one `open-char`, the `end` should + 2.
+          (character-offset end 2)
           (insert-character end end-char)
 
-          ;; Move current-point to the inserted `open-char`. (After we inserted the `open-char` before `start`, the char in `start` is not the `open-char`.)
+          ;; Move current-point to the `inserted space char`.
+          (character-offset start 1)
           (move-point (current-point) start)))))
 
 (define-command paredit-wrap-round () ()


### PR DESCRIPTION
This pr does improve the `implementation` for `paredit-wrap-around` in `buffer-mark-p = nil` branch.

The pr contains:
1. Simplify the impl by re-use the `forward-sexp` and `backward-sexp` funciton. (The `end` is where the `forward-sexp` point at, the `start` is where the `backward-sexp` point at.)
2. Remove the handling of `following-space`. (It's handled by `backward-sexp`, after the eval of `backward-sexp`, the `current-point` are guarantee to at the first char of sexp.)
3. Support to select **the sexp at current point** as a whole **unit**.
4. Always insert **1 space** before the `first char of sexp`, and **move current-point at it**. (Now it's more smooth to chain-call functions, the space is inserted there.)
5. Treat the `open char`, `string between open-char and closed-char` and `closed char` as the same form. (Fix issue like: https://github.com/lem-project/lem/issues/1612)

---

Let's asume your current-point is **inside the word `second`**, the `paredit-wrap` can now treat the `second` as a whole `sexp`, without the need to move current-point to the `(` or `first-char of sexp`

Before this pr
![Screenshot_20241211_092556](https://github.com/user-attachments/assets/7a5c9d1c-048e-4037-aa33-0c9cec6e4086)

After this pr
![image](https://github.com/user-attachments/assets/61d4a078-e6e6-4e79-bad6-7363dbab245e)
