### PR TITLE
Sort commands alphabetically in M-x completion window

### DIFF
--- a/src/ext/prompt-window.lisp
+++ b/src/ext/prompt-window.lisp
@@ -498,7 +498,7 @@
                            items
                            :key #'lem/completion-mode:completion-item-label))))
 
-    (let* ((all-items (collect-items (all-command-names)))
+    (let* ((all-items (collect-items (sort (all-command-names) #'string<)))
            (candidate-items (collect-items candidates))
            (items (remove-duplicates
                    (append candidate-items all-items)


### PR DESCRIPTION
Minor change so that commands are sorted alphabetically.

This preserves the history so that the last n commands are shown first, followed by all the commands in alphabetical order.