### PR TITLE
recenter-top-bottom (emacs-mode)

### DIFF
--- a/src/commands/window.lisp
+++ b/src/commands/window.lisp
@@ -37,7 +37,7 @@
 (define-key *global-keymap* "C-x k" 'kill-buffer)
 (define-key *global-keymap* "C-x Left" 'previous-buffer)
 (define-key *global-keymap* "C-x Right" 'next-buffer)
-(define-key *global-keymap* "C-l" 'recenter-top-bottom)
+(define-key *global-keymap* "C-l" 'recenter)
 (define-key *global-keymap* "C-x 2" 'split-active-window-vertically)
 (define-key *global-keymap* "C-x 3" 'split-active-window-horizontally)
 (define-key *global-keymap* "C-x o" 'next-window)

--- a/src/commands/window.lisp
+++ b/src/commands/window.lisp
@@ -37,7 +37,7 @@
 (define-key *global-keymap* "C-x k" 'kill-buffer)
 (define-key *global-keymap* "C-x Left" 'previous-buffer)
 (define-key *global-keymap* "C-x Right" 'next-buffer)
-(define-key *global-keymap* "C-l" 'recenter)
+(define-key *global-keymap* "C-l" 'recenter-top-bottom)
 (define-key *global-keymap* "C-x 2" 'split-active-window-vertically)
 (define-key *global-keymap* "C-x 3" 'split-active-window-horizontally)
 (define-key *global-keymap* "C-x o" 'next-window)
@@ -121,6 +121,13 @@
   "Scroll so that the cursor is in the middle."
   (clear-screens-of-window-list)
   (unless p (window-recenter (current-window)))
+  (redraw-display)
+  t)
+
+(define-command recenter-top-bottom (p) (:universal-nil)
+  "Scroll so that the cursor is in the middle/top/bottom."
+  (clear-screens-of-window-list)
+  (unless p (window-recenter-top-bottom (current-window)))
   (redraw-display)
   t)
 

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -353,6 +353,7 @@
   ;; virtual-line
   (:export
    :window-recenter
+   :window-recenter-top-bottom
    :window-cursor-x
    :window-cursor-y
    :backward-line-wrap

--- a/src/window/virtual-line.lisp
+++ b/src/window/virtual-line.lisp
@@ -28,7 +28,6 @@ If cursor is on top then move move WINDOW to the bottom."
   (let* ((line (window-cursor-y window))
          (window-height (window-height-without-modeline window))
          (middle (floor window-height 2))
-         (bottom (window-height-without-modeline window))
          (scrolloff (min (floor (/ (window-height window) 2)) 0))
          (top 0))
     (cond

--- a/src/window/virtual-line.lisp
+++ b/src/window/virtual-line.lisp
@@ -21,6 +21,22 @@ If FROM-BOTTOM is T, start counting from the bottom."
       (window-scroll window n)
       n)))
 
+(defun window-recenter-top-bottom (window)
+  "In first call recenter WINDOW to the middle line.
+If cursor is already in the middle of WINDOW then move cursor in the top position.
+If cursor is on top then move move WINDOW to the bottom."
+  (let* ((line (window-cursor-y window))
+         (window-height (window-height-without-modeline window))
+         (middle (floor window-height 2))
+         (bottom (window-height-without-modeline window))
+         (scrolloff (min (floor (/ (window-height window) 2)) 0))
+         (top 0))
+    (cond
+      ((= line middle) (window-recenter window :line scrolloff :from-bottom nil))
+      ((= line top) (window-recenter window :line scrolloff :from-bottom t))
+      (t (window-recenter window :line nil :from-bottom nil)))
+    (redraw-display)))
+
 (defun %calc-window-cursor-x (point window)
   "Return (values cur-x next). the 'next' is a flag if the cursor goes to
 next line because it is at the end of width."

--- a/src/window/virtual-line.lisp
+++ b/src/window/virtual-line.lisp
@@ -34,8 +34,7 @@ If cursor is on top then move move WINDOW to the bottom."
     (cond
       ((= line middle) (window-recenter window :line scrolloff :from-bottom nil))
       ((= line top) (window-recenter window :line scrolloff :from-bottom t))
-      (t (window-recenter window :line nil :from-bottom nil)))
-    (redraw-display)))
+      (t (window-recenter window :line nil :from-bottom nil)))))
 
 (defun %calc-window-cursor-x (point window)
   "Return (values cur-x next). the 'next' is a flag if the cursor goes to


### PR DESCRIPTION
Emacs default behavior of (C-l recenter-top-bottom)

![lem-recenter-top-bottom](https://github.com/user-attachments/assets/fae7e2b7-f6d5-4b00-9a24-04c91b386fcb)
