### PR TITLE
Fix documentation-describe-bindings search path

### DIFF
--- a/extensions/documentation-mode/utils.lisp
+++ b/extensions/documentation-mode/utils.lisp
@@ -10,7 +10,7 @@
   (second form))
 
 (defun collect-global-command-packages ()
-  (loop :for component :in (asdf:component-children (asdf:find-component :lem "commands"))
+  (loop :for component :in (asdf:component-children (asdf:find-component :lem/core "commands"))
         :collect (find-package
                   (extract-defpackage-name
                    (uiop:read-file-form


### PR DESCRIPTION
 I ran into the following error while running `documentation-describe-bindings` and updating asdf's component search path has fixed the command.
 
```
There is no applicable method for the generic function #<STANDARD-GENERIC-FUNCTION ASDF/COMPONENT:COMPONENT-CHILDREN (1)> when called with arguments (NIL).
See also:
  The ANSI Standard, Section 7.6.6
Backtrace for: #<SB-THREAD:THREAD tid=2239 "editor" RUNNING {12072080A3}>
0: ((LAMBDA NIL :IN UIOP/IMAGE:PRINT-BACKTRACE))
1: ((FLET "THUNK" :IN UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX))
2: (SB-IMPL::%WITH-STANDARD-IO-SYNTAX #<FUNCTION (FLET "THUNK" :IN UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX) {7F25A7B85C2B}>)
3: (UIOP/STREAM:CALL-WITH-SAFE-IO-SYNTAX #<FUNCTION (LAMBDA NIL :IN UIOP/IMAGE:PRINT-BACKTRACE) {1205AC6C8B}> :PACKAGE :CL)
4: (LEM-CORE:POP-UP-BACKTRACE #<SB-PCL::NO-APPLICABLE-METHOD-ERROR {1205AC5803}>)
5: ((LAMBDA (CONDITION) :IN LEM-CORE:COMMAND-LOOP) #<SB-PCL::NO-APPLICABLE-METHOD-ERROR {1205AC5803}>)
6: (SB-KERNEL::%SIGNAL #<SB-PCL::NO-APPLICABLE-METHOD-ERROR {1205AC5803}>)
7: (ERROR SB-PCL::NO-APPLICABLE-METHOD-ERROR :GENERIC-FUNCTION #<STANDARD-GENERIC-FUNCTION ASDF/COMPONENT:COMPONENT-CHILDREN (1)> :ARGS (NIL))
8: ((:METHOD NO-APPLICABLE-METHOD (T)) #<STANDARD-GENERIC-FUNCTION ASDF/COMPONENT:COMPONENT-CHILDREN (1)> NIL) [fast-method]
9: (SB-PCL::CALL-NO-APPLICABLE-METHOD #<STANDARD-GENERIC-FUNCTION ASDF/COMPONENT:COMPONENT-CHILDREN (1)> (NIL))
10: (LEM-DOCUMENTATION-MODE/UTILS:COLLECT-GLOBAL-COMMAND-PACKAGES)
11: (LEM-DOCUMENTATION-MODE/INTERNAL::CONSTRUCT-GLOBAL-COMMAND-DOCUMENTATION)
12: (LEM-DOCUMENTATION-MODE/INTERNAL:GENERATE-BUFFER "*Documentation describe-bindings*")
13: (LEM-DOCUMENTATION-MODE::DOCUMENTATION-DESCRIBE-BINDINGS)
14: (LEM-CORE:CALL-COMMAND #<LEM-DOCUMENTATION-MODE::DOCUMENTATION-DESCRIBE-BINDINGS {12029D4593}> NIL)
15: (LEM-CORE:CALL-COMMAND LEM-CORE/COMMANDS/OTHER:EXECUTE-COMMAND NIL)
16: (LEM-CORE::COMMAND-LOOP-BODY)
17: (LEM-CORE:COMMAND-LOOP)
18: (LEM-CORE::TOPLEVEL-COMMAND-LOOP #<FUNCTION (LAMBDA NIL :IN LEM-CORE::RUN-EDITOR-THREAD) {12050133FB}>)
19: ((LAMBDA NIL :IN LEM-CORE::RUN-EDITOR-THREAD))
20: ((LAMBDA NIL :IN LEM-CORE::RUN-EDITOR-THREAD))
21: ((FLET BT2::RUN-FUNCTION :IN BT2::ESTABLISH-DYNAMIC-ENV))
22: ((LABELS BT2::%ESTABLISH-DYNAMIC-ENV-WRAPPER :IN BT2::ESTABLISH-DYNAMIC-ENV))
23: ((FLET SB-UNIX::BODY :IN SB-THREAD::RUN))
24: ((FLET "WITHOUT-INTERRUPTS-BODY-" :IN SB-THREAD::RUN))
25: ((FLET SB-UNIX::BODY :IN SB-THREAD::RUN))
26: ((FLET "WITHOUT-INTERRUPTS-BODY-" :IN SB-THREAD::RUN))
27: (SB-THREAD::RUN)
28: ("foreign function: call_into_lisp_")
29: ("foreign function: funcall1")
```