### PR TITLE
let compute-evaluated-background-color handle nil background-color

### DIFF
--- a/extensions/lisp-mode/ext/eval.lisp
+++ b/extensions/lisp-mode/ext/eval.lisp
@@ -79,7 +79,7 @@
 
 ;; copied from src/display.lisp, TODO: extract this utils
 (defun compute-evaluated-background-color ()
-  (let ((color (parse-color (background-color))))
+  (alexandria:when-let (color (parse-color (background-color)))
     (multiple-value-bind (h s v)
         (rgb-to-hsv (color-red color)
                     (color-green color)


### PR DESCRIPTION
avoid crashing with a color-theme (:background nil)

cf. https://github.com/lem-project/lem/issues/1769

```
(define-color-theme "lem-dark" ("lem-default")
  (:background nil))

(load-theme "lem-dark")
```

Running commands like `C-x C-e lisp-eval-at-point` under the color-theme with `(:background nil)` results in the following error.

```
The value NIL is not of type LEM/COMMON/COLOR:COLOR
Backtrace for: #<SB-THREAD:THREAD tid=268140 "editor" RUNNING {10039E86D3}>
0: (LEM-LISP-MODE/EVAL::COMPUTE-EVALUATED-BACKGROUND-COLOR)
1: (LEM-LISP-MODE/EVAL::DISPLAY-EVALUATED-MESSAGE #<LEM/BUFFER/INTERNAL:POINT (29, 0) "(define-key *global-keymap* \"C-\\\\\" 'undo)" {1006B57B13}> #<LEM/B
2: ((LAMBDA (LEM-LISP-MODE/CONNECTION:CONNECTION) :IN LEM-LISP-MODE/INTERNAL::PULL-EVENTS) #<LEM-LISP-MODE/CONNECTION::SELF-CONNECTION {1005FCD253}>)
3: ((LAMBDA NIL :IN LEM-LISP-MODE/INTERNAL::START-THREAD))
4: (LEM-CORE:RECEIVE-EVENT 0.001)
5: (LEM-CORE::READ-EVENT-INTERNAL :ACCEPT-KEY T :ACCEPT-MOUSE T)
6: (LEM-CORE::READ-EVENT-WITH-RECORDING-AND-RUN-HOOKS :ACCEPT-KEY T :ACCEPT-MOUSE T)
7: (LEM-CORE:READ-COMMAND)
8: (LEM/COMMON/TIMER::CALL-WITH-IDLE-TIMERS #<FUNCTION (LAMBDA NIL :IN LEM-CORE::COMMAND-LOOP-BODY) {B800774C7B}>)
9: (LEM-CORE::COMMAND-LOOP-BODY)
10: (LEM-CORE:COMMAND-LOOP)
11: (LEM-CORE::TOPLEVEL-COMMAND-LOOP #<FUNCTION (LAMBDA NIL :IN LEM-CORE::RUN-EDITOR-THREAD) {10046E38AB}>)
12: ((LAMBDA NIL :IN LEM-CORE::RUN-EDITOR-THREAD))
13: ((LAMBDA NIL :IN LEM-CORE::RUN-EDITOR-THREAD))
14: ((FLET BT2::RUN-FUNCTION :IN BT2::ESTABLISH-DYNAMIC-ENV))
15: ((LABELS BT2::%ESTABLISH-DYNAMIC-ENV-WRAPPER :IN BT2::ESTABLISH-DYNAMIC-ENV))
16: ((FLET SB-UNIX::BODY :IN SB-THREAD::RUN))
17: ((FLET "WITHOUT-INTERRUPTS-BODY-" :IN SB-THREAD::RUN))
18: ((FLET SB-UNIX::BODY :IN SB-THREAD::RUN))
19: ((FLET "WITHOUT-INTERRUPTS-BODY-" :IN SB-THREAD::RUN))
20: (SB-THREAD::RUN)
21: ("foreign function: call_into_lisp_")
```