### PR TITLE
Unify vi-mode visual state with lem buffer marks

### DIFF
--- a/extensions/vi-mode/states.lisp
+++ b/extensions/vi-mode/states.lisp
@@ -127,6 +127,7 @@
     (setf (current-state) state)))
 
 (defun vi-enable-hook ()
+  (setf *region-end-offset* -1)
   (setf (current-state) (or (buffer-state (current-buffer)) (ensure-state 'normal)))
   (add-hook *switch-to-buffer-hook* 'vi-switch-to-buffer)
   (add-hook *switch-to-window-hook* 'vi-switch-to-window)
@@ -134,6 +135,7 @@
   (add-hook *prompt-deactivate-hook* 'exit-prompt))
 
 (defun vi-disable-hook ()
+  (setf *region-end-offset* 0)
   (remove-hook *switch-to-buffer-hook* 'vi-switch-to-buffer)
   (remove-hook *switch-to-window-hook* 'vi-switch-to-window)
   (remove-hook *prompt-after-activate-hook* 'enter-prompt)

--- a/extensions/vi-mode/tests/kbdmacro.lisp
+++ b/extensions/vi-mode/tests/kbdmacro.lisp
@@ -62,4 +62,4 @@
       (handler-case
           (cmd "10@a")
         (end-of-buffer ()))
-      (ok (buf= #?"set-command\nset-command\nset-command\nset[]")))))
+      (ok (buf= #?"set-command\nset-command\nset-command\nse[t]")))))

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -51,7 +51,6 @@
            :normal
            :insert
            :visual
-           :change-state
            :option-value
            :leader-key))
 (in-package :lem-vi-mode)
@@ -105,13 +104,13 @@
 (defmethod post-command-hook :after ((state visual))
   (adjust-window-scroll))
 
-(defmethod state-enabled-hook ((state insert))
+(defmethod buffer-state-enabled-hook ((state insert) buffer)
   (when *enable-repeat-recording*
     (setf *last-repeat-keys* nil))
   (unless *macro-running-p*
-    (buffer-undo-boundary)
-    (buffer-disable-undo-boundary (lem:current-buffer))))
+    (buffer-undo-boundary buffer)
+    (buffer-disable-undo-boundary buffer)))
 
-(defmethod state-disabled-hook ((state insert))
+(defmethod buffer-state-disabled-hook ((state insert) buffer)
   (unless *macro-running-p*
-    (buffer-enable-undo-boundary (lem:current-buffer))))
+    (buffer-enable-undo-boundary buffer)))

--- a/src/buffer/internal/basic.lisp
+++ b/src/buffer/internal/basic.lisp
@@ -442,7 +442,7 @@ If 'line-number' is out of the buffer, 'point' does not move and returns NIL."
 (defun set-current-mark (point)
   "Set 'point' to the current mark."
   (let ((buffer (point-buffer point)))
-    (mark-set-point (buffer-mark-object buffer) point))
+    (setf (buffer-mark buffer) point))
   point)
 
 (defun blank-line-p (point)

--- a/src/buffer/internal/buffer.lisp
+++ b/src/buffer/internal/buffer.lisp
@@ -90,6 +90,11 @@
     :initform nil
     :accessor buffer-last-write-date)))
 
+(defvar *buffer-mark-activate-hook* '()
+  "Hook run when mark is activated.")
+(defvar *buffer-mark-deactivate-hook* '()
+  "Hook run when mark is inactivated.")
+
 (defclass text-buffer (buffer)
   ())
 
@@ -232,8 +237,16 @@ Options that can be specified by arguments are ignored if `temporary` is NIL and
   "Unflag the change flag of 'buffer'."
   (setf (buffer-%modified-p buffer) 0))
 
+(defun (setf buffer-mark) (point &optional (buffer (current-buffer)))
+  (let ((already-active (buffer-mark-p buffer)))
+    (mark-set-point (buffer-mark-object buffer) point)
+    (unless already-active
+      (run-hooks *buffer-mark-activate-hook* buffer))))
+
 (defun buffer-mark-cancel (buffer)
-  (mark-cancel (buffer-mark-object buffer)))
+  (when (buffer-mark-p buffer)
+    (mark-cancel (buffer-mark-object buffer))
+    (run-hooks *buffer-mark-deactivate-hook* buffer)))
 
 (defun buffer-attributes (buffer)
   (concatenate 'string

--- a/src/buffer/package.lisp
+++ b/src/buffer/package.lisp
@@ -78,6 +78,8 @@
    :with-buffer-point
    :with-current-buffer
    :clear-buffer-edit-history
+   :*buffer-mark-activate-hook*
+   :*buffer-mark-deactivate-hook*
    ;; TODO: delete ugly exports
    :%buffer-clear-keep-binfo
    :%buffer-keep-binfo)

--- a/src/commands/s-expression.lisp
+++ b/src/commands/s-expression.lisp
@@ -66,7 +66,7 @@
      (form-offset (mark-point (cursor-mark (current-point))) 1))
     (t
      (save-excursion
-       (form-offset (current-point) 1)
+       (character-offset (form-offset (current-point) 1) *region-end-offset*)
        (set-cursor-mark (current-point) (current-point))))))
 
 (define-command (kill-sexp (:advice-classes editable-advice)) (&optional (n 1)) (:universal)

--- a/src/display/logical-line.lisp
+++ b/src/display/logical-line.lisp
@@ -245,13 +245,15 @@
                          (make-attribute :background color)
                          :temporary t))))
 
-(defun make-temporary-region-overlay-from-cursor (cursor)
+(defgeneric make-region-overlays-using-global-mode (global-mode cursor))
+
+(defmethod make-region-overlays-using-global-mode ((global-mode emacs-mode) cursor)
   (let ((mark (cursor-mark cursor)))
     (when (mark-active-p mark)
-      (make-overlay cursor
+      (list (make-overlay cursor
                     (mark-point mark)
                     'region
-                    :temporary t))))
+                    :temporary t)))))
 
 (defun make-cursor-overlay* (point)
   (make-cursor-overlay
@@ -266,8 +268,8 @@
          (overlays (buffer-overlays buffer)))
     (when (eq (current-window) window)
       (dolist (cursor (buffer-cursors buffer))
-        (if-push (make-temporary-region-overlay-from-cursor cursor)
-                 overlays))
+        (alexandria:when-let ((region-overlays (make-region-overlays-using-global-mode (current-global-mode) cursor)))
+          (dolist (ol region-overlays) (push ol overlays))))
       (if-push (make-temporary-highlight-line-overlay buffer)
                overlays))
     (if (and (eq window (current-window))

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -609,6 +609,9 @@
    :redraw-buffer
    :compute-left-display-area-content
    :compute-wrap-left-area-content)
+  ;; display/logical-line.lisp
+  (:export
+    :make-region-overlays-using-global-mode)
   ;; interface.lisp
   (:export
    :with-implementation

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -644,6 +644,7 @@
    :background-color)
   ;; region.lisp
   (:export
+   :*region-end-offset*
    :check-marked-using-global-mode
    :region-beginning-using-global-mode
    :region-end-using-global-mode

--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -331,7 +331,7 @@
       (get-select-expression-points (current-point))
     (when start
       (set-current-mark start)
-      (move-point (current-point) end))))
+      (move-point (current-point) (character-offset end *region-end-offset*)))))
 
 (defun select-form-at-current-point ()
   (with-point ((start (current-point))
@@ -341,7 +341,7 @@
       (move-point end start)
       (form-offset end 1)
       (set-current-mark start)
-      (move-point (current-point) end))))
+      (move-point (current-point) (character-offset end *region-end-offset*)))))
 
 
 (define-command <mouse-event> () ()

--- a/src/region.lisp
+++ b/src/region.lisp
@@ -1,5 +1,7 @@
 (in-package :lem-core)
 
+(defvar *region-end-offset* 0)
+
 (defgeneric check-marked-using-global-mode (global-mode buffer))
 (defgeneric region-beginning-using-global-mode (global-mode &optional buffer))
 (defgeneric region-end-using-global-mode (global-mode &optional buffer))


### PR DESCRIPTION
Modified the visual states in vi mode to use lem buffer mark as starting point and initiator of visual mode regions. To support synchronisation some small additions to core lem implementation was needed, mainly hooks for enabling and disabling the buffer mark.

This allows activating visual mode from any of the "mark-xxx" commands available on emacs mode side, including mouse operations.

Vi states are now buffer specific, not global. This fixes several small glitches and annoyances when switching between windows and buffers

Closes #1590 