### PR TITLE
fix: Dockerfile now includes webkit for webview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN apk add --no-cache curl bash build-base ncurses-dev sbcl git xdg-utils
+RUN apk add --no-cache curl bash build-base ncurses-dev sbcl git xdg-utils webkit2gtk-4.1
 
 RUN curl -o quicklisp.lisp https://beta.quicklisp.org/quicklisp.lisp
 RUN sbcl --noinform --no-userinit --no-sysinit --non-interactive --load quicklisp.lisp --eval "(quicklisp-quickstart:install)" --eval "(ql-util:without-prompting (ql:add-to-init-file))"


### PR DESCRIPTION
The Dockerfile did not build on my nixos machine. After looking at it for a bit it seems like due to webview being the default frontend there needs to be the libs for webview available even on the ncurses frontend used in docker. After testing this seems to work. 