### PR TITLE
Bugfix: Floating window left as the only one

### DIFF
--- a/src/commands/window.lisp
+++ b/src/commands/window.lisp
@@ -188,6 +188,8 @@
 
 (define-command delete-other-windows () ()
   "Delete all other windows."
+  (when (floating-window-p (current-window))
+    (editor-error "Can not keep active window as the only one"))
   (dolist (win (window-list))
     (unless (eq win (current-window))
       (delete-window win)))


### PR DESCRIPTION
If any floating window is active when delete-other-windows is called the floating window remains stuck in the view and editor needs restart to recover.