### PR TITLE
Add dev shells to nix flake to build from source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -151,7 +151,40 @@
               runHook postInstall
             '';
           };
-        in {
+          lem-sdl2-shell = pkgs.mkShell {
+            packages = with pkgs; [
+              sbcl
+              sbcl.pkgs.qlot-cli
+            ];
+            # Normally we would include pkg-config and list these dependencies
+            # in packages, but it does not appear that pkg-config is being used
+            # when available.
+            shellHook = with pkgs; ''
+              export LD_LIBRARY_PATH="''${LD_LIBRARY_PATH}:${SDL2}/lib:${SDL2_ttf}/lib:${SDL2_image}/lib:${libffi}/lib:${openssl.out}/lib"
+            '';
+          };
+          lem-ncurses-shell = pkgs.mkShell {
+            packages = with pkgs; [
+              sbcl
+              sbcl.pkgs.qlot-cli
+              pkg-config
+              ncurses.dev
+            ];
+            # Normally we would include pkg-config and list these dependencies
+            # in packages, but it does not appear that pkg-config is being used
+            # when available.
+            shellHook = with pkgs; ''
+              export LD_LIBRARY_PATH="''${LD_LIBRARY_PATH}:${ncurses.out}/lib:${libffi}/lib:${openssl.out}/lib"
+            '';
+          };
+        in
+        {
+          devShells =
+            {
+              lem-ncurses = lem-ncurses-shell;
+              lem-sdl2 = lem-ncurses-shell;
+              default = lem-ncurses-shell;
+            };
           packages.lem-ncurses = lem.overrideLispAttrs (o: {
             pname = "lem-ncurses";
             meta.mainProgram = "lem";


### PR DESCRIPTION
This is a dirty first working pass.  I can build a working lem using just the dependencies provided by running `nix develop .#lem-sdl2`

I used `make sdl2`.  I have previously ran `qlot install` but I'm not sure if this is necessary.  I don't use a lot of Common Lisp.

It should be possible to make this work with pkg-config.  I just don't know how to usually convince CL to ask pkg-config.