### PR TITLE
Modifying file completion so that backspace will go up a directory

### DIFF
--- a/src/ext/completion-mode.lisp
+++ b/src/ext/completion-mode.lisp
@@ -7,7 +7,8 @@
            :completion-item-detail
            :run-completion
            :completion-end
-           :completion-mode)
+           :completion-mode
+           :completion-refresh)
   #+sbcl
   (:lock t))
 (in-package :lem/completion-mode)
@@ -185,13 +186,18 @@
           (t (unread-key-sequence (last-read-key-sequence))
              (completion-end)))))
 
+(defun completion-refresh ()
+  "This will refresh the contents of the completion window using any changes made in the interim"
+  (when *completion-context*
+    (continue-completion *completion-context*)))
+
 (define-command completion-delete-previous-char (n) (:universal)
   (delete-previous-char n)
-  (continue-completion *completion-context*))
+  (completion-refresh))
 
 (define-command completion-backward-delete-word (n) (:universal)
   (backward-delete-word n)
-  (continue-completion *completion-context*))
+  (completion-refresh))
 
 (define-command completion-next-line () ()
   (popup-menu-down (context-popup-menu *completion-context*))

--- a/src/prompt.lisp
+++ b/src/prompt.lisp
@@ -18,6 +18,7 @@
 (defgeneric %prompt-for-line (prompt &key initial-value completion-function test-function
                                           history-symbol syntax-table gravity edit-callback
                                           special-keymap use-border))
+(defgeneric %prompt-for-file (prompt directory default existing gravity))
 
 (flet ((f (c1 c2 step-fn)
          (when c1
@@ -119,26 +120,7 @@
 
 (defun prompt-for-file (prompt &key directory (default (buffer-directory)) existing
                                     (gravity *default-prompt-gravity*))
-  (let ((result
-          (prompt-for-string (if default
-                                 (format nil "~a(~a) " prompt default)
-                                 prompt)
-                             :initial-value (when directory (princ-to-string directory))
-                             :completion-function
-                             (when *prompt-file-completion-function*
-                               (lambda (str)
-                                 (funcall *prompt-file-completion-function*
-                                          (if (alexandria:emptyp str)
-                                              "./"
-                                              str)
-                                          (or directory
-                                              (namestring (user-homedir-pathname))))))
-                             :test-function (and existing #'virtual-probe-file)
-                             :history-symbol 'prompt-for-file
-                             :gravity gravity)))
-    (if (string= result "")
-        default
-        result)))
+  (%prompt-for-file prompt directory default existing gravity))
 
 (defun prompt-for-directory (prompt &rest args
                                     &key directory (default (buffer-directory)) existing


### PR DESCRIPTION
This changes file completion (e.g. for find-file) so that if the user's cursor is after '/', then if the user presses backspace, then instead of deleting this, it will instead go up a directory.

(In the following examples I'm using '|' as the cursor position)

E.g. 
/src/extension/file/|
[backspace]
/src/extension/|

/src/extension/file|
[backspace]
/src/extension/fil|

/|
[backspace]
/.

(The last example is to show that it does preserve existing behavior).