### PR TITLE
refactor: lazy initialization for clipboard enable flag

### DIFF
--- a/src/clipboard.lisp
+++ b/src/clipboard.lisp
@@ -14,10 +14,7 @@
            ((cons major _)
             (<= 2 major))))))
 
-(defparameter *enable-clipboard-p*
-  (ignore-errors
-    #+darwin (sbcl-2.0.0-or-later-p)
-    #-darwin (not (wsl-p))))
+(defvar *enable-clipboard-p*)
 
 (defmacro with-enable-clipboard (value &body body)
   "Execute BODY with clipboard enabled/disabled.
@@ -36,7 +33,12 @@ Argument VALUE is a boolean, and it will be set to enable/disable the clipboard.
 
 (defun enable-clipboard-p ()
   "Return t if clipboard is enabled."
-  *enable-clipboard-p*)
+  (if (boundp '*enable-clipboard-p)
+      *enable-clipboard-p*
+      (setf *enable-clipboard-p*
+            (ignore-errors
+              #+darwin (sbcl-2.0.0-or-later-p)
+              #-darwin (not (wsl-p))))))
 
 (defun copy-to-clipboard (string)
   "Save STRING to clipboard, so it lives on top of the stack."


### PR DESCRIPTION
## Summary
- クリップボード有効フラグ `*enable-clipboard-p*` を遅延初期化に変更
- `defparameter` から `defvar` に変更し、初回アクセス時に初期化するよう `enable-clipboard-p` 関数を修正
- 起動時のWSL/Darwin判定処理を必要になるまで遅延させることでパフォーマンス向上

## Test plan
- [ ] クリップボードのコピー/ペーストが正常に動作することを確認
- [ ] macOS環境でクリップボード機能が動作することを確認
- [ ] WSL環境でクリップボードが無効化されることを確認
- [ ] `with-enable-clipboard` マクロが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)