### PR TITLE
fix nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
               outputHash = if pkgs.stdenv.isDarwin then
                 "sha256-BV1m58fUe1zfLH5iKbDP7KTNhv1p+g3W99tFQFYxPqs="
               else
-                "sha256-NtCSBxEo/4uuhlLc9Xqlq+PM1fAbDfRBH64imMLvKYE=";
+                "sha256-qewn0FbgXUOFSFjzSlyK2DNyfhzVteC45iwdSCS0tPo=";
             };
 
             configurePhase = ''

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -45,7 +45,7 @@
 ("lem-extension-manager" .
  (:class qlot/source/git:source-git
   :initargs (:remote-url "https://github.com/lem-project/lem-extension-manager.git")
-  :version "git-13e0e1d476d1e1c827360b9a789fd7df2cb1ef1c"))
+  :version "git-cb19321345d6fd13dc3ca59d4d5b9a6b14cc00b1"))
 ("webview" .
  (:class qlot/source/git:source-git
   :initargs (:remote-url "https://github.com/lem-project/webview.git")


### PR DESCRIPTION
installation through the nix flake was failing because of:
1. wrong hash output
2. old revision of `lem-extension-manager` which had references of the package `ql-http` and caused compilation issues.

this isnt a complete fix as now running `nix run github:lem-project/lem` gives `SDL Error: EGL not initialized`, but the compilation errors were fixed.