### PR TITLE
feat: add nix support for webview frontend

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -98,5 +98,26 @@
             "url": "https://github.com/lem-project/webview.git"
         },
         "version": "238a0be10c6c37311ce2587ef99142f65abd880a"
+    },
+    "webview-upstream": {
+        "cargoLocks": null,
+        "date": null,
+        "extract": null,
+        "name": "webview-upstream",
+        "passthru": null,
+        "pinned": false,
+        "src": {
+            "deepClone": false,
+            "fetchSubmodules": false,
+            "leaveDotGit": false,
+            "name": null,
+            "owner": "webview",
+            "repo": "webview",
+            "rev": "0.12.0",
+            "sha256": "sha256-pmqodl2fIlCNJTZz1U5spW4MpcoMhQt5WFh3+TRny3U=",
+            "sparseCheckout": [],
+            "type": "github"
+        },
+        "version": "0.12.0"
     }
 }

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -71,4 +71,15 @@
     };
     date = "2025-08-23";
   };
+  webview-upstream = {
+    pname = "webview-upstream";
+    version = "0.12.0";
+    src = fetchFromGitHub {
+      owner = "webview";
+      repo = "webview";
+      rev = "0.12.0";
+      fetchSubmodules = false;
+      sha256 = "sha256-pmqodl2fIlCNJTZz1U5spW4MpcoMhQt5WFh3+TRny3U=";
+    };
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -98,13 +98,6 @@
               queues_dot_simple-cqueue
             ];
           };
-          # Fetch upstream webview library
-          webview-upstream = pkgs.fetchFromGitHub {
-            owner = "webview";
-            repo = "webview";
-            rev = "0.12.0";
-            hash = "sha256-pmqodl2fIlCNJTZz1U5spW4MpcoMhQt5WFh3+TRny3U=";
-          };
           # Build the webview C library from lem-project/webview
           c-webview = pkgs.stdenv.mkDerivation {
             pname = "c-webview";
@@ -124,7 +117,7 @@
               runHook preConfigure
               cmake -G Ninja -B build -S c \
                 -DCMAKE_BUILD_TYPE=Release \
-                -DFETCHCONTENT_SOURCE_DIR_WEBVIEW=${webview-upstream}
+                -DFETCHCONTENT_SOURCE_DIR_WEBVIEW=${sources.webview-upstream.src}
               runHook postConfigure
             '';
             buildPhase = ''

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -33,3 +33,7 @@ fetch.git = "https://github.com/cxxxr/jsonrpc"
 [webview]
 src.git = "https://github.com/lem-project/webview.git"
 fetch.git = "https://github.com/lem-project/webview.git"
+
+[webview-upstream]
+src.manual = "0.12.0"
+fetch.github = "webview/webview"


### PR DESCRIPTION
## Summary

Add Nix support for the webview frontend, enabling `nix build .#lem-webview` and `nix run .#lem-webview`.

### Changes
- Enable webview source in nvfetcher
- Add webview C library build (`c-webview`) using WebKitGTK
- Add Common Lisp webview bindings (`cl-webview`)
- Add `lem-webview` package with proper entry point
- Add jsonrpc websocket and local-domain-socket transports
- Configure DejaVu Sans Mono as default font for proper rendering

## Changes

| File | Description |
|------|-------------|
| `nvfetcher.toml` | Enable webview source |
| `_sources/generated.*` | Auto-generated by nvfetcher |
| `flake.nix` | Add webview-related derivations and lem-webview package |

## Usage

```bash
# Build webview frontend
nix build .#lem-webview

# Run webview frontend
nix run .#lem-webview

# Traditional ncurses/SDL2 version (unchanged)
nix run .#lem
```

## Test Plan

- [x] Verify `nix build .#lem-webview` completes successfully
- [x] Verify `nix run .#lem-webview` launches with proper font rendering
- [x] Verify `nix build .#lem` still works (no regression)