### PR TITLE
Persist M-x commands

### DIFF
--- a/src/commands/other.lisp
+++ b/src/commands/other.lisp
@@ -15,6 +15,8 @@
 
 (defparameter *persist-commands* t
   "If non true, don't persist the history of commands called with M-x into Lem's home config directory.")
+(defparameter *max-persisted-commands-candidates* 10
+  "Number of command names from the history we show on M-x completion. Set to NIL to show all of them.")
 
 (define-key *global-keymap* "NopKey" 'nop-command)
 (define-key *global-keymap* "C-g" 'keyboard-quit)
@@ -87,9 +89,15 @@
            (lem/common/history:save-file history)))))
 
 (defun saved-commands ()
-  "Return persisted commands names as a list."
-  (reverse
-   (lem/common/history:history-data-list (commands-history))))
+  "Return persisted commands names as a list.
+  
+  Return a maximum of *max-persisted-commands-candidates* items."
+  (alexandria-2:subseq*
+   (reverse
+    (lem/common/history:history-data-list (commands-history)))
+   0
+   ;; subseq* is ok with the end index being greater than the sequence length.
+   *max-persisted-commands-candidates*))
 
 
 (define-command execute-command (arg) (:universal-nil)

--- a/src/commands/other.lisp
+++ b/src/commands/other.lisp
@@ -80,12 +80,16 @@
         (setf input (symbol-name (command-name input))))
       ;; find-command wants downcase strings.
       (setf input (str:downcase input))
-      (and (lem/common/history:add-history history input :allow-duplicates nil)
+      (and (lem/common/history:add-history history input
+                                           :move-to-top t
+                                           :allow-duplicates nil
+                                           )
            (lem/common/history:save-file history)))))
 
 (defun saved-commands ()
   "Return persisted commands names as a list."
-  (lem/common/history:history-data-list (commands-history)))
+  (reverse
+   (lem/common/history:history-data-list (commands-history))))
 
 
 (define-command execute-command (arg) (:universal-nil)

--- a/src/commands/other.lisp
+++ b/src/commands/other.lisp
@@ -72,7 +72,7 @@
   *commands-history*)
 
 (defun remember-command (input)
-  "Add this command (string) to the history file."
+  "Add this command (string) to the history file if *persist-commands* is non nil."
   (when *persist-commands*
     (let ((history (commands-history)))
       (unless (stringp input)
@@ -94,7 +94,7 @@
 
 (define-command execute-command (arg) (:universal-nil)
   "Read a command name, then read the ARG and call the command."
-  (let* ((candidates (saved-commands))
+  (let* ((candidates (when *persist-commands* (saved-commands)))
          (name (prompt-for-command 
                 (if arg
                     (format nil "~D M-x " arg)
@@ -103,8 +103,7 @@
          (command (find-command name)))
     (if command
         (progn
-          (when *persist-commands*
-            (remember-command command))
+          (remember-command command)
           (call-command command arg))
         (message "invalid command"))))
 

--- a/src/common/command.lisp
+++ b/src/common/command.lisp
@@ -11,6 +11,7 @@
            :add-command
            :remove-command
            :all-command-names
+           :all-command-names-append
            :all-commands
            :find-command
            :exist-command-p)
@@ -60,7 +61,15 @@
   (remhash name (command-table-table command-table)))
 
 (defun all-command-names (&optional (command-table *command-table*))
+  "Return all existing command names."
   (alexandria:hash-table-keys (command-table-table command-table)))
+
+(defun all-command-names-append (candidates)
+  "Return a list of commands names (strings), but append CANDIDATES (list of strings) to the list and remove possible duplicates."
+  (remove-duplicates
+   (append candidates (all-command-names))
+   :test #'equal
+   :from-end t))
 
 (defun all-commands (&optional (command-table *command-table*))
   (alexandria:hash-table-values (command-table-table command-table)))

--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -430,38 +430,76 @@
                     :start s
                     :end (line-end e)))))
 
-(defun collect-command-all-keybindings (buffer command)
-  (let ((command-name (command-name command)))
-    (flet ((find-keybindings (keymap)
-             (alexandria:when-let (keybindings (collect-command-keybindings command-name keymap))
-               (mapcar (lambda (keybinding)
-                         (format nil "~{~A~^ ~}" keybinding))
-                       keybindings))))
-      (format nil "~{~A~^, ~}"
-              (append (find-keybindings (mode-keymap (buffer-major-mode buffer)))
-                      (loop :for mode :in (buffer-minor-modes buffer)
-                            :for keymap := (mode-keymap mode)
-                            :when keymap
-                            :append (find-keybindings keymap))
-                      (find-keybindings *global-keymap*))))))
+(declaim (inline find-command-keybindings-in-keymap))
+(defun find-command-keybindings-in-keymap (command &optional (keymap *global-keymap*))
+  "Return a list of keybindings (strings) for a COMMAND (command object or string).
 
-(defun prompt-command-completion (string)
-  (let ((items (loop :for name :in (all-command-names)
+  Search in the given KEYMAP. See also collect-command-all-keybindings."
+  (when (stringp command)
+    (setf command (find-command command)))
+  (alexandria:when-let (keybindings (collect-command-keybindings (command-name command) keymap))
+    (mapcar (lambda (keybinding)
+              (format nil "~{~A~^ ~}" keybinding))
+            keybindings)))
+
+(defun collect-command-all-keybindings (buffer command)
+  (format nil "~{~A~^, ~}"
+          (append (find-command-keybindings-in-keymap command (mode-keymap (buffer-major-mode buffer)))
+                  (loop :for mode :in (buffer-minor-modes buffer)
+                        :for keymap := (mode-keymap mode)
+                        :when keymap
+                        :append (find-command-keybindings-in-keymap command keymap))
+                  (find-command-keybindings-in-keymap command *global-keymap*))))
+
+;; (defun append-completion-candidates (candidates)
+;;   "Return a list of commands where our command candidates (list of strings) are appended to the list of all existing commands.
+
+;;   Return a list of strings, our candidates first, with no duplicates.
+
+;;   Only used when M-x commnands are persisted."
+;;   (remove-duplicates
+;;    (append candidates (all-command-names))
+;;    :test #'equal :from-end t))
+
+(defun prompt-command-completion (string &key candidates)
+  "Filter the list of commands from an input string and return a list of command completion items.
+
+  For each command, find and display its available keybindings for the current keymaps.
+  Display CANDIDATES command names (list of strings) before the rest of all commands.
+  The rest of commands are sorted by name."
+  (let ((items (loop :for name :in (all-command-names-append candidates)
                      :collect (lem/completion-mode:make-completion-item
                                :label name
                                :detail (collect-command-all-keybindings
                                         (current-buffer)
-                                        (find-command name))))))
-    (sort
+                                        (find-command name)))))
+        (candidate-items (loop :for name :in candidates
+                               :collect (lem/completion-mode:make-completion-item
+                                         :label name
+                                         :detail (collect-command-all-keybindings
+                                                  (current-buffer)
+                                                  (find-command name))))))
+    (append
+     ;; don't sort our candidates (they are already last used first).
      (if (find #\- string)
-         (completion-hyphen string
-                            items
-                            :key #'lem/completion-mode:completion-item-label)
-         (completion string
-                     items
-                     :key #'lem/completion-mode:completion-item-label))
-     #'string-lessp
-     :key #'lem/completion-mode:completion-item-label)))
+          (completion-hyphen string
+                             candidate-items
+                             :key #'lem/completion-mode:completion-item-label)
+          (completion string
+                      candidate-items
+                      :key #'lem/completion-mode:completion-item-label))
+
+     ;; sort the rest of the commands by name.
+     (sort
+      (if (find #\- string)
+          (completion-hyphen string
+                             items
+                             :key #'lem/completion-mode:completion-item-label)
+          (completion string
+                      items
+                      :key #'lem/completion-mode:completion-item-label))
+      #'string-lessp
+      :key #'lem/completion-mode:completion-item-label))))
 
 (setf *prompt-file-completion-function* 'prompt-file-completion)
 (setf *prompt-buffer-completion-function* 'prompt-buffer-completion)

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -420,7 +420,8 @@
    :universal-argument-of-this-command
    :execute
    :call-command
-   :all-command-names)
+   :all-command-names
+   :all-command-names-append)
   ;; defcommand.lisp
   (:export
    :define-command)

--- a/src/prompt.lisp
+++ b/src/prompt.lisp
@@ -169,23 +169,13 @@
        (completion str (all-command-names)))
    #'string-lessp))
 
-(defun append-completion-candidates (candidates)
-  "Return a list of commands where our command candidates (list of strings) are appended to the list of all existing commands.
-
-  Return a list of strings, our candidates first, with no duplicates.
-
-  Only used when M-x commnands are persisted."
-  (remove-duplicates
-   (append candidates (all-command-names))
-   :test #'equal :from-end t))
-
 (defun prompt-for-command (prompt &key candidates)
   (let ((completion-function (if candidates
-                                 (lambda (x)
-                                   (completion-strings
-                                    x
-                                    ;; We list the persisted commands first (if any).
-                                    (append-completion-candidates candidates)))
+                                 (lambda (input)
+                                   ;; Use the built-in function (it properly creates completion items,
+                                   ;; it displays the command's key bindings),
+                                   ;; but display our candidates first.
+                                   (funcall *prompt-command-completion-function* input :candidates candidates))
                                  *prompt-command-completion-function*)))
 
     (prompt-for-string

--- a/src/prompt.lisp
+++ b/src/prompt.lisp
@@ -180,23 +180,20 @@
    :test #'equal :from-end t))
 
 (defun prompt-for-command (prompt &key candidates)
-  (if candidates
-      (prompt-for-string
-       prompt
-       :completion-function (lambda (x)
-                              (completion-strings
-                               x
-                               ;; We list the persisted commands first (if any).
-                               (append-completion-candidates candidates)))
-       :test-function 'exist-command-p
-       :history-symbol 'mh-execute-command
-       :syntax-table *prompt-syntax-table*)
-      (prompt-for-string
-       prompt
-       :completion-function *prompt-command-completion-function*
-       :test-function 'exist-command-p
-       :history-symbol 'mh-execute-command
-       :syntax-table *prompt-syntax-table*)))
+  (let ((completion-function (if candidates
+                                 (lambda (x)
+                                   (completion-strings
+                                    x
+                                    ;; We list the persisted commands first (if any).
+                                    (append-completion-candidates candidates)))
+                                 *prompt-command-completion-function*)))
+
+    (prompt-for-string
+         prompt
+         :completion-function completion-function
+         :test-function 'exist-command-p
+         :history-symbol 'mh-execute-command
+         :syntax-table *prompt-syntax-table*)))
 
 (defun prompt-for-library (prompt &key history-symbol)
   (macrolet ((ql-symbol-value (symbol)

--- a/src/prompt.lisp
+++ b/src/prompt.lisp
@@ -169,13 +169,29 @@
        (completion str (all-command-names)))
    #'string-lessp))
 
-(defun prompt-for-command (prompt)
-  (prompt-for-string
-   prompt
-   :completion-function *prompt-command-completion-function*
-   :test-function 'exist-command-p
-   :history-symbol 'mh-execute-command
-   :syntax-table *prompt-syntax-table*))
+(defun prompt-for-command (prompt &key candidates)
+  (if candidates
+      (prompt-for-string
+       prompt
+       ;; :completion-function *prompt-command-completion-function*
+
+       ;; TODO: what do we want? List our persisted commands first,
+       ;; but, of course, be able to TAB-complete all commands.
+       
+       :completion-function (lambda (x) 
+                              (completion-strings 
+                               x
+                               ;; testing: merging our candidates to all the command names.
+                               (append candidates (all-command-names))))
+       :test-function 'exist-command-p
+       :history-symbol 'mh-execute-command
+       :syntax-table *prompt-syntax-table*)
+      (prompt-for-string
+       prompt
+       :completion-function *prompt-command-completion-function*
+       :test-function 'exist-command-p
+       :history-symbol 'mh-execute-command
+       :syntax-table *prompt-syntax-table*)))
 
 (defun prompt-for-library (prompt &key history-symbol)
   (macrolet ((ql-symbol-value (symbol)

--- a/src/prompt.lisp
+++ b/src/prompt.lisp
@@ -169,20 +169,25 @@
        (completion str (all-command-names)))
    #'string-lessp))
 
+(defun append-completion-candidates (candidates)
+  "Return a list of commands where our command candidates (list of strings) are appended to the list of all existing commands.
+
+  Return a list of strings, our candidates first, with no duplicates.
+
+  Only used when M-x commnands are persisted."
+  (remove-duplicates
+   (append candidates (all-command-names))
+   :test #'equal :from-end t))
+
 (defun prompt-for-command (prompt &key candidates)
   (if candidates
       (prompt-for-string
        prompt
-       ;; :completion-function *prompt-command-completion-function*
-
-       ;; TODO: what do we want? List our persisted commands first,
-       ;; but, of course, be able to TAB-complete all commands.
-       
-       :completion-function (lambda (x) 
-                              (completion-strings 
+       :completion-function (lambda (x)
+                              (completion-strings
                                x
-                               ;; testing: merging our candidates to all the command names.
-                               (append candidates (all-command-names))))
+                               ;; We list the persisted commands first (if any).
+                               (append-completion-candidates candidates)))
        :test-function 'exist-command-p
        :history-symbol 'mh-execute-command
        :syntax-table *prompt-syntax-table*)

--- a/src/prompt.lisp
+++ b/src/prompt.lisp
@@ -170,20 +170,15 @@
    #'string-lessp))
 
 (defun prompt-for-command (prompt &key candidates)
-  (let ((completion-function (if candidates
-                                 (lambda (input)
-                                   ;; Use the built-in function (it properly creates completion items,
-                                   ;; it displays the command's key bindings),
-                                   ;; but display our candidates first.
-                                   (funcall *prompt-command-completion-function* input :candidates candidates))
-                                 *prompt-command-completion-function*)))
-
-    (prompt-for-string
-         prompt
-         :completion-function completion-function
-         :test-function 'exist-command-p
-         :history-symbol 'mh-execute-command
-         :syntax-table *prompt-syntax-table*)))
+  (prompt-for-string
+   prompt
+   :completion-function (if candidates
+                            (lambda (input)
+                              (funcall *prompt-command-completion-function* input :candidates candidates))
+                            *prompt-command-completion-function*)
+   :test-function 'exist-command-p
+   :history-symbol 'mh-execute-command
+   :syntax-table *prompt-syntax-table*))
 
 (defun prompt-for-library (prompt &key history-symbol)
   (macrolet ((ql-symbol-value (symbol)


### PR DESCRIPTION
I think it's good for review but I'd appreciate more tests by more people.

Now:

- by default, persist M-x commands on disk, or set `*persist-M-x-commands*` to NIL.
- 10 (default) of these commands are showed at the top of the M-x completion
 - they also show their keybindings, and they are correctly filtered on user input.

Now the core function `prompt-command-completion` accepts a key parameter `candidates`. If it is present, we build the completion items like the others and we show them first.
