### PR TITLE
vi-mode: Add paragraph text object

### DIFF
--- a/extensions/vi-mode/binds.lisp
+++ b/extensions/vi-mode/binds.lisp
@@ -194,6 +194,8 @@
 (define-key *inner-text-objects-keymap* "(" 'vi-inner-paren)
 (define-key *inner-text-objects-keymap* ")" 'vi-inner-paren)
 (define-key *inner-text-objects-keymap* "b" 'vi-inner-paren)
+(define-key *outer-text-objects-keymap* "p" 'vi-a-paragraph)
+(define-key *inner-text-objects-keymap* "p" 'vi-inner-paragraph)
 
 (setf (gethash (lem:make-key :sym "a") (keymap-table *operator-keymap*))
       (keymap-table *outer-text-objects-keymap*))

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -136,6 +136,8 @@
            :vi-inner-double-quote
            :vi-a-paren
            :vi-inner-paren
+           :vi-a-paragraph
+           :vi-inner-paragraph
            :vi-repeat
            :vi-normal
            :vi-keyboard-quit
@@ -1100,6 +1102,14 @@ on the same line or at eol if there are none."
 (define-text-object-command vi-inner-paren (count) ("p")
     (:expand-selection t)
   (inner-range-of 'paren-object (current-state) count))
+
+(define-text-object-command vi-a-paragraph (count) ("p")
+    (:expand-selection t)
+  (a-range-of 'paragraph-object (current-state) count))
+
+(define-text-object-command vi-inner-paragraph (count) ("p")
+    (:expand-selection t)
+  (inner-range-of 'paragraph-object (current-state) count))
 
 (define-command vi-normal () ()
   (change-state 'normal))

--- a/extensions/vi-mode/tests/text-objects.lisp
+++ b/extensions/vi-mode/tests/text-objects.lisp
@@ -76,3 +76,12 @@
         (cmd "va\"")
         (ok (buf= " <\"foo\"  [ ]>\"bar\""))))))
 
+(deftest paragraph-object
+  (with-fake-interface ()
+    (with-vi-buffer (#?" \n \n f[o]o \n bar \n \n \n")
+      (cmd "vip")
+      (ok (buf= #?" \n \n< foo \n bar [\n]> \n \n")))
+    (with-vi-buffer (#?" \n \n f[o]o \n bar \n \n \n")
+      (cmd "vap")
+      (ok (buf= #?" \n \n< foo \n bar \n \n [\n]>")))))
+

--- a/extensions/vi-mode/text-objects.lisp
+++ b/extensions/vi-mode/text-objects.lisp
@@ -399,6 +399,7 @@
 (defclass paragraph-object (text-object) ())
 
 (defmethod inner-range-of ((object paragraph-object) state count)
+  (declare (ignore state count))
   (with-point ((start (current-point))
                (end (current-point)))
     ;; Start


### PR DESCRIPTION
# Change Description

Add the paragraph text object to vi-mode. Tested myself with the other operations: `dip`, `yap`, etc.

# Tests
Passing:
![image](https://github.com/user-attachments/assets/4f13f5a5-5897-4c10-964c-fd294988d755)
