### PR TITLE
fix: lazy initialization for clipboard enable flag

### DIFF
--- a/src/clipboard.lisp
+++ b/src/clipboard.lisp
@@ -14,6 +14,10 @@
            ((cons major _)
             (<= 2 major))))))
 
+;; Use defvar instead of defparameter for lazy initialization.
+;; On Nix builds, defparameter would evaluate at compile time,
+;; causing platform detection to run in the build environment
+;; rather than the execution environment.
 (defvar *enable-clipboard-p*)
 
 (defmacro with-enable-clipboard (value &body body)


### PR DESCRIPTION
## Summary

- Fix clipboard initialization issue on Nix builds
- Change `*enable-clipboard-p*` from `defparameter` to `defvar` for lazy initialization
- Move platform detection logic into `enable-clipboard-p` function

## Problem

On Nix builds, the clipboard enable flag was incorrectly initialized at compile time rather than runtime. This caused the platform detection (macOS SBCL version check, WSL detection) to evaluate in the build environment instead of the execution environment, resulting in incorrect clipboard behavior.

## Solution

Defer the platform detection to runtime by initializing the flag lazily on first access to `enable-clipboard-p`.