### PR TITLE
CI for Nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: Nix CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  # Trigger manually to optionally include heavier/unstable targets
+  workflow_dispatch:
+    inputs:
+      include_optional:
+        description: 'Include optional targets (SDL2, Intel Mac)'
+        type: boolean
+        default: false
+
+jobs:
+  # 1. Job to generate the matrix dynamically based on inputs
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.set-matrix.outputs.os }}
+      backend: ${{ steps.set-matrix.outputs.backend }}
+    steps:
+      - name: Generate Matrix JSON
+        id: set-matrix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Default configuration (Stable & Lightweight targets)
+            let osList = ["ubuntu-24.04", "ubuntu-24.04-arm", "macos-15"];
+            let backendList = ["lem-ncurses", "lem-webview"];
+
+            // Check if optional targets should be included
+            // (Only strictly when triggered via workflow_dispatch with the flag set to true)
+            if (context.payload.inputs && context.payload.inputs.include_optional === 'true') {
+              console.log("Adding optional targets (SDL2, Intel Mac)...");
+              osList.push("macos-15-intel");
+              backendList.push("lem-sdl2");
+            }
+
+            // Set outputs for the next job to consume
+            core.setOutput('os', JSON.stringify(osList));
+            core.setOutput('backend', JSON.stringify(backendList));
+
+  # 2. Build job using the dynamically generated matrix
+  build:
+    needs: setup
+    name: builds ${{ matrix.backend }} on ${{ matrix.os }}
+    # The 'runs-on' key also uses the dynamic matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Parse JSON strings from the setup job outputs
+        os: ${{ fromJson(needs.setup.outputs.os) }}
+        backend: ${{ fromJson(needs.setup.outputs.backend) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v16
+
+      - name: Setup Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+
+      - name: Check flake
+        run: nix flake check --all-systems --no-build
+
+      - name: Build ${{ matrix.backend }}
+        run: nix build .#${{ matrix.backend }} --print-build-logs

--- a/README.md
+++ b/README.md
@@ -19,14 +19,20 @@ https://github.com/lem-project/lem/releases/tag/nightly-latest
 
 ### Nix
 
-    $ nix profile add github:lem-project/lem#lem
+    $ nix profile add github:lem-project/lem#
+    $ nix profile add github:lem-project/lem#lem-ncurses
+    $ nix profile add github:lem-project/lem#lem-webview
+    $ nix profile add github:lem-project/lem#lem-sdl2
 
 Or run Lem temporarily (no install):
 
-    $ nix run github:lem-project/lem#lem
+    $ nix run github:lem-project/lem#
+    $ nix run github:lem-project/lem#lem-ncurses
+    $ nix run github:lem-project/lem#lem-webview
+    $ nix run github:lem-project/lem#lem-sdl2
 
 Use the overlay when you already have a flake-based NixOS/home-manager config and
-want `pkgs.lem` (and `apps.lem`) available from your `nixpkgs` set.
+want `pkgs.lem-ncurses` (and `apps.lem-ncurses`) available from your `nixpkgs` set.
 You can also consume `lem` as an overlay in `flake.nix`:
 
     {
@@ -40,7 +46,7 @@ You can also consume `lem` as an overlay in `flake.nix`:
           system = "x86_64-linux";
           modules = [
             { nixpkgs.overlays = [ lem.overlays.default ]; }
-            { environment.systemPackages = [ pkgs.lem ]; }
+            { environment.systemPackages = [ pkgs.lem-ncurses ]; }
           ];
         };
       };


### PR DESCRIPTION
This enables CI testing for the Nix recipe.
GitHub Actions test `lem-{ncurses,webview,sdl2}` on macOS and Linux with two archtectures `arm64` and `x86_64`. Note that this test fails currently because `lem-sdl2` especially SDL2 for Common Lisp does not work on macOS. If you wishes to drop `lem-sdl2` on macOS, I'll update script to skip test for this issue.
