### PR TITLE
Project - Prompt Save + Message

### DIFF
--- a/src/commands/project.lisp
+++ b/src/commands/project.lisp
@@ -13,6 +13,7 @@
            :project-kill-buffers
            :project-switch
            :project-save
+           :project-save-prompt
            :project-unsave)
   #+sbcl
   (:lock t)
@@ -251,8 +252,10 @@
          ;; Project roots (pathnames) are converted to strings for the
          ;; string completion prompt.
          (input (namestring input)))
-    (lem/common/history:add-history history input :allow-duplicates nil)
-    (lem/common/history:save-file history)))
+    (if (and (lem/common/history:add-history history input :allow-duplicates nil)
+             (lem/common/history:save-file history))
+        (message "Saved project: ~A" input)
+        (message "Failed saving project: ~A" input))))
 
 (defun forget-project (input)
   "Remove this project (string) from the projects' history file.
@@ -268,9 +271,12 @@
   (lem/common/history:history-data-list (history)))
 
 (define-command project-save () ()
-  "Remember the current project for later sessions."
-  (when (remember-project (find-root (buffer-directory)))
-    (message "Project saved.")))
+  "Remember the current project to the projects list."
+  (remember-project (find-root (buffer-directory))))
+
+(define-command project-save-prompt () ()
+  "Prompts for a directory to save to the projects list."
+  (remember-project (prompt-for-directory "Save Project: " :directory (buffer-directory))))
 
 (define-command project-unsave () ()
   "Prompt for a project and remove it from the list of saved projects."
@@ -278,7 +284,7 @@
     (and
      (forget-project choice)
      (lem/common/history:save-file (history))
-     (message "Project removed."))))
+     (message "Project removed: ~A" choice))))
 
 (defun prompt-for-project ()
   "Prompt for a project saved in the projects history."


### PR DESCRIPTION
# Overview

This is 2 small changes. When I started using `Project`, I had a hard time deciphering which folder was being saved as a project, since there are multiple files it can match on.

This change:
 - Adds a message informing the user which directory was saved/removed from the project list.
 - Adds a command `project-save-project` which will prompt the user for a directory to save.
   This uses the existing functionality to remember the path, just gets the path from (prompt-for-directory)

# Images

The prompt invokes this:
![image](https://github.com/user-attachments/assets/4e950da7-8c09-4b24-9ac4-27641719a190)

Both saves trigger this:
![image](https://github.com/user-attachments/assets/6bd57b33-526b-4589-be49-f0b7220b4ee9)

And the removed:
![image](https://github.com/user-attachments/assets/3ce83393-e1af-447f-b45b-4c315a7738aa)


# Extra
This is just something small, I am happy to keep it in my config if not.

P.S. Take your time with any of my pull requests, no hurry! I have them in my config so I am happy :)
