### PR TITLE
Add micros keybinds to lisp-mode

### DIFF
--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -92,6 +92,10 @@
 (define-key *lisp-mode-keymap* "Return" 'newline-and-indent)
 (define-key *lisp-mode-keymap* "C-c C-j" 'lisp-eval-expression-in-repl)
 (define-key *lisp-mode-keymap* "C-c ~" 'lisp-listen-in-current-package)
+(define-key *lisp-mode-keymap* "C-c m s" 'slime)
+(define-key *lisp-mode-keymap* "C-c m r" 'slime-restart)
+(define-key *lisp-mode-keymap* "C-c m q" 'slime-quit)
+(define-key *lisp-mode-keymap* "C-c m c" 'slime-connect)
 
 (defmethod convert-modeline-element ((element (eql 'lisp-mode)) window)
   (format nil "  ~A~A" (buffer-package (window-buffer window) "CL-USER")
@@ -891,7 +895,7 @@
 
 (defun notify-change-connection-to-wait-message-thread ()
   (bt2:interrupt-thread *wait-message-thread*
-                       (lambda () (error 'change-connection))))
+                        (lambda () (error 'change-connection))))
 
 (defun message-waiting-some-connections-p (&key (timeout 0))
   (with-broadcast-connections (connection)


### PR DESCRIPTION
Starting/restarting slime (micros) is a common-enough task I think it makes sense for it to have default keybinds.

I used the `C-c m` prefix, so e.g. `C-c m s` to start micros, `C-c m r` to restart, etc. Originally wanted `C-c C-m` but `C-m` is reserved for return.

Side-note, we should rename the `slime-*` commands at some point to `micros-*`. I didn't want to include that here since that's a breaking change.

Also, merry christmas :christmas_tree: :santa: 