### PR TITLE
Add a keybinding/command for file prompt that allows the user to jump to the parent folder

### DIFF
--- a/src/ext/completion-mode.lisp
+++ b/src/ext/completion-mode.lisp
@@ -7,7 +7,8 @@
            :completion-item-detail
            :run-completion
            :completion-end
-           :completion-mode)
+           :completion-mode
+           :completion-refresh)
   #+sbcl
   (:lock t))
 (in-package :lem/completion-mode)
@@ -185,13 +186,18 @@
           (t (unread-key-sequence (last-read-key-sequence))
              (completion-end)))))
 
+(defun completion-refresh ()
+  "This will refresh the contents of the completion window using any changes made in the interim"
+  (when *completion-context*
+    (continue-completion *completion-context*)))
+
 (define-command completion-delete-previous-char (n) (:universal)
   (delete-previous-char n)
-  (continue-completion *completion-context*))
+  (completion-refresh))
 
 (define-command completion-backward-delete-word (n) (:universal)
   (backward-delete-word n)
-  (continue-completion *completion-context*))
+  (completion-refresh))
 
 (define-command completion-next-line () ()
   (popup-menu-down (context-popup-menu *completion-context*))

--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -397,7 +397,7 @@
           *special-paths*
           :initial-value path))
 
-
+
 (defun prompt-file-completion (string directory &key directory-only)
   (replace-prompt-input (normalize-path-input string))
   (flet ((move-to-file-start (point)
@@ -466,3 +466,41 @@
 (setf *prompt-file-completion-function* 'prompt-file-completion)
 (setf *prompt-buffer-completion-function* 'prompt-buffer-completion)
 (setf *prompt-command-completion-function* 'prompt-command-completion)
+
+(defvar *file-prompt-keymap* (make-keymap :name '*file-mode-prompt-keymap*))
+(define-key *file-prompt-keymap* "C-Backspace" 'file-prompt-parent-folder)
+
+(define-command file-prompt-parent-folder () ()
+  "In file prompt jump the parent folder and show the completion results for that folder."
+  (when (char= (character-at (current-point) -1) #\/)
+      (delete-previous-char))
+  (with-point ((end (current-point)))
+    (let ((point (search-backward (current-point) "/")))
+      (when point
+        (call-command 'forward-char nil)
+        (with-point ((start (current-point)))
+          (delete-between-points start end)))))
+  (lem/completion-mode:completion-refresh))
+
+(defmethod lem-core::%prompt-for-file (prompt directory default existing gravity)
+  (let ((result
+          (lem-core::%prompt-for-line (if default
+                                (format nil "~a(~a) " prompt default)
+                                prompt)
+                            :initial-value (when directory (princ-to-string directory))
+                            :completion-function
+                            (when *prompt-file-completion-function*
+                              (lambda (str)
+                                (funcall *prompt-file-completion-function*
+                                         (if (alexandria:emptyp str)
+                                             "./"
+                                             str)
+                                         (or directory
+                                             (namestring (user-homedir-pathname))))))
+                            :test-function (and existing #'virtual-probe-file)
+                            :history-symbol 'prompt-for-file
+                            :gravity gravity
+                            :special-keymap *file-prompt-keymap*)))
+    (if (string= result "")
+        default
+        result)))

--- a/src/prompt.lisp
+++ b/src/prompt.lisp
@@ -18,6 +18,7 @@
 (defgeneric %prompt-for-line (prompt &key initial-value completion-function test-function
                                           history-symbol syntax-table gravity edit-callback
                                           special-keymap use-border))
+(defgeneric %prompt-for-file (prompt directory default existing gravity))
 
 (flet ((f (c1 c2 step-fn)
          (when c1
@@ -119,26 +120,7 @@
 
 (defun prompt-for-file (prompt &key directory (default (buffer-directory)) existing
                                     (gravity *default-prompt-gravity*))
-  (let ((result
-          (prompt-for-string (if default
-                                 (format nil "~a(~a) " prompt default)
-                                 prompt)
-                             :initial-value (when directory (princ-to-string directory))
-                             :completion-function
-                             (when *prompt-file-completion-function*
-                               (lambda (str)
-                                 (funcall *prompt-file-completion-function*
-                                          (if (alexandria:emptyp str)
-                                              "./"
-                                              str)
-                                          (or directory
-                                              (namestring (user-homedir-pathname))))))
-                             :test-function (and existing #'virtual-probe-file)
-                             :history-symbol 'prompt-for-file
-                             :gravity gravity)))
-    (if (string= result "")
-        default
-        result)))
+  (%prompt-for-file prompt directory default existing gravity))
 
 (defun prompt-for-directory (prompt &rest args
                                     &key directory (default (buffer-directory)) existing


### PR DESCRIPTION
Continued from original pull request:
https://github.com/lem-project/lem/pull/1848

In the file prompt by clicking C-Backspace the user can jump to the parent folder.

Some clarifying examples '|' is the user cursor.
```
Find File: /folder1/folder2/|
[C-backspace]
Find File: /folder1/|
```

```
Find File: /folder1/folder2/index.html|
[C-backspace]
Find File: /folder1/folder2/|
```

This preserves the existing behavior, while adding useful additional behavior.