### PR TITLE
Fix Couldn't execute "xdg-open": No such file or directory error (Docker)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN apk add --no-cache curl bash build-base ncurses-dev sbcl git
+RUN apk add --no-cache curl bash build-base ncurses-dev sbcl git xdg-utils
 
 RUN curl -o quicklisp.lisp https://beta.quicklisp.org/quicklisp.lisp
 RUN sbcl --noinform --no-userinit --no-sysinit --non-interactive --load quicklisp.lisp --eval "(quicklisp-quickstart:install)" --eval "(ql-util:without-prompting (ql:add-to-init-file))"


### PR DESCRIPTION
Closes #1712 