### PR TITLE
build legit binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,13 @@ webview:
 
 lem: sdl2
 
+.PHONY: legit
+
+legit:
+	qlot install
+	$(LISP) --load .qlot/setup.lisp \
+		--load scripts/build-legit.lisp
+
 install-bin:
 	install -m 755 lem $(PREFIX)/bin
 

--- a/scripts/build-legit.lisp
+++ b/scripts/build-legit.lisp
@@ -1,0 +1,10 @@
+(ql:quickload :lem-ncurses)
+
+(lem:init-at-build-time)
+
+
+(setf lem:*splash-function* #'lem/legit::legit-status)
+
+(sb-ext:save-lisp-and-die "legit"
+                          :toplevel #'lem:main
+                          :executable t)


### PR DESCRIPTION
Now, we can call a `legit` binary from anywhere in the terminal.

Note: I tried creating an alias but `lem --eval '(lem/legit::legit-status)'` fails, "the value NIL is not of type NUMBER", "directory does not exist: … /lem/(lem/. Create?" etc