### PR TITLE
Add English translations for comments in `extensions/`.

### DIFF
--- a/extensions/language-server/commands.lisp
+++ b/extensions/language-server/commands.lisp
@@ -14,7 +14,7 @@
 
 (defun execute-command (name arguments)
   (let ((command (get-command name)))
-    (assert command) ; TODO: Return error response / error responseを返す
+    (assert command) ; TODO: Return error response
     (call-command command arguments)))
 
 (defmacro define-lsp-command (class-name command-name (arguments) &body body)

--- a/extensions/language-server/controller/language-features.lisp
+++ b/extensions/language-server/controller/language-features.lisp
@@ -319,7 +319,6 @@
 
 (defun document-symbol (buffer)
   ;; Assumes there is only one `in-package` at the start of the file.
-  ;; in-packageがファイル先頭に一つだけあることを前提にしている
   (let* ((package-name (buffer-package buffer))
          (symbol-definitions (collect-definition-symbols-in-buffer buffer package-name)))
     (convert-to-json
@@ -332,7 +331,6 @@
                   (kind (micros/lsp-api::symbol-information-kind symbol-information)))
               
               ;; Doesn't account for symbols having multiple bindings (variable, function, ..)
-              ;; symbolに複数の束縛があることを考慮していない(variableとfunctionなど)
               (make-instance 'lsp:document-symbol
                              :name name
                              :detail line-string ;(or detail "")

--- a/extensions/language-server/eval.lisp
+++ b/extensions/language-server/eval.lisp
@@ -80,7 +80,7 @@
           (lsp:text-document-position-params-text-document params)))
     (lem:with-point ((start point :left-inserting)
                      (end point :left-inserting))
-      (when (lem:form-offset start -1) ; TODO: Consider `nil` case / nilの場合を考慮する
+      (when (lem:form-offset start -1) ; TODO: Consider `nil` case
         (lem:form-offset (lem:move-point end start) 1)
         (let ((string (lem:points-to-string start end))
               (range (points-to-lsp-range start end))

--- a/extensions/lisp-mode/ext/organize-imports.lisp
+++ b/extensions/lisp-mode/ext/organize-imports.lisp
@@ -58,7 +58,6 @@
 (defun read-symbol-name (symbol-string)
   ;; FIXME: For symbols of the form `prefix:name`, if the package doesn't exist in the client,
   ;;   it causes an error and can't extract the name.
-  ;; FIXME: prefix:name という形式でclientにパッケージがない時はエラーになり取り出せない
   (ignore-errors
     (let ((*read-eval* nil))
       (read-from-string symbol-string))))
@@ -130,4 +129,3 @@
 
 ;; TODO:
 ;; - Exported symbols shouldn't be removed from `import-from`
-;; - exportするシンボルはimport-fromから除外してはならない

--- a/extensions/lisp-mode/ext/package-inferred-system.lisp
+++ b/extensions/lisp-mode/ext/package-inferred-system.lisp
@@ -105,8 +105,6 @@
                                     (length (rest prefix-directory)))))
                          ;; If we encounter `:pathname "tests"` within the defsystem,
                          ;; extract just the `/a/b` of `project-root/tests/a/b`
-                         ;; defsystem内に:pathname "tests"とあった場合
-                         ;; project-root/tests/a/bの/a/bだけを残す
                          (when (eql mismatch2 (length (rest prefix-directory)))
                            (append (list (project-root-name project-root))
                                    (subseq relative-lisp-file-directory mismatch2)

--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -1151,9 +1151,6 @@
                        ;; We want to to show the repl prompt and change the cursor position.
                        ;; However, it's disruptive to change the buffer/window while working on another file,
                        ;; so we use `with-current-window` to switch back afterwards.
-                       ;; replのプロンプトの表示とカーソル位置の変更をしたいが
-                       ;; 他のファイルの作業中にバッファ/ウィンドウが切り替わると作業の邪魔なので
-                       ;; with-current-windowで元に戻す
                        (unless (repl-buffer)
                          (with-current-window (current-window) (start-lisp-repl)))
                        (success))))

--- a/extensions/lsp-mode/lsp-mode.lisp
+++ b/extensions/lsp-mode/lsp-mode.lisp
@@ -723,11 +723,6 @@
         ;; ```
         ;; `range.start` and `range.end` point to the end of the line, and aren't highlighted.
         ;; Shift by one character to fix this.
-        ;; XXX: gopls用
-        ;; func main() {
-        ;;     fmt.
-        ;; というコードでrange.start, range.endが行末を
-        ;; 差していてハイライトされないので一文字ずらしておく
         (if (end-line-p end)
             (character-offset start -1)
             (character-offset end 1)))
@@ -801,11 +796,8 @@
 ;; - workDoneProgress
 ;; - partialResult
 ;; - Set `contentFormat`  `hoverClientCapabilities`
-;;   hoverClientCapabilitiesのcontentFormatを設定する
 ;; - Use `hover`'s `range` to add background color to the range
-;;   hoverのrangeを使って範囲に背景色をつける
 ;; - Check if supported by server
-;;   serverでサポートしているかのチェックをする
 
 (defun contents-to-string (contents)
   (flet ((marked-string-to-string (marked-string)
@@ -861,13 +853,10 @@
 
 ;; TODO
 ;; - Check if supported by the server
-;;   serverでサポートしているかのチェックをする
 ;; - workDoneProgress
 ;; - partialResult
 ;; - completionParams.context, include information about how completion was triggered.
-;;   completionParams.context, どのように補完が起動されたかの情報を含める
 ;; - There are many unused fields in `completionItem`
-;;   completionItemの使っていない要素が多分にある
 ;; - completionResolve
 
 (defclass completion-item (completion:completion-item)
@@ -904,7 +893,6 @@
                 :start start
                 ;; After showing completion candidates, if you type characters and select a candidate,
                 ;; the `end` position becomes mis-aligned and can't be used.
-                ;; 補完候補を表示した後に文字を入力し, 候補選択をするとendがずれるので使えない
                 ;; :end end
                 :label label
                 :detail (handler-case (lsp:completion-item-detail item)
@@ -1001,7 +989,6 @@
       (let ((label (lsp:parameter-information-label parameter)))
         ;; TODO:
         ;; Handle the case where the label's type is [number, number]
-        ;; labelの型が[number, number]の場合に対応する
         (when (stringp label)
           (search-forward point label)
           (when (= active-parameter index)
@@ -1095,7 +1082,6 @@
   (declare (ignore point))
   ;; TODO: 
   ;; not supported by `gopls`, delaying to later 
-  ;; goplsが対応していなかったので後回し
   nil)
 
 ;;; definition
@@ -1122,7 +1108,6 @@
     ;; TODO: 
     ;; Also use `end-position`. 
     ;; After moving to definition location, set the highlight to the start/end range.
-    ;; end-positionも使い、定義位置への移動後のハイライトをstart/endの範囲にする
     (let* ((start-position (lsp:range-start (lsp:location-range location)))
            (end-position (lsp:range-end (lsp:location-range location)))
            (uri (lsp:location-uri location))
@@ -1361,7 +1346,6 @@
 
 ;; TODO
 ;; - Sort by `position`
-;; - position順でソートする
 
 (define-attribute symbol-kind-file-attribute
   (t :foreground "snow1"))
@@ -1540,7 +1524,7 @@
 (defun append-document-symbol-item (buffer document-symbol nest-level)
   (let ((selection-range (lsp:document-symbol-selection-range document-symbol))
         (range (lsp:document-symbol-range document-symbol)))
-    (declare (ignore range)) ; TODO: use `range` in region highlighting / rangeをリージョンのハイライトに使う
+    (declare (ignore range)) ; TODO: use `range` in region highlighting
     (lem/peek-source:with-appending-source
         (point :move-function (lambda ()
                                 (let ((point (buffer-point buffer)))
@@ -1596,8 +1580,6 @@
   ;; TODO
   ;; Need to look at response, and deal with it somehow.
   ;; This feature isn't currently used by `gopls`, so its behavior hasn't been tested.
-  ;; レスポンスを見てなんらかの処理をする必要がある
-  ;; この機能はgoplsで使われる事が今のところないので動作テストをできていない
   (request:request
    (workspace-client workspace)
    (make-instance 'lsp:workspace/execute-command)
@@ -1722,7 +1704,6 @@
 ;;; range formatting
 
 ;; WARNING: This is unsupported by `gopls`, so behavior is not tested. 
-;; WARNING: goplsでサポートされていないので動作未確認
 
 (defun provide-range-formatting-p (workspace)
   (handler-case (lsp:server-capabilities-document-range-formatting-provider
@@ -1753,7 +1734,6 @@
 
 ;; TODO
 ;; - Add a hook to call `text-document/on-type-formatting` when buffer is initialized
-;; - バッファの初期化時にtext-document/on-type-formattingを呼び出すフックを追加する
 
 (defun provide-on-type-formatting-p (workspace)
   (handler-case (lsp:server-capabilities-document-on-type-formatting-provider
@@ -1810,8 +1790,6 @@
   ;; TODO:
   ;; It's not enough to reopen just the current buffer,
   ;; we need to check the entire `buffer-list`.
-  ;; 現在のバッファを開き直すだけでは不十分
-  ;; buffer-listを全て見る必要がある
   (ensure-lsp-buffer (current-buffer)))
 
 ;;;

--- a/extensions/shell-mode/shell-mode.lisp
+++ b/extensions/shell-mode/shell-mode.lisp
@@ -100,7 +100,6 @@
     (with-point ((start point))
       ;; TODO: 
       ;; This shouldn't depend on `lisp-mode`. Provide a general-purpose package.
-      ;; lisp-modeに依存するのはおかしいので汎用的なパッケージを用意する
       (lem-lisp-mode/internal::insert-escape-sequence-string point string)
       (lem/link::scan-link start point :set-attribute-function 'set-link-attribute))
     (lem/listener-mode:refresh-prompt buffer nil)))


### PR DESCRIPTION
I translated all the JP comments I could find under `extensions/`.
I tried to check these translations carefully, but I'm not an expert on these packages, or totally fluent in technical Japanese. If anyone's able to double-check these, I'd be grateful.