### PR TITLE
Fix broken paste in vi-mode

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -543,7 +543,7 @@ Move the cursor to the first non-blank character of the line."
                   ((member :vi-line options) :line)
                   ((member :vi-block options) :block)
                   (t :char)))
-        (and (enable-clipboard-p) (get-clipboard-data)))))
+        (and (enable-clipboard-p) (values (get-clipboard-data) :block)))))
 
 (define-command vi-paste-after (&optional (n 1)) (:universal)
   (dotimes (i n) 

--- a/extensions/vi-mode/registers.lisp
+++ b/extensions/vi-mode/registers.lisp
@@ -261,28 +261,29 @@
 
 (defun paste-yank (string type &optional (position :after))
   (check-type position (member :before :after))
-  (let ((point (current-point)))
-    (ecase type
-      (:line
-       (lem:yank)
-       (move-point point (cursor-yank-start point))
-       (back-to-indentation point))
-      (:block
-        (setf (cursor-yank-start point) (copy-point point :right-inserting))
-        (let ((col (point-charpos point))
-              (first-line t))
-          (dolist (row (split-sequence #\Newline string))
-            (if first-line
-                (setf first-line nil)
-                (line-offset point 1 col))
-            (dotimes (i (max 0 (- col (point-charpos point))))
-              (insert-character point #\Space))
-            (insert-string point row)))
-        (setf (cursor-yank-end point) (copy-point point :left-inserting))
-        (move-point point (cursor-yank-start point)))
-      (:char
-       (lem:yank)
-       (character-offset point -1)))))
+  (when string
+    (let ((point (current-point)))
+      (ecase type
+        (:line
+         (lem:yank)
+         (move-point point (cursor-yank-start point))
+         (back-to-indentation point))
+        (:block
+            (setf (cursor-yank-start point) (copy-point point :right-inserting))
+          (let ((col (point-charpos point))
+                (first-line t))
+            (dolist (row (split-sequence #\Newline string))
+              (if first-line
+                  (setf first-line nil)
+                  (line-offset point 1 col))
+              (dotimes (i (max 0 (- col (point-charpos point))))
+                (insert-character point #\Space))
+              (insert-string point row)))
+          (setf (cursor-yank-end point) (copy-point point :left-inserting))
+          (move-point point (cursor-yank-start point)))
+        (:char
+         (lem:yank)
+         (character-offset point -1))))))
 
 (defun register (name)
   (let ((name (ensure-char name)))

--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -471,7 +471,7 @@
   (lem-sdl2/log:with-debug ("clipboard-paste")
     (display:with-display (display)
       (display:with-renderer (display)
-        (sdl2-ffi.functions:sdl-get-clipboard-text)))))
+        (multiple-value-bind (str _) (sdl2-ffi.functions:sdl-get-clipboard-text) str)))))
 
 #+windows
 (defmethod lem-if:clipboard-paste ((implementation sdl2))


### PR DESCRIPTION
### Overview
Fix broken paste in vi-mode. (https://github.com/lem-project/lem/issues/1700)

- We are not correctly handling the case when `(get-clipboard-data)` returns nil.
- `(get-clipboard-data)` was erroneously returning a SB-SYS:INT-SAP alongside the clipboard string which was being passed into `vi-paste-before/after` instead of a `:type`.

### Testing
- `make`
- Open new buffer in vi-mode
- Press `p` to yank
- No more backtrace