### PR TITLE
Add (undefine-key) functionality

### DIFF
--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -459,6 +459,8 @@
    :*global-keymap*
    :define-key
    :define-keys
+   :undefine-key
+   :undefine-keys
    :keyseq-to-string
    :find-keybind
    :insertion-key-p


### PR DESCRIPTION
# Overview

I noticed this here, and wasn't going to look into it. But I started getting into paredit myself, so I encountered the same issue. Now it's personal..

Issue: [feature: the undefine-key function to delete an existing key in a keymap.](https://github.com/lem-project/lem/issues/1611)
    
# Change Description

Add public function: `undefine-keys` and marco `undefine-keys`. These are very much in the same style as their `define` counterparts.

# Testing

I tested both functionality in my own config:
```common-lisp
(undefine-key *paredit-mode-keymap* "C-k")

(undefine-keys *paredit-mode-keymap* ("C-k")
  ( "C-L"))
```
    
I also tested attempting to undefine keys that don't exist in the map. This is fine with no errors.

For example with paredit, you can define your own keys before or after undefining the paredit keys, as it will just remove from the map, your keys and paredit will not interfere.

You can undefine keys to your hearts content:

![image](https://github.com/user-attachments/assets/9a1f4338-139e-49bf-a8e2-4aa8f2f2f884)