### PR TITLE
remove the asdf check from find dist path

### DIFF
--- a/frontends/server/main.lisp
+++ b/frontends/server/main.lisp
@@ -48,8 +48,6 @@
 (defvar *dist* (dump-files))
 
 (defun find-dist-by-path (path)
-  (asdf:system-relative-pathname :lem-server path)
-  #+(or)
   (cdr (assoc path *dist* :test #'equal)))
 
 (defun clack-handler (env)


### PR DESCRIPTION
#1953 
I am a little new to lisp images and lisp in general or I should say it's been a while. 
What I believe was happening here is at runtime, the get-dist-by-path function was using asdf to look for needed asset files for the server. As a result of asdf not being available to the runtime it would never find it thus resulting in the 404. I tested this locally and was able to get the editor working again on my Mac Silicon. 


Would love some eyes on this so that others can just get started by using the binary. Let me know if there is anything I need to change or a reason why this is a bad change. Still learning .