### PR TITLE
Add meta key to modifier text input (sdl2-compat fix)

### DIFF
--- a/frontends/sdl2/keyboard.lisp
+++ b/frontends/sdl2/keyboard.lisp
@@ -132,7 +132,8 @@
 
 ;; linux
 (defun modifier-is-accept-text-input-p (modifier)
-  (not (modifier-ctrl modifier)))
+  (and (not (modifier-ctrl modifier))
+       (not (modifier-meta modifier))))
 
 (defmethod handle-text-input ((platform lem-sdl2/platform:linux) text)
   (handle-text-input-unix text))


### PR DESCRIPTION
Closes #1800 

It seems that when meta  is pressed with an alphanumeric key, SDL2-compat still generates TEXTINPUT events (unlike native SDL2). This PR makes meta key combinations work again with SDL2-compat.