### PR TITLE
directory-mode: follow buffer name and directory when moving one file (r)

### DIFF
--- a/src/ext/directory-mode/commands.lisp
+++ b/src/ext/directory-mode/commands.lisp
@@ -231,8 +231,12 @@ With prefix argument ARG, unmark all those files."
   (update-all-buffers))
 
 (define-command directory-mode-rename-files () ()
-  (let ((dst-file (prompt-for-file "Destination Filename: " :directory (get-dest-directory))))
-    (rename-files (selected-files (current-point)) dst-file))
+  (let ((dst-file (prompt-for-file "Destination: " :directory (get-dest-directory)))
+        (files (selected-files (current-point))))
+    (when (and (< 1 (length files))
+               (uiop:file-pathname-p dst-file))
+      (editor-error "Please select a directory to move multiple files."))
+    (rename-files files dst-file))
   (update-all-buffers))
 
 (defun move-to-file-position (point)


### PR DESCRIPTION
for https://github.com/lem-project/lem/issues/993

- on "r" (rename one file): 
  - rename buffer and setf the buffer filename
  - add a prompt, so we understand we do have a prompt (that is not a popup and has no borders)
- on "R" (multiple): prevent an annoying case
  - (these buffer files would need to be updated too, but that's for another time)

new inline prompt:

<img width="498" height="130" alt="Selection_330" src="https://github.com/user-attachments/assets/7b4cc48d-d6a9-4276-929c-be5ea60545e8" />
