### PR TITLE
Fix: [line-number-mode] - Wrapped line attributes & Uniform number width

### DIFF
--- a/src/display/base.lisp
+++ b/src/display/base.lisp
@@ -16,6 +16,10 @@
 (defgeneric compute-left-display-area-content (mode buffer point)
   (:method (mode buffer point) nil))
 
+(defgeneric compute-wrap-left-area-content (left-side-width left-side-characters)
+  (:method (left-side-width left-side-characters)
+    nil))
+
 (defvar *in-redraw-display* nil
   "T if the screen is currently being redrawn by `redraw-display`.
 Used to prevent recursive `redraw-display` calls.")

--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -272,19 +272,14 @@
          (objects-per-physical-line
            (separate-objects-by-width (create-drawing-objects logical-line)
                                       (- (window-view-width window) left-side-width)
-                                      (window-buffer window)))
-         (empty-left-side-object (if (< 0 left-side-width)
-                                     (list (make-object-with-type
-                                            (make-string left-side-characters :initial-element #\space)
-                                            nil
-                                            (char-type #\space)))
-                                     nil)))
+                                      (window-buffer window))))
     (loop :for objects :in objects-per-physical-line
           :for all-objects := (append left-side-objects objects)
           :for height := (max-height-of-objects all-objects)
           :do (render-line-with-caching window 0 y all-objects height)
               (incf y height)
-              (setq left-side-objects (copy-list empty-left-side-object))
+              (setq left-side-objects (copy-list (compute-wrap-left-area-content
+                                                  left-side-width left-side-characters)))
           :sum height)))
 
 (defun find-cursor-object (objects)

--- a/src/ext/line-numbers.lisp
+++ b/src/ext/line-numbers.lisp
@@ -18,9 +18,10 @@
 
 (defvar *initialized* nil)
 
-(define-editor-variable line-number-format "~6D "
+(define-editor-variable line-number-format nil
   "Set to desired format, for example, \"~2D \" for a
-two-character line-number column and a margin of one space.")
+two-character line-number column and a margin of one space.
+The default NIL will use a number format matching the current buffer length.")
 
 (define-editor-variable custom-current-line nil
   "Set to desired current-line value when relative line
@@ -68,10 +69,17 @@ With a positive universal argument, use relative line numbers. Also obey the glo
             (abs (- cursor-line line))))
       (line-number-at-point point)))
 
+(defun get-buffer-num-format (buffer)
+  (let* ((last-line (lem/buffer/internal::point-linum (buffer-end-point buffer)))
+         (digit-count (1+ (floor (log (abs last-line) 10)))))
+    (format nil " ~~~aD " digit-count)))
+
 (defmethod lem-core:compute-left-display-area-content ((mode line-numbers-mode) buffer point)
   (when (buffer-filename (point-buffer point))
     (let* ((computed-line (compute-line buffer point))
-           (string (format nil (variable-value 'line-number-format :default buffer) computed-line))
+           (num-format (or (variable-value 'line-number-format :default buffer)
+                           (get-buffer-num-format buffer)))
+           (string (format nil num-format computed-line))
            (attribute (if (eq computed-line
                               (compute-line buffer (buffer-point buffer)))
                           `((0 ,(length string) active-line-number-attribute))

--- a/src/ext/line-numbers.lisp
+++ b/src/ext/line-numbers.lisp
@@ -41,7 +41,6 @@ the absolute value of the current line display.")
 (define-minor-mode line-numbers-mode
     (:name "Line numbers"
      :global t
-     :enable-hook 'enable-hook
      :disable-hook 'disable-hook))
 
 (define-command toggle-line-numbers (&optional relative) (:universal-nil)
@@ -52,9 +51,6 @@ With a positive universal argument, use relative line numbers. Also obey the glo
         *relative-line* (or *relative-line*
                             (and relative (plusp relative))))
   (line-numbers-mode))
-
-(defun enable-hook ()
-  (setf (lem:variable-value 'lem-core:wrap-line-attribute :global) 'line-numbers-attribute))
 
 (defun disable-hook ()
   (setf *relative-line* *previous-relative-line*))

--- a/src/ext/line-numbers.lisp
+++ b/src/ext/line-numbers.lisp
@@ -40,6 +40,7 @@ the absolute value of the current line display.")
 (define-minor-mode line-numbers-mode
     (:name "Line numbers"
      :global t
+     :enable-hook 'enable-hook
      :disable-hook 'disable-hook))
 
 (define-command toggle-line-numbers (&optional relative) (:universal-nil)
@@ -50,6 +51,9 @@ With a positive universal argument, use relative line numbers. Also obey the glo
         *relative-line* (or *relative-line*
                             (and relative (plusp relative))))
   (line-numbers-mode))
+
+(defun enable-hook ()
+  (setf (lem:variable-value 'lem-core:wrap-line-attribute :global) 'line-numbers-attribute))
 
 (defun disable-hook ()
   (setf *relative-line* *previous-relative-line*))
@@ -74,3 +78,11 @@ With a positive universal argument, use relative line numbers. Also obey the glo
                           `((0 ,(length string) line-numbers-attribute)))))
       (lem/buffer/line:make-content :string string
                                     :attributes attribute))))
+
+(defmethod lem-core:compute-wrap-left-area-content (left-side-width left-side-characters)
+  (if (< 0 left-side-width)
+      (list (lem-core::make-object-with-type
+             (make-string left-side-characters :initial-element #\space)
+             'line-numbers-attribute
+             (lem-core::char-type #\space)))
+      nil))

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -601,7 +601,8 @@
    :wrap-line-attribute
    :inactive-window-background-color
    :redraw-buffer
-   :compute-left-display-area-content)
+   :compute-left-display-area-content
+   :compute-wrap-left-area-content)
   ;; interface.lisp
   (:export
    :with-implementation


### PR DESCRIPTION
This change is fixes 2 bugs with line-numbers-mode. They are broken up into 2 commits if you wish to view the changes individually. Line numbers are looking a lot smoother now.

# Wrapped lines have no font attributes
Currently, wrapped lines do not have the same font attributes as the line numbers and it looks very strange.

I moved the computation of the wrapped left area to a generic and removed the implementation(not needed when no line numbers). line-numbers-mode then implements this generic to allow using it's attributes to highlight the blank spaces.

I could have just exposed the attribute, but this is now matching with the unwrapped lines, and it allows more flexibility in extensions(adding icons to wrapped lines, etc.)

Before:
![image](https://github.com/user-attachments/assets/4dd30655-023c-40c7-b3f1-a820c1624e73)

After:
![image](https://github.com/user-attachments/assets/36ff4c30-ecc0-45d4-8c8f-32429e830407)

# Line numbers format match max buffer lines
This is a fix for my own issue: [improve: [line-numbers-mode] - Sync line format with lines that are displayed](https://github.com/lem-project/lem/issues/1726)

I looked at a few editors, and most of the handle this by making the line number width for all lines match the amount of digits in the last line of the buffer. Some base it of the visual lines on the screen(if you can see a higher digit), but it's fully customizable via a minor mode now so people can change it if they wish.

Before:
![image](https://github.com/user-attachments/assets/d3499ccd-d77d-4f9d-b409-a41b868c63ac)

After:
![image](https://github.com/user-attachments/assets/456e395b-5d4c-48a7-8353-2b85b3b34b8e)
