### PR TITLE
Add a simple python lsp config using python-lsp-server

### DIFF
--- a/extensions/python-mode/lem-python-mode.asd
+++ b/extensions/python-mode/lem-python-mode.asd
@@ -4,4 +4,5 @@
   :serial t
   :components ((:file "python-mode")
                #+#.(cl:if (asdf:find-system :async-process cl:nil) '(and) '(or))
-               (:file "run-python")))
+               (:file "run-python")
+               (:file "lsp-config")))

--- a/extensions/python-mode/lsp-config.lisp
+++ b/extensions/python-mode/lsp-config.lisp
@@ -1,0 +1,12 @@
+(uiop:define-package #:lem-python-mode/lsp-config
+  (:use #:cl)
+  (:export))
+(in-package :lem-python-mode/lsp-config)
+
+(lem-lsp-mode:define-language-spec (python-spec lem-python-mode:python-mode)
+  :language-id "python"
+  :root-uri-patterns '("setup.py" "pyproject.toml" "requirements.txt" "poetry.lock")
+  :command '("pylsp")
+  :install-command "pip install python-lsp-server"
+  :readme-url "https://github.com/python-lsp/python-lsp-server"
+  :connection-mode :stdio)


### PR DESCRIPTION
So, this is a simple file similar to those in `js-mode` and `ts-mode` that add lsp configuartion to the python mode.