### PR TITLE
Fix `right-window`: Find windows where `left.x + left.width == right.x`

### DIFF
--- a/src/window/window.lisp
+++ b/src/window/window.lisp
@@ -999,7 +999,7 @@ You can pass in the optional argument WINDOW-LIST to replace the default
   (unless (floating-window-p window)
     (first (sort (min-if #'window-x
                          (remove-if-not (lambda (w)
-                                          (> (window-x w)
+                                          (>= (window-x w)
                                              (+ (window-x window)
                                                 (window-width window))))
                                         (window-list)))


### PR DESCRIPTION
Fixes #1970.
I tested the movement manually. Everything seemed to work normally.
It looks like `lem-core::right-window` is only called by `lem-core/commands/window::move-right`, so it shouldn't mess with anything else.
I think it's logically fine that window `{ left: 0, width: 100, ... }` has window `{ left: 100, ... }` to its right.