### PR TITLE
only change recent frame list when switch target is different

### DIFF
--- a/src/ext/frame-multiplexer.lisp
+++ b/src/ext/frame-multiplexer.lisp
@@ -447,10 +447,12 @@ The prefix argument ID defaults to 1."
   ;; and asking for the frame name (or buffer of the frame, if it has no name)
   (check-frame-multiplexer-usable)
   (let* ((vf (gethash (implementation) *virtual-frame-map*))
-         (entry (aref (virtual-frame-id/frame-table vf) id)))
-    (if entry
-        (switch-current-frame vf (frame-table-entry-frame entry))
-        (editor-error "No frame with ID ~a" id))))
+         (entry (aref (virtual-frame-id/frame-table vf) id))
+         (same-frame-p (eq (current-frame) (frame-table-entry-frame entry))))
+    (unless same-frame-p
+      (if entry
+          (switch-current-frame vf (frame-table-entry-frame entry))
+          (editor-error "No frame with ID ~a" id)))))
 
 (macrolet ((def (command-name n)
              `(define-command (,command-name (:advice-classes frame-multiplexer-advice))


### PR DESCRIPTION
only change recent frame list when switch target is different.  i find this to be very helpful because sometimes i choose the same frame either through a command or by accident, and then `frame-multiplexer-recent` becomes useless.  with this change, `frame-multiplexer-recent` will continue to be useful even after a mistake or a redundant switch

for example :
i run a command that always opens a file in frame 1.  so i run the command a few times (maybe while changing buffers on the same frame), and now when i do `frame-multiplexer-recent`, it is useless.  with this patch, `frame-multiplexer-recent` will continue to be useful in such situations