### PR TITLE
Fixed bugs in lem/link package and added link properties in Markdown Mode

### DIFF
--- a/extensions/markdown-mode/syntax-parser.lisp
+++ b/extensions/markdown-mode/syntax-parser.lisp
@@ -133,32 +133,23 @@
 
                     (move-to-column match-start start)
                     (move-to-column match-end end)
-
                     (put-text-property match-start match-end
                                        :attribute 'document-link-attribute)
 
                     ;; the second capture group will contain the actual link text, so
                     ;; the second item in reg-starts and reg-ends will contain that
                     ;; information.
-
                     (move-to-column url-start (elt reg-starts 1))
                     (move-to-column url-end (elt reg-ends 1))
 
-                    (let (links)
-                      (message "~&~%<<~A>> ~A"
-                               line (lem:points-to-string url-start url-end))
+                    (put-text-property
+                     match-start match-end
 
-                      (with-point ((a url-start)
-                                   (b url-end))
-                        (setf links (lem/link::search-link a b)))
-
-                      (message "~&done: ~A" (first links))
-
-                      (put-text-property
-                       match-start match-end
-                       ;; search link returns a list of links, however there is
-                       ;; only one link here.
-                       :link (first links))))))
+                     ;; search link returns a list of links, however there is
+                     ;; only one link here.
+                     :link (with-point ((a url-start)
+                                        (b url-end))
+                             (first (lem/link::search-link a b)))))))
 
               ; Exit if we can't move forward
           :do (unless (line-offset point 1)

--- a/src/ext/link.lisp
+++ b/src/ext/link.lisp
@@ -131,7 +131,7 @@
                (funcall set-attribute-function (link-start link) (link-end link)))
              (put-text-property (link-start link)
                                 (link-end link)
-                                'link link)
+                                :link link)
              (lem-core::set-clickable (link-start link)
                                       (link-end link)
                                       'click-callback))


### PR DESCRIPTION
I tried to open a link using the `link-open` command in markdown mode, but the links did not open.
After some investigation I found a few issues:
1. markdown mode was not setting a `:link` property on the highlighted link text
2. the `lem/link::link-at` function was searching for `'link` and not `:link`
3. in `lem/link::search-url-link` and `lem/link::search-file-link`, link searches were not obeying the LIMIT parameter.  I added a check to ensure that the returned URL is bounded by LIMIT.

I fixed these issues and added code to the Markdown Mode syntax parser to add the `:link` text properties.
Lem Markdown mode adds the correct text properties to links, so they can be opened by the lem/link package.