### PR TITLE
Configurable Automatic Completions

### DIFF
--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -14,7 +14,10 @@
 (defconstant +min-width+   10)
 (defconstant +min-height+  1)
 
-(defvar *automatic-tab-completion* t)
+(defvar *automatic-tab-completion* t 
+  "When set to true, the completion list is opened instantly.
+When set to false, the completion list only opens when the user presses TAB")
+
 (defvar *fill-width* nil)
 (defvar *history-table* (make-hash-table))
 


### PR DESCRIPTION
This adds a user configurable option:
`lem:prompt-window:*automatic-tab-completion*`

This is set to true by default (let me know if you want this set to false), and when set to true - the completion window opens automatically when the user opens a text prompt.

This also fixes issue: #1869 