### PR TITLE
vi-mode - Bug - Fix freeze when using _i"/_a" in escaped string

### DIFF
--- a/extensions/vi-mode/README.md
+++ b/extensions/vi-mode/README.md
@@ -39,9 +39,18 @@ Here's a list of all options currently implemented:
   * Default: `nil` (don't show)
   * Aliases: `nu`
 
-## Unittests
-
-```
+## Unit Tests
+    
+### Command Line
+    
+```bash
 qlot install
 .qlot/bin/rove extensions/vi-mode/lem-vi-mode.asd
+```
+    
+### In Lem
+    
+Use `C-c C-r` or:
+```common-lisp Example Test
+  (rove:run-test 'lem-vi-mode/tests/text-objects::word-object)
 ```

--- a/extensions/vi-mode/tests/text-objects.lisp
+++ b/extensions/vi-mode/tests/text-objects.lisp
@@ -46,4 +46,20 @@
       (ok (buf= " \"foo\"< \"bar[\"]>")))
     (with-vi-buffer (" \"foo\" \"bar[\"]")
       (cmd "va\"")
-      (ok (buf= " \"foo\"< \"bar[\"]>")))))
+      (ok (buf= " \"foo\"< \"bar[\"]>")))
+
+    ;; Escape Character 
+    ; v i
+    (with-vi-buffer (" \" f[o]o \\\" bar \"")
+      (cmd "vi\"")
+      (ok (buf= " \"< foo \\\" bar[ ]>\"")))
+    (with-vi-buffer (" \" foo \\\" b[a]r \"")
+      (cmd "vi\"")
+      (ok (buf= " \"< foo \\\" bar[ ]>\"")))
+    ; v a
+    (with-vi-buffer (" \" f[o]o \\\" bar \"")
+      (cmd "va\"")
+      (ok (buf= " <\" foo \\\" bar [\"]>")))
+    (with-vi-buffer (" \" foo \\\" b[a]r \"")
+      (cmd "va\"")
+      (ok (buf= " <\" foo \\\" bar [\"]>")))))

--- a/extensions/vi-mode/text-objects.lisp
+++ b/extensions/vi-mode/text-objects.lisp
@@ -289,10 +289,14 @@
              ;; No quote-char found
              ((null prev-char)
               (keyboard-quit))
-             ;; Skip escaped quote-char
-             ((and escape-char
-                   (char= prev-char escape-char)))
-             ;; Successfully found
+             
+             ;; Skip escape & quote-char
+             ((and escape-char 
+                   (character-at point -2) ;; Bound check
+                   (char= (character-at point -2) escape-char))
+              (character-offset point -2))
+       
+             ;; Successfully found unescaped quote
              (t
               (character-offset point -1)
               (return))))))
@@ -304,9 +308,13 @@
              ;; No quote-char found
              ((null next-char)
               (keyboard-quit))
-             ;; Skip escaped quote-char
+             
+             ;; Skip escape & quote-char
              ((and escape-char
-                   (char= (character-at point -1) escape-char)))
+                   (character-at point 2) ;; Bound Check
+                   (char= (character-at point -1) escape-char))
+              (character-offset point 2))             
+             
              ;; Successfully found
              (t
               (character-offset point 1)


### PR DESCRIPTION
# Change Description

The fix is for the bug in [Issue #1657](https://github.com/lem-project/lem/issues/1657).
This affects code in operator pending mode, so the editor will freeze when using:
 - v i/a "
 - c i/a "
 - d i/a "
 - y i/a "
    
This occurs as when the escape character is found, it does not move the character forward/back, causing an infinite loop of finding the escape char.

As shown in this seek backward example, I have changed it to skip over 2 chars (the escape and the quote char). I did the same for when seeking forward.
```common-lisp
  ;; Before
  ((and escape-char)
    (char= prev-char escape-char))
   
  ;; After 
  ((and escape-char 
            (character-at point -2) ;; Bound check
            (char= (character-at point -2) escape-char))
    (character-offset point -2))
```
    
This behaviour to ignore escape chars, which seems intended for Lem's vi-mode(just bugged), does match vanilla vim so good to have.


# Testing

I have updated the tests to account for this case.
This image shows the rendered test outputs which can help you decipher the string in the tests in you want:
![Tests Passing](https://github.com/user-attachments/assets/9242fd4c-23d3-49ec-bbc0-147561b5794c)

# Other Bugs

I found some more bugs that are existing already with this functionality, but no more editor freezes, just unexpected behavious in some cases.
I hope to fix them with a bit of changes to the logic around finding quotes specifically.
 - Both have different but unexpected behavior when they are before the first quote/after the last quote
 - Both do not gracefully fail in all cases(one "). This is particularly annoying when doing d_" or c_" where you don't have the visual feedback

### Feature
 - Both do not mimic vim seek ahead in line with operator pending mode