### PR TITLE
Added marks to vi-mode.

### DIFF
--- a/extensions/vi-mode/binds.lisp
+++ b/extensions/vi-mode/binds.lisp
@@ -112,7 +112,7 @@
 
 (define-key *motion-keymap* "C-o" 'vi-jump-back)
 (define-key *motion-keymap* "C-i" 'vi-jump-next)
-(define-key *motion-keymap* "' '" 'vi-jump-previous)
+(define-key *motion-keymap* "'" 'vi-goto-mark)
 (define-key *motion-keymap* ":" 'vi-ex)
 
 (define-key *motion-keymap* "v" 'vi-visual-char)
@@ -135,6 +135,8 @@
 (define-key *normal-keymap* "D" 'vi-delete-line)
 (define-key *normal-keymap* "c" 'vi-change)
 (define-key *normal-keymap* "C" 'vi-change-line)
+(define-key *normal-keymap* "m" 'vi-set-mark)
+(define-key *normal-keymap* "M-m" 'vi-delete-mark)
 (define-key *normal-keymap* "g J" 'vi-join)
 (define-key *normal-keymap* "J" 'vi-join-line)
 (define-key *normal-keymap* "y" 'vi-yank)

--- a/extensions/vi-mode/commands.lisp
+++ b/extensions/vi-mode/commands.lisp
@@ -142,6 +142,9 @@
            :vi-normal
            :vi-keyboard-quit
            :vi-close
+           :vi-set-mark
+           :vi-delete-mark
+           :vi-goto-mark
            :vi-window-move-left
            :vi-window-move-down
            :vi-window-move-up
@@ -1165,3 +1168,23 @@ on the same line or at eol if there are none."
   (dotimes (i n)
     (vi-window-split-vertically)
     (vi-switch-to-buffer filename)))
+
+(define-command vi-set-mark () ()
+    "Set mark to current point"
+  (when-let (c (key-to-char (read-key)))
+    (lem/named-point:set-named-point c)))
+
+(define-command vi-delete-mark () ()
+  "Delete mark"
+  (when-let (c (key-to-char (read-key)))
+    (when (lem/named-point:delete-named-point c)
+      (message (format nil "Mark ~A deleted" c)))))
+
+(define-motion vi-goto-mark () ()
+  (:jump t)
+  "Move to mark"
+  (when-let (c (key-to-char (read-key)))
+    (flet ((move () (lem/named-point:goto-named-point c :global (not (operator-pending-mode-p)))))
+      (if (eq c #\') ; Support "' '" as jump-previous if ' is not marked
+        (or (move) (vi-jump-previous))
+        (move)))))

--- a/lem.asd
+++ b/lem.asd
@@ -98,6 +98,7 @@
                (:file "clipboard")
                (:file "save-excursion")
                (:file "killring")
+               (:file "named-point")
                (:file "file")
                (:file "frame")
                (:file "echo")

--- a/src/named-point.lisp
+++ b/src/named-point.lisp
@@ -1,0 +1,46 @@
+(defpackage :lem/named-point
+  (:use :cl
+        :lem-core)
+  (:import-from :alexandria
+                :if-let
+                :when-let)
+  (:export :set-named-point
+           :get-named-point
+           :delete-named-point
+           :goto-named-point))
+
+(in-package :lem/named-point)
+
+(let ((stored-points (make-hash-table :test 'equal)))
+
+  (defun set-named-point (name &optional (point (current-point)))
+    "Store point with name. Default point is current point."
+    (let ((old (gethash name stored-points)))
+      (when old (delete-point old)))
+    (setf (gethash name stored-points) (copy-point point)))
+
+  (defun get-named-point (name)
+    "Retrieve a point stored with name if exists and is still alive"
+    (when-let ((point (gethash name stored-points)))
+      (if (and (not (deleted-buffer-p (point-buffer point)))
+               (alive-point-p point))
+          point
+          (progn (delete-named-point name)
+                 nil))))
+
+  (defun delete-named-point (name)
+    "Delete point with name"
+    (when-let ((point (gethash name stored-points)))
+      (delete-point point)
+      (remhash name stored-points))))
+
+(defun goto-named-point (name &key (global t))
+  "Go to named point"
+  (when-let ((point (get-named-point name)))
+    (let* ((b (point-buffer point))
+           (same-buffer (eq b (current-buffer))))
+      (if same-buffer
+          (move-point (current-point) point)
+          (when global
+            (switch-to-buffer b)
+            (move-point (current-point) point))))))


### PR DESCRIPTION
Named point implementation is added to general lem to be usable also outside of vi-mode.

In contrast to original vi marks are global and can be set to any printable character.