### PR TITLE
removed C-i and C-m conversion from parse-keyspec

### DIFF
--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -132,12 +132,6 @@ Example: (undefine-key *paredit-mode-keymap* \"C-k\")"
                                (not (named-key-sym-p str)))
                           (fail))
                          (t
-                          (cond ((and ctrl (string= str "i"))
-                                 (setf ctrl nil
-                                       str "Tab"))
-                                ((and ctrl (string= str "m"))
-                                 (setf ctrl nil
-                                       str "Return")))
                           (return (make-key :ctrl ctrl
                                             :meta meta
                                             :super super


### PR DESCRIPTION
# Overview

GUI mode had no ability to seperate ```Tab``` from ```C-i```.

# Change Description

```lisp
(defun parse-keyspec (string)
  (labels ((fail ()
             (editor-error "parse error: ~A" string))
           (parse (str)
             (loop :with ctrl :and meta :and super :and hyper :and shift
                   :do (cond
                         ((ppcre:scan "^[cmshCMSH]-" str)
                          (ecase (char-downcase (char str 0))
                            ((#\c) (setf ctrl t))
                            ((#\m) (setf meta t))
                            ((#\s) (setf super t))
                            ((#\h) (setf hyper t)))
                          (setf str (subseq str 2)))
                         ((ppcre:scan "^[sS]hift-" str)
                          (setf shift t)
                          (setf str (subseq str 6)))
                         ((string= str "")
                          (fail))
                         ((and (not (insertion-key-sym-p str))
                               (not (named-key-sym-p str)))
                          (fail))
                         (t
                          ;; Removed this conversion
                          ;; (cond ((and ctrl (string= str "i"))
                          ;;        (setf ctrl nil
                          ;;              str "Tab"))
                          ;;       ((and ctrl (string= str "m"))
                          ;;        (setf ctrl nil
                          ;;              str "Return")))
                          (return (make-key :ctrl ctrl
                                            :meta meta
                                            :super super
                                            :hyper hyper
                                            :shift shift
                                            :sym (or (named-key-sym-p str)
                                                     str))))))))
    (mapcar #'parse (uiop:split-string string :separator " "))))
```

I don't know the original purpose, as it isn't actually doing the ```C-[``` to ```Escape``` conversion here.

# Testing 

```lisp
(setf lem-core::*key-conversions*
      '(("C-m" . "Return")
        ("C-i" . "Tab")
        ("C-[" . "Escape")))
```

cause the traditional terminal behavior, ```C-i``` acts as ```Tab```

```lisp
(setf lem-core::*key-conversions*
      '(("C-m" . "Return")
        ("C-[" . "Escape")))
```

allows me to define ```Tab``` to a separate command from ```C-i```

closes #1729