### PR TITLE
Lem SDL2 can now properly display zero-width characters.

### DIFF
--- a/frontends/sdl2/display.lisp
+++ b/frontends/sdl2/display.lisp
@@ -147,13 +147,13 @@
         ((eq type :braille)
          (display-braille-font display))
         (bold
-         (if (eq type :latin)
-             (display-latin-bold-font display)
-             (display-cjk-bold-font display)))
+         (case type
+           ((:latin :zero-width) (display-latin-bold-font display))
+           (otherwise (display-cjk-bold-font display))))
         (t
-         (if (eq type :latin)
-             (display-latin-font display)
-             (display-cjk-normal-font display)))))
+         (case type
+           ((:latin :zero-width) (display-latin-font display))
+           (otherwise (display-cjk-normal-font display))))))
 
 (defmethod scaled-char-width ((display display) x)
   (let ((scale-x (round (first (display-scale display)))))

--- a/src/attribute.lisp
+++ b/src/attribute.lisp
@@ -70,9 +70,9 @@
                   :background (or (attribute-background over)
                                   (attribute-background under))
                   :bold (or (attribute-bold over)
-                              (attribute-bold under))
+                            (attribute-bold under))
                   :reverse (or (attribute-reverse over)
-                                 (attribute-reverse under))
+                               (attribute-reverse under))
                   :underline (or (attribute-underline over)
                                  (attribute-underline under))
                   :plist (append (attribute-plist over)
@@ -195,6 +195,9 @@
   (t :bold t :background "#212121" :foreground "#707070"))
 
 (define-attribute truncate-attribute)
+
+(define-attribute special-char-attribute
+  (t :foreground "red"))
 
 (define-attribute compiler-note-attribute
   (t :underline "red"))

--- a/src/display/char-type.lisp
+++ b/src/display/char-type.lisp
@@ -1,7 +1,7 @@
 (in-package :lem-core)
 
 (deftype char-type ()
-  '(member :latin :cjk :braille :emoji :icon :control))
+  '(member :latin :cjk :braille :emoji :icon :control :zero-width))
 
 (defun cjk-char-code-p (code)
   (or (<= #x4E00 code #x9FFF)
@@ -27,6 +27,9 @@
 (defun icon-char-code-p (code)
   (icon-value code :font))
 
+(defun zero-width-char-code-p (code)
+  (or (<= #x200B code #x200D) (= code #xFEFF)))
+
 (defun char-type (char)
   (let ((code (char-code char)))
     (cond ((control-char char)
@@ -47,5 +50,7 @@
            :emoji)
           ((icon-code-p code)
            :latin)
+          ((zero-width-char-code-p code)
+           :zero-width)
           (t
            :cjk))))

--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -132,10 +132,19 @@
                      (:emoji 'emoji-object)
                      (:control 'control-character-object)
                      (otherwise 'text-object))
-                   :string (if (eq type :control)
-                               (control-char (char string 0))
-                               string)
-                   :attribute attribute
+                   :string (case type
+                             (:control
+                              (control-char (char string 0)))
+                             (:zero-width
+                              (make-string (length string) :initial-element #\·))
+                             (otherwise
+                              string))
+                   :attribute (case type
+                                ((:control :zero-width)
+                                 (merge-attribute attribute
+                                                  (ensure-attribute 'special-char-attribute nil)))
+                                (otherwise
+                                 attribute))
                    :type type
                    :within-cursor (and attribute
                                        (cursor-attribute-p attribute)))))


### PR DESCRIPTION
Previously, if someone tried to open a file that contains zero-width characters, such as `U+200B`, `U+200C`, `U+200D`, and `U+FEFF`, Lem SDL2 will just refuse to display any content, leaving the user with a blank window.  This is probably because SDL2 does not like zero-width characters.

So now I try to fix this problem by adding another `char-type` dedicated for zero-width characters, and display them with a special character.

I've also created a new attribute for zero-width characters and control characters, so users won't confuse them with real contents.