### PR TITLE
Fix zero-width characters and control characters attribute issue.

### DIFF
--- a/src/common/character/string-width-utils.lisp
+++ b/src/common/character/string-width-utils.lisp
@@ -50,7 +50,7 @@
     table))
 
 (defun control-char (char)
-  (values (gethash char *char-replacement*)))
+  (gethash char *char-replacement*))
 
 (defun wide-char-p (char)
   (declare (character char))

--- a/src/display/char-type.lisp
+++ b/src/display/char-type.lisp
@@ -28,7 +28,9 @@
   (icon-value code :font))
 
 (defun zero-width-char-code-p (code)
-  (or (<= #x200B code #x200D) (= code #xFEFF)))
+  (or (<= #x200B code #x200D)
+      (<= #xFE00 code #xFE0F)
+      (= code #xFEFF)))
 
 (defun char-type (char)
   (let ((code (char-code char)))

--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -141,10 +141,11 @@
                               string))
                    :attribute (case type
                                 ((:control :zero-width)
-                                 (merge-attribute attribute
-                                                  (ensure-attribute 'special-char-attribute nil)))
-                                (otherwise
-                                 attribute))
+                                 (let ((attr (ensure-attribute 'special-char-attribute nil)))
+                                   (if attribute
+                                       (merge-attribute attribute attr)
+                                       attr)))
+                                (otherwise attribute))
                    :type type
                    :within-cursor (and attribute
                                        (cursor-attribute-p attribute)))))


### PR DESCRIPTION
Since 1e42f96b44e4c2eb664100858c482a480526a4b4, if you put the cursor on the different line than the line those special characters are on, Lem will signal an error.  This issue is fixed in this PR.