### PR TITLE
Fixes #1685

### DIFF
--- a/src/ext/language-mode.lisp
+++ b/src/ext/language-mode.lisp
@@ -199,12 +199,19 @@
                 (cond ((space*-p start))
                       ((indentation-point-p end))
                       (t
+                       ;; Cannot assume this line has the same indentation, 
+                       ;; or greater, than the previous line
+                       (line-start start)
+                       (skip-whitespace-forward start)
                        (insert-string start line-comment)
                        (unless (space*-p end)
                          (insert-character end #\newline))))
                 (return))
               (unless (space*-p start)
-                (insert-string start line-comment))
+                (progn
+                  (line-start start)
+                  (skip-whitespace-forward start)
+                  (insert-string start line-comment)))
               (line-offset start 1 charpos))))))))
 
 (define-command (uncomment-region (:advice-classes editable-advice)) () ()

--- a/src/interp.lisp
+++ b/src/interp.lisp
@@ -86,6 +86,7 @@
          (editor-abort-handler (c)
            (declare (ignore c))
            (buffer-mark-cancel (current-buffer)) ; TODO: define handler
+           (clear-overlays)
            (run-hooks *editor-abort-hook*)
            )
 


### PR DESCRIPTION
Fixes a problem in comment-region where lisp code was not being commented out properly (this would probably affect other languages too if they used line comments like Lisp).

The problem was that if the previous line had a greater indent, then it would treat any part of the line before that indent as whitespace. This fix changes the behavior so that it always goes to the beginning of the next line, and then searches for the end of whitespace.
