### PR TITLE
Fix query-replace to highlight all candidates

### DIFF
--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -212,9 +212,10 @@
       (when (string= search-string "")
         (return-from highlight-region nil))
       (with-point ((p start-point))
-        (loop
-          (unless (or (funcall *isearch-search-forward-function* p search-string end-point)
-                      (point= start-point end-point))
+        (loop 
+          (unless (funcall *isearch-search-forward-function* p search-string end-point)
+            (return))
+          (when (point= start-point p)
             (return))
           (with-point ((before p))
             (funcall *isearch-search-backward-function* before search-string)

--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -214,12 +214,12 @@
       (with-point ((p start-point))
         (loop
           (unless (or (funcall *isearch-search-forward-function* p search-string end-point)
-                      (point= start-point end-point)))
-          (return))
-        (with-point ((before p))
-          (funcall *isearch-search-backward-function* before search-string)
-          (isearch-add-overlay buffer
-                                 (make-overlay before p 'isearch-highlight-attribute))))
+                      (point= start-point end-point))
+            (return))
+          (with-point ((before p))
+            (funcall *isearch-search-backward-function* before search-string)
+            (isearch-add-overlay buffer
+                                 (make-overlay before p 'isearch-highlight-attribute)))))
       (isearch-sort-overlays buffer))))
 
 (defun isearch-update-display ()


### PR DESCRIPTION
Hello everyone.

I have found a small bug and am trying to fix it.
When I run `query-replace`, only the first hit word is highlighted and I can't see where the word is after the second.

Looking at the current `highlight-region` implementation, only one search result is added to isearch-overlays.
It seems that the parentheses of `unless` have the wrong correspondence and it is not used to determine whether to exit the loop.

The following images show the before and after behaviour.

![SS 2025-03-15 11 28 19](https://github.com/user-attachments/assets/01533d21-5b5b-4d40-9a17-62ebde519cde)