### PR TITLE
[VI-Mode] Ability to customize cursor theme in VI Mode

### DIFF
--- a/extensions/vi-mode/core.lisp
+++ b/extensions/vi-mode/core.lisp
@@ -53,8 +53,9 @@
 
 (defvar *default-cursor-color*  "#ffffff")
 
-(defun get-cursor-theme-color () (let ((attribute (ensure-attribute 'cursor)))
-  (color-to-hex-string (attribute-background-color attribute))))
+(defun get-cursor-theme-color ()
+  (let ((attribute (ensure-attribute 'cursor)))
+    (color-to-hex-string (attribute-background-color attribute))))
 
 (defun vi-load-theme-hook () 
  (setf *default-cursor-color*  (get-cursor-theme-color)))


### PR DESCRIPTION
Fixes issue where cursor theme background and foreground color isn't respected. The currently a hard-coded orange color is used for the cursor color.