### PR TITLE
Minor fixes for coalton-mode

### DIFF
--- a/extensions/coalton-mode/coalton-mode.lisp
+++ b/extensions/coalton-mode/coalton-mode.lisp
@@ -5,6 +5,7 @@
   (:import-from #:lem-lisp-mode/grammar
                 #:wrap-symbol-names
                 #:symbol-boundary-begin
+                #:maybe-package-prefix
                 #:symbol-boundary-end)
   (:import-from #:lem-lisp-mode/internal
                 #:check-connection
@@ -114,6 +115,7 @@
                    (make-tm-match
                     `(:sequence
                       symbol-boundary-begin
+                      maybe-package-prefix
                       ,(ppcre:parse-string "[A-Z]") symbol
                       symbol-boundary-end)
                     :name 'syntax-type-attribute))))

--- a/extensions/coalton-mode/coalton-mode.lisp
+++ b/extensions/coalton-mode/coalton-mode.lisp
@@ -161,6 +161,7 @@
     ("while" 1)
     ("while-let" . "let")
     ("progn" (&rest &body))
+    ("do" . "progn")
     ("package" (4 &rest (&whole 2 &rest coalton-package-body)))))
 
 (defun coalton-package-body (path indent-point sexp-column)


### PR DESCRIPTION
* Highlight type symbols with a package prefix. (ex. `file:Pathname`)
* Add an indentation rule for `do` notation.