### PR TITLE
Change Escape so that it closes non temporary overlays in the current buffer

### DIFF
--- a/src/interp.lisp
+++ b/src/interp.lisp
@@ -86,6 +86,7 @@
          (editor-abort-handler (c)
            (declare (ignore c))
            (buffer-mark-cancel (current-buffer)) ; TODO: define handler
+           (clear-overlays)
            (run-hooks *editor-abort-hook*)
            )
 


### PR DESCRIPTION
I've got annoyed by overlays not always closing when I press escape.

This minor change fixes that by calling 'clear-overlays'.

Currently it only clears the overlays for the current buffer. I could change it so that it does it for all buffers.

I also wasn't sure if this was appropriate behavior, as maybe there are some overlays that should never be closed?