### PR TITLE
change `hypher` to `hyper` across lem repo

### DIFF
--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -94,7 +94,7 @@
    :key-ctrl
    :key-meta
    :key-super
-   :key-hypher
+   :key-hyper
    :key-shift
    :key-sym
    :match-key

--- a/src/key.lisp
+++ b/src/key.lisp
@@ -23,23 +23,23 @@
   (ctrl nil :type boolean)
   (meta nil :type boolean)
   (super nil :type boolean)
-  (hypher nil :type boolean)
+  (hyper nil :type boolean)
   (shift nil :type boolean)
   (sym 0 :type string))
 
 (defmethod print-object ((object key) stream)
-  (with-slots (ctrl meta super hypher shift sym) object
+  (with-slots (ctrl meta super hyper shift sym) object
     (write-string (key-to-string :ctrl ctrl
                                  :meta meta
                                  :super super
-                                 :hypher hypher
+                                 :hyper hyper
                                  :shift shift
                                  :sym sym)
                   stream)))
 
-(defun key-to-string (&key ctrl meta super hypher shift sym)
+(defun key-to-string (&key ctrl meta super hyper shift sym)
   (with-output-to-string (stream)
-    (when hypher (write-string "H-" stream))
+    (when hyper (write-string "H-" stream))
     (when super (write-string "S-" stream))
     (when meta (write-string "M-" stream))
     (when ctrl (write-string "C-" stream))
@@ -54,35 +54,35 @@
 
 (defvar *key-constructor-cache* (make-hash-table :test 'equal))
 
-(defun convert-key (&rest args &key ctrl meta super hypher shift sym)
+(defun convert-key (&rest args &key ctrl meta super hyper shift sym)
   (let ((elt (assoc (apply #'key-to-string args) *key-conversions* :test #'equal)))
     (if elt
         (let ((key (first (parse-keyspec (cdr elt)))))
           (list :ctrl (key-ctrl key)
                 :meta (key-meta key)
                 :super (key-super key)
-                :hypher (key-hypher key)
+                :hyper (key-hyper key)
                 :shift (key-shift key)
                 :sym (key-sym key)))
         (list :ctrl ctrl
               :meta meta
               :super super
-              :hypher hypher
+              :hyper hyper
               :shift shift
               :sym sym))))
 
-(defun make-key (&rest args &key ctrl meta super hypher shift sym)
-  (declare (ignore ctrl meta super hypher shift sym))
+(defun make-key (&rest args &key ctrl meta super hyper shift sym)
+  (declare (ignore ctrl meta super hyper shift sym))
   (let ((hashkey (apply #'convert-key args)))
     (or (gethash hashkey *key-constructor-cache*)
         (setf (gethash hashkey *key-constructor-cache*)
               (apply #'%make-key args)))))
 
-(defun match-key (key &key ctrl meta super hypher shift sym)
+(defun match-key (key &key ctrl meta super hyper shift sym)
   (and (eq (key-ctrl key) ctrl)
        (eq (key-meta key) meta)
        (eq (key-super key) super)
-       (eq (key-hypher key) hypher)
+       (eq (key-hyper key) hyper)
        (eq (key-shift key) shift)
        (equal (key-sym key) sym)))
 

--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -80,14 +80,14 @@ Example: (define-key *global-keymap* \"C-'\" 'list-modes)"
   (labels ((fail ()
              (editor-error "parse error: ~A" string))
            (parse (str)
-             (loop :with ctrl :and meta :and super :and hypher :and shift
+             (loop :with ctrl :and meta :and super :and hyper :and shift
                    :do (cond
                          ((ppcre:scan "^[cmshCMSH]-" str)
                           (ecase (char-downcase (char str 0))
                             ((#\c) (setf ctrl t))
                             ((#\m) (setf meta t))
                             ((#\s) (setf super t))
-                            ((#\h) (setf hypher t)))
+                            ((#\h) (setf hyper t)))
                           (setf str (subseq str 2)))
                          ((ppcre:scan "^[sS]hift-" str)
                           (setf shift t)
@@ -107,7 +107,7 @@ Example: (define-key *global-keymap* \"C-'\" 'list-modes)"
                           (return (make-key :ctrl ctrl
                                             :meta meta
                                             :super super
-                                            :hypher hypher
+                                            :hyper hyper
                                             :shift shift
                                             :sym (or (named-key-sym-p str)
                                                      str))))))))

--- a/tests/self-insert-command.lisp
+++ b/tests/self-insert-command.lisp
@@ -17,7 +17,7 @@
     (ok "aaaa" (execute-self-insert (make-key :ctrl t :sym "u") (make-key :sym "a")))
     (handler-case
         (progn
-          (execute-key-sequence (list (make-key :super t :meta t :hypher t :sym "a")))
+          (execute-key-sequence (list (make-key :super t :meta t :hyper t :sym "a")))
           (fail "unreachable"))
       (editor-error (e)
         (ok (search "Key not found: " (princ-to-string e)))))))


### PR DESCRIPTION
change the word `hypher` to `hyper` in the entire lem repo.  sometimes it's spelled correctly while other times it's not.  this patch unifies the repo