### PR TITLE
fix: the paredit-splice should not backward 1 form if current point already at open-char

### DIFF
--- a/extensions/paredit-mode/paredit-mode.lisp
+++ b/extensions/paredit-mode/paredit-mode.lisp
@@ -2,6 +2,7 @@
 link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
 |#
 
+
 (defpackage :lem-paredit-mode
   (:use :cl
         :lem)
@@ -473,7 +474,11 @@ link : http://www.daregada.sakuraweb.com/paredit_tutorial_ja.html
            (delete-character end)
            (delete-character start))))
       (t
-       (scan-lists start -1 1)
+       ;; If current-point is already at open-char, simply select current list.
+       (unless
+           (syntax-open-paren-char-p (character-at start))
+         (scan-lists start -1 1))
+       
        (when (syntax-open-paren-char-p (character-at start))
          (with-point ((end start))
            (scan-lists end 1 0)


### PR DESCRIPTION
This pr fixes the `matched level` of `open-char` and `closed-char`.
To fix cases like: https://github.com/lem-project/lem/issues/1612

Before this pr: the `paredit-splice` treat `string between open-char and closed-char` and `closed-char` as the `same form`, but treat the `open-char` as the `(form-offset (current-point) -1)`.

After this pr: the `paredit-splice` treat `open-char`, `string between open-char and closed-char` and `closed-char` as the `same form`.

---
For this test-case:
![image](https://github.com/user-attachments/assets/e9f20498-983b-4ab7-b67a-efb86545695f)

Before this pr:
![image](https://github.com/user-attachments/assets/8dd22b63-e654-45b2-9992-24ddf5c8aa27)

After this pr:
![image](https://github.com/user-attachments/assets/ccc143ec-b4ed-4f78-a7ae-8b9d83b872ec)

