### PR TITLE
Fixed #1845 where prompt-window hangs

### DIFF
--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -297,6 +297,10 @@
                    gensyms
                    bindings)))))
 
+(defun exit-prompt (old-window)
+  (declare (ignore old-window))
+  (error 'editor-abort :message nil))
+
 (defun prompt-for-aux (&key (prompt-string (alexandria:required-argument :prompt-string))
                             (initial-string (alexandria:required-argument :initial-string))
                             (parameters (alexandria:required-argument :parameters))
@@ -312,6 +316,7 @@
                                          initial-string
                                          parameters)))
       (switch-to-prompt-window prompt-window)
+      (add-hook (window-leave-hook prompt-window) #'exit-prompt)
       (handler-case
           (with-unwind-setf (((frame-floating-prompt-window (current-frame))
                               prompt-window))
@@ -328,6 +333,7 @@
                         (funcall body-function))
                       (funcall body-function))))
             (lem/completion-mode:completion-end)
+            (remove-hook (window-leave-hook prompt-window) #'exit-prompt)
             (delete-prompt prompt-window)
             (run-hooks *prompt-deactivate-hook*))
         (execute-condition (e)

--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -96,6 +96,10 @@
     (when callback
       (funcall callback window point))))
 
+(defmethod handle-button-1 ((window floating-window) x y clicks)
+  (if (floating-window-focusable-p window)
+      (call-next-method)))
+
 (defmethod handle-button-1 ((window window) x y clicks)
   (let* ((point (get-point-from-window-with-coordinates window x y))
          (callback (text-property-at point :click-callback)))


### PR DESCRIPTION
Fixes #1845 

Behavior changes:
- Clicking on a floating window which has focusable set to `false` has no effect.
- Clicking in the main buffer windows when using the aux-prompt - closes the aux-prompt.

This definitely needs careful review, but so far my experience of this has been an improvement over previous behavior.