### PR TITLE
Added shift arrow key selection

### DIFF
--- a/src/commands/edit.lisp
+++ b/src/commands/edit.lisp
@@ -32,7 +32,11 @@
            :transpose-characters
            :undo
            :redo
-           :delete-trailing-whitespace)
+           :delete-trailing-whitespace
+           :mark-and-forward-char
+           :mark-and-backward-char
+           :mark-and-previous-line
+           :mark-and-next-line)
   #+sbcl
   (:lock t))
 (in-package :lem-core/commands/edit)
@@ -469,3 +473,23 @@ current line."
 
 (defmethod lem-core:paste-using-mode (mode text)
   (yank-string (current-point) text))
+
+(define-command mark-and-forward-char (n) (:universal)
+  (unless (buffer-mark-p (current-buffer))
+    (set-cursor-mark (current-point) (current-point)))
+  (character-offset (current-point) n))
+
+(define-command mark-and-backward-char (n) (:universal)
+  (unless (buffer-mark-p (current-buffer))
+    (set-cursor-mark (current-point) (current-point)))
+  (character-offset (current-point) (- n)))
+
+(define-command mark-and-previous-line (n) (:universal)
+  (unless (buffer-mark-p (current-buffer))
+    (set-cursor-mark (current-point) (current-point)))
+  (next-line (- n)))
+
+(define-command mark-and-next-line (n) (:universal)
+  (unless (buffer-mark-p (current-buffer))
+    (set-cursor-mark (current-point) (current-point)))
+  (next-line n))

--- a/src/commands/edit.lisp
+++ b/src/commands/edit.lisp
@@ -63,6 +63,11 @@
 (define-key *global-keymap* "C-\\" 'undo)
 (define-key *global-keymap* "C-_" 'redo)
 (define-key *global-keymap* "C-/" 'redo)
+(define-key *global-keymap* "Shift-Left" 'mark-and-backward-char)
+(define-key *global-keymap* "Shift-Right" 'mark-and-forward-char)
+(define-key *global-keymap* "Shift-Up" 'mark-and-previous-line)
+(define-key *global-keymap* "Shift-Down" 'mark-and-next-line)
+
 
 (define-editor-variable self-insert-before-hook '())
 (define-editor-variable self-insert-after-hook '())
@@ -475,21 +480,25 @@ current line."
   (yank-string (current-point) text))
 
 (define-command mark-and-forward-char (n) (:universal)
+  "Sets a mark if none is set, then moves cursor forward by n characters"
   (unless (buffer-mark-p (current-buffer))
     (set-cursor-mark (current-point) (current-point)))
   (character-offset (current-point) n))
 
 (define-command mark-and-backward-char (n) (:universal)
+  "Sets a mark if none is set, then moves cursor backward by n characters"
   (unless (buffer-mark-p (current-buffer))
     (set-cursor-mark (current-point) (current-point)))
   (character-offset (current-point) (- n)))
 
 (define-command mark-and-previous-line (n) (:universal)
+  "Sets a mark if none is set, then moves cursor up by n lines"
   (unless (buffer-mark-p (current-buffer))
     (set-cursor-mark (current-point) (current-point)))
   (next-line (- n)))
 
 (define-command mark-and-next-line (n) (:universal)
+  "Sets a mark if none is set, then moves cursor down by n lines"
   (unless (buffer-mark-p (current-buffer))
     (set-cursor-mark (current-point) (current-point)))
   (next-line n))


### PR DESCRIPTION
Added commands that allow the user to select regions using the shift and arrow keys.

If no mark is set, then shift + arrow-key will set the mark at point and move the cursor in the direction specified.
If the mark is set then it acts identically to the arrow key.

