### PR TITLE
Make extension-commands.lisp dependent on if quicklisp is present

### DIFF
--- a/lem.asd
+++ b/lem.asd
@@ -215,7 +215,7 @@
                              (:file "deepl")
                              (:file "themes")
                              (:file "detective")
-                             (:file "extension-commands")
+                             (:file "extension-commands" :if-feature :quicklisp)
                              (:file "read-only-sources")))
 
                (:module "ui"


### PR DESCRIPTION
The extension commands are dependent on quicklisp and should only be loaded if quicklisp is available in *features*