### PR TITLE
Update flake.nix to reflect checksum on macOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,9 @@
               dontBuild = true;
               dontFixup = true;
               outputHashMode = "recursive";
-              outputHash =
+              outputHash = if pkgs.stdenv.isDarwin then
+                "sha256-BV1m58fUe1zfLH5iKbDP7KTNhv1p+g3W99tFQFYxPqs="
+              else
                 "sha256-NtCSBxEo/4uuhlLc9Xqlq+PM1fAbDfRBH64imMLvKYE=";
             };
 


### PR DESCRIPTION
I tried running `nix run github:lem-project/lem` on NixOS and macOS. On NixOS, this runs fine. However on macOS it shows this error message:

```
error: hash mismatch in fixed-output derivation '/nix/store/3sy98z0x1s7jnjnrjrx4mzhrhyhqk4px-lem-qlot-bundle-unstable.drv':
         specified: sha256-NtCSBxEo/4uuhlLc9Xqlq+PM1fAbDfRBH64imMLvKYE=
            got:    sha256-BV1m58fUe1zfLH5iKbDP7KTNhv1p+g3W99tFQFYxPqs=
error: 1 dependencies of derivation '/nix/store/y74flmb9scgzz5h75hqqvidb6cicwwff-sbcl-lem-ncurses-unstable.drv' failed to build
```

This commit fixes that by adding an `if` condition on checksum.