### PR TITLE
Implemented improved Python indent function.

### DIFF
--- a/extensions/python-mode/python-mode.lisp
+++ b/extensions/python-mode/python-mode.lisp
@@ -91,10 +91,21 @@
            (column (point-column (back-to-indentation point)))
            (next-indent-column (+ last-line-indent-column tab-width))
            (previous-indent-column
-             (max (- last-line-indent-column tab-width) 0)))
+             (max (- last-line-indent-column tab-width) 0))
+           (last-line-end-with-delimiter-start-p
+             (progn
+               (line-end last-line-point)
+               (skip-whitespace-backward last-line-point t)
+               (when (> (point-charpos last-line-point) 0)
+                 (character-offset last-line-point -1)
+                 (member (character-at last-line-point)
+                         '(#\: #\( #\[ #\{)
+                         :test #'char=)))))
       (cond
-        ((and (>= column last-line-indent-column)
-              (< column next-indent-column))
+        ((or last-line-end-with-delimiter-start-p
+             (and (>= column last-line-indent-column)
+                  (< column next-indent-column)
+                  (not (zerop column))))
          next-indent-column)
         ((>= column next-indent-column)
          previous-indent-column)


### PR DESCRIPTION
The new indent function for Python mimics the behaviour of indent function as seen in Emacs, where hitting tab key will cycle through the following positions:

- Same indent level as last line.
- +1 indent level relative to last line.
- -1 indent level relative to last line.

There're still a flaw in this function, that I currently have no idea how to fix:

```python
         v Cursor.
foo = bar|
```

after `newline-and-indent`:

```python
foo = bar
    |
    ^ It should not have indented, since the last line is just a
      top-level declaration.
```