### PR TITLE
Use gitignore when finding project files

### DIFF
--- a/src/commands/project.lisp
+++ b/src/commands/project.lisp
@@ -4,6 +4,7 @@
            :*root-files*
            :*delete-repl-buffer*
            :*delete-last-buffer*
+           :*respect-gitignore*
            :root-p
            :find-root
            :saved-projects


### PR DESCRIPTION
This PR takes into account .gitignore when finding project files in git repos by default. Toggle with `*respect-gitignore*`.

Besides having more accurate autocomplete (e.g. ignoring .git/node_modules), `project-find-file` is actually usable on large projects now (e.g. autocomplete Linux kernel would take ~5 seconds to show up, now shows up instantly).