### PR TITLE
Improved parenthesis highlighting in vi insert mode

### DIFF
--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -10,6 +10,8 @@
         :lem-vi-mode/registers
         :lem-vi-mode/text-objects
         :lem-vi-mode/commands/utils)
+  (:import-from :lem-vi-mode/core
+                :ensure-state)
   (:import-from :lem-vi-mode/options
                 :option-value)
   (:import-from :lem-vi-mode/states
@@ -755,10 +757,11 @@ on the same line or at eol if there are none."
         (character-offset point offset)))))
 
 (defun vi-backward-matching-paren (window point &optional (offset -1))
-  (declare (ignore window offset))
-  (with-point ((point point))
-    (when (syntax-closed-paren-char-p (character-at point))
-      (scan-lists (character-offset (copy-point point :temporary) 1) -1 0 t))))
+  (declare (ignore window))
+  (let ((offset (if (state= (current-state) (ensure-state 'insert)) offset 0)))
+    (with-point ((point point))
+      (when (syntax-closed-paren-char-p (character-at point offset))
+        (scan-lists (character-offset (copy-point point :temporary) (+ offset 1)) -1 0 t)))))
 
 (define-motion vi-move-to-matching-item (&optional n) (:universal-nil)
     (:type :inclusive


### PR DESCRIPTION
Matching parenthesis highlighting was not very useful in vi insert mode, because it didn't highlight the opening parenthesis for just inserted closing parenthesis. Only after switching back to normal mode you could see the matching pair highlighted.

This patch changes insert mode behaviour to use parenthesis before the cursor as the highlighted pair in insert mode. This way it is also similar to emacs mode.

Before the patch:
![parens-original](https://github.com/user-attachments/assets/57943e9e-31a9-419f-8874-ae9a6d888b0b)

After the patch:
![parens-improved](https://github.com/user-attachments/assets/aae53cda-2c29-465e-9966-64a1a48e8ca1)

