### PR TITLE
Command exports for keybindings

### DIFF
--- a/extensions/terminal/terminal-mode.lisp
+++ b/extensions/terminal/terminal-mode.lisp
@@ -8,6 +8,10 @@
 (defvar *bypass-commands*
   '(next-window
     previous-window
+    window-move-up
+    window-move-down
+    window-move-left
+    window-move-right
     split-active-window-vertically
     split-active-window-horizontally
     delete-other-windows

--- a/src/commands/help.lisp
+++ b/src/commands/help.lisp
@@ -2,6 +2,7 @@
   (:use :cl :lem-core)
   (:export :describe-key
            :describe-bindings
+           :describe-mode
            :apropos-command
            :lem-version
            :list-modes)

--- a/src/ext/language-mode.lisp
+++ b/src/ext/language-mode.lisp
@@ -16,6 +16,7 @@
    :buffer-language-mode
    :completion-spec
    :complete-symbol
+   :pop-definition-stack
    :indent-size
    :root-uri-patterns
    :detective-search


### PR DESCRIPTION
When configuring key bindings I bumped into a few commands which were not exported properly.

Also added some more window move commands to terminal bypass list to help switching between terminal and editor windows.