### PR TITLE
Vue mode: Add template expression highlights

### DIFF
--- a/extensions/vue-mode/vue-mode.lisp
+++ b/extensions/vue-mode/vue-mode.lisp
@@ -54,12 +54,13 @@
   "Make syntax table instance and configure it for vue-mode"
   (let ((syntax-table (make-syntax-table
                        :space-chars lem-js-mode::*js-spaces*
-                       :paren-pairs '((#\( . #\))
-                                      (#\{ . #\})
-                                      (#\[ . #\]))
-                       :string-quote-chars '(#\" #\' #\`)
+                       :paren-pairs (list
+                                     (cons #\( #\))
+                                     (cons #\{ #\})
+                                     (cons #\[ #\]))
+                       :string-quote-chars (list #\" #\' #\`)
                        :line-comment-string "//"
-                       :block-comment-pairs '(("/*" . "*/"))))
+                       :block-comment-pairs (list (cons "/*" "*/"))))
         (tmlanguage (make-tmlanguage-vue)))
     (set-syntax-parser syntax-table tmlanguage)
     syntax-table))


### PR DESCRIPTION
This updates the syntax highlighting of vue-mode to highlight the js expressions in templates.

Before:

<img width="1893" height="989" alt="Screenshot_15" src="https://github.com/user-attachments/assets/fcd63d0c-d98e-44cf-8518-314441a37bc2" />

After:

<img width="1894" height="986" alt="Screenshot_16" src="https://github.com/user-attachments/assets/f5918701-d236-4127-9542-ebf1fdbdee6b" />
