### PR TITLE
Fixed eternal loop when searching with regexp $

### DIFF
--- a/src/ext/isearch.lisp
+++ b/src/ext/isearch.lisp
@@ -215,7 +215,8 @@
         (loop 
           (unless (funcall *isearch-search-forward-function* p search-string end-point)
             (return))
-          (when (point= start-point p)
+          (when (or (point= start-point p)
+                    (end-line-p p))
             (return))
           (with-point ((before p))
             (funcall *isearch-search-backward-function* before search-string)


### PR DESCRIPTION
Vi-mode ex command s/$/whatever/ triggered the issue.