### PR TITLE
Fix grammar of window movement commands

### DIFF
--- a/docs/default-keybindings.md
+++ b/docs/default-keybindings.md
@@ -140,8 +140,8 @@ Supported modes include: c-mode with clang-format, go-mode with gofmt, js-mode a
 | [next-window](https://github.com/lem-project/lem/blob/main/src/commands/window.lisp#L139)                      | C-x o, M-o     | Go to the next window.                                                |
 | [previous-window](https://github.com/lem-project/lem/blob/main/src/commands/window.lisp#L151)                  | M-O            |                                                                       |
 | [switch-to-last-focused-window](https://github.com/lem-project/lem/blob/main/src/commands/window.lisp#L154)    |                | Go to the window that was last in focus.                              |
-| [window-move-down](https://github.com/lem-project/lem/blob/main/src/commands/window.lisp#L162)                 |                | Go to the window on the down.                                         |
-| [window-move-up](https://github.com/lem-project/lem/blob/main/src/commands/window.lisp#L167)                   |                | Go to the window on the up.                                           |
+| [window-move-down](https://github.com/lem-project/lem/blob/main/src/commands/window.lisp#L162)                 |                | Go to the window below.                                         |
+| [window-move-up](https://github.com/lem-project/lem/blob/main/src/commands/window.lisp#L167)                   |                | Go to the window above.                                           |
 | [window-move-right](https://github.com/lem-project/lem/blob/main/src/commands/window.lisp#L172)                |                | Go to the window on the right.                                        |
 | [window-move-left](https://github.com/lem-project/lem/blob/main/src/commands/window.lisp#L177)                 |                | Go to the window on the left.                                         |
 | [delete-other-windows](https://github.com/lem-project/lem/blob/main/src/commands/window.lisp#L182)             | C-x 1          | Delete all other windows.                                             |

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -1125,11 +1125,11 @@ on the same line or at eol if there are none."
   (dotimes (i n) (window-move-left)))
 
 (define-command vi-window-move-down (&optional (n 1)) (:universal)
-  "Go to the window on the down N times."
+  "Go to the window below N times."
   (dotimes (i n) (window-move-down)))
 
 (define-command vi-window-move-up (&optional (n 1)) (:universal)
-  "Go to the window on the up N times."
+  "Go to the window above N times."
   (dotimes (i n) (window-move-up)))
 
 (define-command vi-window-move-right (&optional (n 1)) (:universal)

--- a/src/commands/window.lisp
+++ b/src/commands/window.lisp
@@ -160,12 +160,12 @@
     (switch-to-window window)))
 
 (define-command window-move-down () ()
-  "Go to the window on the down."
+  "Go to the window below."
   (alexandria:when-let ((window (down-window (current-window))))
     (switch-to-window window)))
 
 (define-command window-move-up () ()
-  "Go to the window on the up."
+  "Go to the window above."
   (alexandria:when-let ((window (up-window (current-window))))
     (switch-to-window window)))
 


### PR DESCRIPTION
Changed "move to the window on the up" and "move to the window on the down" to "move to the window above" and "move to the window below" respectively.