### PR TITLE
Fixes #1685

### DIFF
--- a/src/ext/language-mode.lisp
+++ b/src/ext/language-mode.lisp
@@ -199,12 +199,17 @@
                 (cond ((space*-p start))
                       ((indentation-point-p end))
                       (t
+                       (line-start start)
+                       (skip-whitespace-forward start)
                        (insert-string start line-comment)
                        (unless (space*-p end)
-                         (insert-character end #\newline))))
+                           (insert-character end #\newline))))
                 (return))
               (unless (space*-p start)
-                (insert-string start line-comment))
+                (progn
+                  (line-start start)
+                  (skip-whitespace-forward start)
+                  (insert-string start line-comment)))
               (line-offset start 1 charpos))))))))
 
 (define-command (uncomment-region (:advice-classes editable-advice)) () ()


### PR DESCRIPTION
Fixes a problem in comment-region where lisp code was not being commented out properly (this would probably affect other languages too if they used line comments like Lisp).

Previously if there was a string in the form:
```cl
    234
  123
```
Then the first line would commented out properly, but then the cursor would go to the column directly below, regardless of the next line's indentation, and insert the comment there.

```cl
    ;; 234
  12;; 3
```

This is now fixed so that it starts each line from column 0.