### PR TITLE
Add parsing of native pathnames to avoid errors with some files

### DIFF
--- a/src/commands/file.lisp
+++ b/src/commands/file.lisp
@@ -134,6 +134,11 @@
                 (setf *find-program* key)
                 (return key)))))
 
+(defun parse-find-program-output (output)
+  (mapcar #'namestring
+          (mapcar #'uiop:parse-native-namestring
+                  (str:lines output))))
+
 (defgeneric get-files-recursively (program)
   (:documentation "Find files recursively on the current working
   directory with the program set in `*find-program*'.
@@ -143,15 +148,15 @@
 
 (defmethod get-files-recursively ((finder (eql :fdfind)))
   ;; fdfind excludes .git, node_modules and such by default.
-  (str:lines
+  (parse-find-program-output
    (uiop:run-program (list "fdfind") :output :string)))
 
 (defmethod get-files-recursively ((finder (eql :fd)))
-  (str:lines
+  (parse-find-program-output
    (uiop:run-program (list "fd") :output :string)))
 
 (defmethod get-files-recursively ((finder (eql :find)))
-  (str:lines
+  (parse-find-program-output
    (uiop:run-program (list "find" ".") :output :string)))
 
 (defun %shorten-path (cwd path)


### PR DESCRIPTION
When a file (in linux at least) contains brackets it will make the completion dialogs fail because the output of native \*find-programs\* is not scaped in `src/commands/file.lisp`.

Specifically it will fail when trying to turn a string into a path/namestring in the function `maybe-make-pattern` (see the [SBCL source](https://github.com/sbcl/sbcl/blob/1d6df61f2368b48586a530136f3101e6c5c62322/src/code/filesys.lisp)).

I used the function `uiop:parse-native-namestring` to turn them into paths and then `namestring` to turn them into strings again because `completion-files` and `file-completion-rank` need strings.

If anything is wrong I'm happy to change/fix it.