### PR TITLE
Up and Down keys in the prompt now replicate M-p and M-n behavior.

### DIFF
--- a/src/ext/completion-mode.lisp
+++ b/src/ext/completion-mode.lisp
@@ -112,6 +112,8 @@
 (define-key *completion-mode-keymap* "Space"    'completion-insert-space-and-cancel)
 (define-key *completion-mode-keymap* 'delete-previous-char 'completion-delete-previous-char)
 (define-key *completion-mode-keymap* 'backward-delete-word 'completion-backward-delete-word)
+(define-key *completion-mode-keymap* "Up" 'completion-previous-line)
+(define-key *completion-mode-keymap* "Down" 'completion-next-line)
 
 (define-attribute detail-attribute
   (t :foreground :base03))

--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -77,6 +77,8 @@
 (define-key *prompt-mode-keymap* "Tab" 'prompt-completion)
 (define-key *prompt-mode-keymap* "M-p" 'prompt-previous-history)
 (define-key *prompt-mode-keymap* "M-n" 'prompt-next-history)
+(define-key *prompt-mode-keymap* "Up" 'prompt-previous-history)
+(define-key *prompt-mode-keymap* "Down" 'prompt-next-history)
 (define-key *prompt-mode-keymap* 'delete-active-window 'prompt-quit)
 
 (defun current-prompt-window ()


### PR DESCRIPTION
In the prompt currently if the user presses the up/down key then it behaves differently to the M-p and M-n bindings.

This pull request fixes that behavior.