### PR TITLE
Fix tm-apply-region for nested tm-region patterns

### DIFF
--- a/src/buffer/internal/tmlanguage.lisp
+++ b/src/buffer/internal/tmlanguage.lisp
@@ -308,10 +308,12 @@
                  (tm-scan-line point
                                (tm-region-patterns rule)
                                start2
-                               (line:line-length (point-line point)))
+                               end)
                  (tm-apply-begin-captures rule point begin-result start-line-p)
                  (set-syntax-context (point-line point) (cons rule begin-result))
-                 (line-end point)
+                 (if end
+                     (line-offset point 0 end)
+                     (line-end point))
                  (return))
                 ((and best end-result (tm-result= best end-result))
                  (line:line-add-property (point-line point) start1 (tm-result-end end-result)


### PR DESCRIPTION
Fix #1946 

Fix syntax rule application for tm-apply-region where it would skip to end of line without respecting a potential end parameter.

This fixes an error with nested region patterns where if a nested pattern could not find it's end pattern, the pattern would move the point to the end of the line, skipping the application of it's "parent patterns" and giving an editor-error.