### PR TITLE
feat(git-gutter): add directory-mode git status support

### DIFF
--- a/extensions/git-gutter/git-gutter.lisp
+++ b/extensions/git-gutter/git-gutter.lisp
@@ -5,9 +5,14 @@
            :git-gutter-set-ref
            :git-gutter-refresh
            :git-gutter-toggle-line-highlight
+           :git-gutter-refresh-directory-status
            :*git-gutter-ref*
            :*git-gutter-highlight-line*
-           :*git-gutter-update-delay*))
+           :*git-gutter-update-delay*
+           :*directory-status-cache-ttl*
+           ;; For testing
+           :parse-git-status-porcelain
+           :status-to-display))
 (in-package :lem-git-gutter)
 
 ;;; Configuration
@@ -20,6 +25,9 @@
 
 (defvar *git-gutter-update-delay* 300
   "Delay in milliseconds before updating gutter after edit.")
+
+(defvar *directory-status-cache-ttl* 5000
+  "Cache time-to-live in milliseconds for directory git status.")
 
 ;;; Attributes
 
@@ -224,13 +232,43 @@
   (when (buffer-filename buffer)
     (update-git-gutter-for-buffer buffer)))
 
+(defun add-directory-mode-inserter ()
+  "Add git status inserter to directory-mode if available."
+  (when (find-package :lem/directory-mode/internal)
+    (let ((inserters-sym (find-symbol "*FILE-ENTRY-INSERTERS*" :lem/directory-mode/internal)))
+      (when (and inserters-sym (boundp inserters-sym))
+        (unless (member #'insert-git-status (symbol-value inserters-sym))
+          (setf (symbol-value inserters-sym)
+                (cons #'insert-git-status (symbol-value inserters-sym))))))))
+
+(defun remove-directory-mode-inserter ()
+  "Remove git status inserter from directory-mode if available."
+  (when (find-package :lem/directory-mode/internal)
+    (let ((inserters-sym (find-symbol "*FILE-ENTRY-INSERTERS*" :lem/directory-mode/internal)))
+      (when (and inserters-sym (boundp inserters-sym))
+        (setf (symbol-value inserters-sym)
+              (remove #'insert-git-status (symbol-value inserters-sym)))))))
+
+(defun update-all-directory-buffers ()
+  "Update all directory-mode buffers to reflect git status."
+  (when (find-package :lem/directory-mode/internal)
+    (let ((update-buffer-sym (find-symbol "UPDATE-BUFFER" :lem/directory-mode/internal))
+          (directory-mode-sym (find-symbol "DIRECTORY-MODE" :lem/directory-mode/mode)))
+      (when (and update-buffer-sym (fboundp update-buffer-sym) directory-mode-sym)
+        (dolist (buffer (buffer-list))
+          (when (eq (buffer-major-mode buffer) directory-mode-sym)
+            (funcall update-buffer-sym buffer)))))))
+
 (defun enable-hook ()
   "Called when git-gutter-mode is enabled."
   (update-all-buffers)
   (add-hook (variable-value 'after-save-hook :global t)
             'git-gutter-after-save)
   (add-hook (variable-value 'after-change-functions :global t)
-            'git-gutter-on-change))
+            'git-gutter-on-change)
+  ;; Add directory-mode support
+  (add-directory-mode-inserter)
+  (update-all-directory-buffers))
 
 (defun disable-hook ()
   "Called when git-gutter-mode is disabled."
@@ -239,7 +277,10 @@
   (remove-hook (variable-value 'after-change-functions :global t)
                'git-gutter-on-change)
   (cancel-all-git-gutter-timers)
-  (clear-all-buffers))
+  (clear-all-buffers)
+  ;; Remove directory-mode support and clear cache
+  (remove-directory-mode-inserter)
+  (clear-directory-status-cache))
 
 (define-minor-mode git-gutter-mode
     (:name "GitGutter"
@@ -295,3 +336,149 @@
   (setf *git-gutter-highlight-line* (not *git-gutter-highlight-line*))
   (update-all-buffers)
   (message "Git gutter line highlight: ~A" (if *git-gutter-highlight-line* "on" "off")))
+
+;;; Directory Mode Git Status Support
+
+(defvar *directory-git-status-cache* (make-hash-table :test #'equal)
+  "Cache for directory git status. Maps directory path to (timestamp . status-hash).")
+
+(define-attribute git-status-modified-attribute
+  (t :foreground "yellow"))
+
+(define-attribute git-status-added-attribute
+  (t :foreground "green"))
+
+(define-attribute git-status-deleted-attribute
+  (t :foreground "red"))
+
+(define-attribute git-status-untracked-attribute
+  (t :foreground "cyan"))
+
+(define-attribute git-status-staged-attribute
+  (t :foreground "green" :bold t))
+
+(defun parse-git-status-porcelain (output)
+  "Parse git status --porcelain=v1 output into a hash-table.
+   Returns hash-table mapping relative-path -> status-keyword."
+  (let ((status (make-hash-table :test #'equal)))
+    (dolist (line (uiop:split-string output :separator '(#\Newline)))
+      (when (>= (length line) 3)
+        (let ((x (char line 0))
+              (y (char line 1))
+              (file (string-trim " " (subseq line 3))))
+          (when (plusp (length file))
+            ;; Handle renamed files: "R  old -> new"
+            (when (find #\> file)
+              (setf file (string-trim " " (subseq file (1+ (position #\> file))))))
+            (cond
+              ;; Untracked
+              ((and (char= x #\?) (char= y #\?))
+               (setf (gethash file status) :untracked))
+              ;; Staged changes (index)
+              ((char= x #\M) (setf (gethash file status) :staged-modified))
+              ((char= x #\A) (setf (gethash file status) :staged-added))
+              ((char= x #\D) (setf (gethash file status) :staged-deleted))
+              ((char= x #\R) (setf (gethash file status) :staged-added))
+              ;; Unstaged changes (work tree)
+              ((char= y #\M) (setf (gethash file status) :modified))
+              ((char= y #\D) (setf (gethash file status) :deleted)))))))
+    status))
+
+(defun get-directory-git-status (directory)
+  "Get git status for all files in directory. Uses cache when available."
+  (let* ((dir-key (namestring directory))
+         (cached (gethash dir-key *directory-git-status-cache*))
+         (now (get-internal-real-time))
+         (ttl-ticks (* *directory-status-cache-ttl*
+                       (/ internal-time-units-per-second 1000))))
+    (if (and cached
+             (< (- now (car cached)) ttl-ticks))
+        (cdr cached)
+        ;; Refresh cache
+        (alexandria:when-let ((git-root (find-git-root directory)))
+          (uiop:with-current-directory (git-root)
+            (let* ((output (run-git (list "status" "--porcelain=v1")))
+                   (status-table (parse-git-status-porcelain output)))
+              (setf (gethash dir-key *directory-git-status-cache*)
+                    (cons now status-table))
+              status-table))))))
+
+(defun find-status-in-directory (dir-prefix status-table)
+  "Find if any file under dir-prefix has a git status.
+   Returns the most significant status found (:modified > :added > :deleted > :untracked)."
+  (let ((found-status nil))
+    (maphash (lambda (path status)
+               (when (and (> (length path) (length dir-prefix))
+                          (string= dir-prefix (subseq path 0 (length dir-prefix))))
+                 ;; Found a file under this directory
+                 (case status
+                   ((:modified :staged-modified)
+                    (setf found-status :modified))
+                   ((:added :staged-added)
+                    (unless (eq found-status :modified)
+                      (setf found-status :added)))
+                   ((:deleted :staged-deleted)
+                    (unless (member found-status '(:modified :added))
+                      (setf found-status :deleted)))
+                   (:untracked
+                    (unless found-status
+                      (setf found-status :untracked))))))
+             status-table)
+    found-status))
+
+(defun get-file-git-status (pathname directory)
+  "Get git status symbol for a specific file or directory.
+   For directories, checks if any file underneath has changes."
+  (alexandria:when-let ((status-table (get-directory-git-status directory)))
+    (alexandria:when-let ((git-root (find-git-root directory)))
+      (let ((relative-path (namestring (enough-namestring pathname git-root))))
+        (if (uiop:directory-pathname-p pathname)
+            ;; For directories, check if any files underneath have changes
+            (let ((dir-prefix (if (alexandria:ends-with #\/ relative-path)
+                                  relative-path
+                                  (concatenate 'string relative-path "/"))))
+              (find-status-in-directory dir-prefix status-table))
+            ;; For files, direct lookup
+            (gethash relative-path status-table))))))
+
+(defun status-to-display (status)
+  "Convert status keyword to display character and attribute."
+  (case status
+    (:modified (values "M" 'git-status-modified-attribute))
+    (:staged-modified (values "M" 'git-status-staged-attribute))
+    (:added (values "A" 'git-status-added-attribute))
+    (:staged-added (values "A" 'git-status-staged-attribute))
+    (:deleted (values "D" 'git-status-deleted-attribute))
+    (:staged-deleted (values "D" 'git-status-staged-attribute))
+    (:untracked (values "?" 'git-status-untracked-attribute))
+    (otherwise (values " " nil))))
+
+(defun insert-git-status (point item)
+  "Inserter function for directory-mode to show git status."
+  (let* ((item-pathname-fn (find-symbol "ITEM-PATHNAME" :lem/directory-mode/internal))
+         (item-directory-fn (find-symbol "ITEM-DIRECTORY" :lem/directory-mode/internal))
+         (pathname (when item-pathname-fn (funcall item-pathname-fn item)))
+         (directory (when item-directory-fn (funcall item-directory-fn item)))
+         (status (when (and pathname directory)
+                   (get-file-git-status pathname directory))))
+    (multiple-value-bind (char attr)
+        (status-to-display status)
+      (if attr
+          (insert-string point (format nil "~A " char) :attribute attr)
+          (insert-string point "  ")))))
+
+(defun clear-directory-status-cache ()
+  "Clear the directory git status cache."
+  (clrhash *directory-git-status-cache*))
+
+(define-command git-gutter-refresh-directory-status () ()
+  "Refresh git status cache for current directory buffer."
+  (let ((directory (buffer-directory (current-buffer))))
+    (when directory
+      (remhash (namestring directory) *directory-git-status-cache*)
+      ;; Force redisplay of directory buffer if in directory-mode
+      (when (find-package :lem/directory-mode/internal)
+        (let ((update-buffer-sym (find-symbol "UPDATE-BUFFER" :lem/directory-mode/internal)))
+          (when (and update-buffer-sym (fboundp update-buffer-sym))
+            (funcall update-buffer-sym (current-buffer)))))
+      (message "Git status refreshed"))))

--- a/extensions/git-gutter/lem-git-gutter.asd
+++ b/extensions/git-gutter/lem-git-gutter.asd
@@ -14,7 +14,7 @@
   :in-order-to ((test-op (test-op "lem-git-gutter/tests"))))
 
 (defsystem "lem-git-gutter/tests"
-  :depends-on ("lem-git-gutter/diff-parser" "rove")
+  :depends-on ("lem-git-gutter" "rove")
   :components ((:module "tests"
                 :components ((:file "git-gutter-tests"))))
   :perform (test-op (op c) (symbol-call :rove '#:run c)))

--- a/extensions/git-gutter/tests/git-gutter-tests.lisp
+++ b/extensions/git-gutter/tests/git-gutter-tests.lisp
@@ -1,6 +1,7 @@
 (defpackage :lem-git-gutter/tests
   (:use :cl :rove)
-  (:local-nicknames (:parser :lem-git-gutter/diff-parser)))
+  (:local-nicknames (:parser :lem-git-gutter/diff-parser)
+                    (:gutter :lem-git-gutter)))
 (in-package :lem-git-gutter/tests)
 
 ;;; Test parse-hunk-header
@@ -148,3 +149,175 @@ index a92d664b..7c7d6265 100644
     (ok (eq (gethash 2 changes) :modified) "Line 2 should be modified")
     (ok (eq (gethash 4 changes) :added) "Line 4 should be added")
     (ok (= (hash-table-count changes) 2) "Should have exactly 2 changes")))
+
+;;; Test parse-git-status-porcelain (directory status)
+
+(deftest test-parse-git-status-porcelain-untracked
+  "Test parsing untracked files"
+  (let* ((output "?? newfile.txt
+?? another/path.lisp")
+         (status (gutter:parse-git-status-porcelain output)))
+    (ok (eq (gethash "newfile.txt" status) :untracked)
+        "newfile.txt should be untracked")
+    (ok (eq (gethash "another/path.lisp" status) :untracked)
+        "another/path.lisp should be untracked")))
+
+(deftest test-parse-git-status-porcelain-modified
+  "Test parsing modified files (unstaged)"
+  (let* ((output " M src/file.lisp
+ M tests/test.lisp")
+         (status (gutter:parse-git-status-porcelain output)))
+    (ok (eq (gethash "src/file.lisp" status) :modified)
+        "src/file.lisp should be modified")
+    (ok (eq (gethash "tests/test.lisp" status) :modified)
+        "tests/test.lisp should be modified")))
+
+(deftest test-parse-git-status-porcelain-staged
+  "Test parsing staged files"
+  (let* ((output "M  staged-mod.lisp
+A  new-staged.lisp
+D  deleted-staged.lisp")
+         (status (gutter:parse-git-status-porcelain output)))
+    (ok (eq (gethash "staged-mod.lisp" status) :staged-modified)
+        "staged-mod.lisp should be staged-modified")
+    (ok (eq (gethash "new-staged.lisp" status) :staged-added)
+        "new-staged.lisp should be staged-added")
+    (ok (eq (gethash "deleted-staged.lisp" status) :staged-deleted)
+        "deleted-staged.lisp should be staged-deleted")))
+
+(deftest test-parse-git-status-porcelain-deleted
+  "Test parsing deleted files (unstaged)"
+  (let* ((output " D removed.lisp")
+         (status (gutter:parse-git-status-porcelain output)))
+    (ok (eq (gethash "removed.lisp" status) :deleted)
+        "removed.lisp should be deleted")))
+
+(deftest test-parse-git-status-porcelain-renamed
+  "Test parsing renamed files"
+  (let* ((output "R  old-name.lisp -> new-name.lisp")
+         (status (gutter:parse-git-status-porcelain output)))
+    (ok (eq (gethash "new-name.lisp" status) :staged-added)
+        "new-name.lisp (renamed) should be staged-added")))
+
+(deftest test-parse-git-status-porcelain-mixed
+  "Test parsing mixed status output"
+  (let* ((output "?? untracked.txt
+ M modified.lisp
+M  staged.lisp
+A  added.lisp
+ D deleted.lisp")
+         (status (gutter:parse-git-status-porcelain output)))
+    (ok (= (hash-table-count status) 5) "Should have 5 entries")
+    (ok (eq (gethash "untracked.txt" status) :untracked))
+    (ok (eq (gethash "modified.lisp" status) :modified))
+    (ok (eq (gethash "staged.lisp" status) :staged-modified))
+    (ok (eq (gethash "added.lisp" status) :staged-added))
+    (ok (eq (gethash "deleted.lisp" status) :deleted))))
+
+(deftest test-parse-git-status-porcelain-empty
+  "Test parsing empty output"
+  (let ((status (gutter:parse-git-status-porcelain "")))
+    (ok (= (hash-table-count status) 0) "Empty output should have no entries")))
+
+;;; Test status-to-display
+
+(deftest test-status-to-display-modified
+  "Test display conversion for modified status"
+  (multiple-value-bind (char attr)
+      (gutter:status-to-display :modified)
+    (ok (string= char "M") "Modified should display as M")
+    (ok (eq attr 'gutter::git-status-modified-attribute))))
+
+(deftest test-status-to-display-staged-modified
+  "Test display conversion for staged-modified status"
+  (multiple-value-bind (char attr)
+      (gutter:status-to-display :staged-modified)
+    (ok (string= char "M") "Staged-modified should display as M")
+    (ok (eq attr 'gutter::git-status-staged-attribute))))
+
+(deftest test-status-to-display-added
+  "Test display conversion for added status"
+  (multiple-value-bind (char attr)
+      (gutter:status-to-display :added)
+    (ok (string= char "A") "Added should display as A")
+    (ok (eq attr 'gutter::git-status-added-attribute))))
+
+(deftest test-status-to-display-staged-added
+  "Test display conversion for staged-added status"
+  (multiple-value-bind (char attr)
+      (gutter:status-to-display :staged-added)
+    (ok (string= char "A") "Staged-added should display as A")
+    (ok (eq attr 'gutter::git-status-staged-attribute))))
+
+(deftest test-status-to-display-deleted
+  "Test display conversion for deleted status"
+  (multiple-value-bind (char attr)
+      (gutter:status-to-display :deleted)
+    (ok (string= char "D") "Deleted should display as D")
+    (ok (eq attr 'gutter::git-status-deleted-attribute))))
+
+(deftest test-status-to-display-untracked
+  "Test display conversion for untracked status"
+  (multiple-value-bind (char attr)
+      (gutter:status-to-display :untracked)
+    (ok (string= char "?") "Untracked should display as ?")
+    (ok (eq attr 'gutter::git-status-untracked-attribute))))
+
+(deftest test-status-to-display-nil
+  "Test display conversion for nil/no status"
+  (multiple-value-bind (char attr)
+      (gutter:status-to-display nil)
+    (ok (string= char " ") "No status should display as space")
+    (ok (null attr) "No status should have nil attribute")))
+
+;;; Test find-status-in-directory (directory status aggregation)
+
+(deftest test-find-status-in-directory-modified
+  "Test finding modified status in subdirectory"
+  (let* ((output " M src/foo/bar.lisp
+ M src/foo/baz.lisp")
+         (status (gutter:parse-git-status-porcelain output))
+         (result (lem-git-gutter::find-status-in-directory "src/foo/" status)))
+    (ok (eq result :modified) "Directory with modified files should show :modified")))
+
+(deftest test-find-status-in-directory-mixed
+  "Test priority when directory has mixed statuses"
+  (let* ((output "?? src/sub/untracked.txt
+A  src/sub/added.lisp
+ M src/sub/modified.lisp")
+         (status (gutter:parse-git-status-porcelain output))
+         (result (lem-git-gutter::find-status-in-directory "src/sub/" status)))
+    (ok (eq result :modified) "Modified should take priority over added and untracked")))
+
+(deftest test-find-status-in-directory-added-only
+  "Test directory with only added files"
+  (let* ((output "A  lib/new/file1.lisp
+A  lib/new/file2.lisp")
+         (status (gutter:parse-git-status-porcelain output))
+         (result (lem-git-gutter::find-status-in-directory "lib/new/" status)))
+    (ok (eq result :added) "Directory with only added files should show :added")))
+
+(deftest test-find-status-in-directory-untracked-only
+  "Test directory with only untracked files"
+  (let* ((output "?? docs/draft/readme.md")
+         (status (gutter:parse-git-status-porcelain output))
+         (result (lem-git-gutter::find-status-in-directory "docs/draft/" status)))
+    (ok (eq result :untracked) "Directory with only untracked files should show :untracked")))
+
+(deftest test-find-status-in-directory-no-match
+  "Test directory with no matching files"
+  (let* ((output " M other/file.lisp")
+         (status (gutter:parse-git-status-porcelain output))
+         (result (lem-git-gutter::find-status-in-directory "src/" status)))
+    (ok (null result) "Directory with no matching files should return nil")))
+
+(deftest test-find-status-in-directory-nested
+  "Test nested directory detection"
+  (let* ((output " M a/b/c/deep.lisp")
+         (status (gutter:parse-git-status-porcelain output))
+         (result-a (lem-git-gutter::find-status-in-directory "a/" status))
+         (result-ab (lem-git-gutter::find-status-in-directory "a/b/" status))
+         (result-abc (lem-git-gutter::find-status-in-directory "a/b/c/" status)))
+    (ok (eq result-a :modified) "Parent dir 'a/' should show modified")
+    (ok (eq result-ab :modified) "Parent dir 'a/b/' should show modified")
+    (ok (eq result-abc :modified) "Parent dir 'a/b/c/' should show modified")))

--- a/src/ext/directory-mode/internal.lisp
+++ b/src/ext/directory-mode/internal.lisp
@@ -15,6 +15,9 @@
                 :directory-mode)
   (:export :sort-method
            :*default-sort-method*
+           :*file-entry-inserters*
+           :item-pathname
+           :item-directory
            :update-buffer
            :directory-buffer
            :open-selected-file


### PR DESCRIPTION
## Summary

- Display git status indicators (M/A/D/?) in directory-mode file listings when git-gutter-mode is enabled
- Aggregate status for directories - shows if any file underneath has changes
- Status priority: modified > added > deleted > untracked
- Add caching with configurable TTL (default 5 seconds)
- New command: `git-gutter-refresh-directory-status`

## Changes

- Export `*file-entry-inserters*`, `item-pathname`, `item-directory` from `lem/directory-mode/internal` for extensibility
- Add `parse-git-status-porcelain` for parsing `git status --porcelain` output
- Add 20 new test cases for directory status functionality

## Usage

```lisp
;; Enable git-gutter-mode (directory-mode support is automatic)
(lem-git-gutter:git-gutter-mode t)

;; Optionally compare against a different ref
(lem-git-gutter:git-gutter-set-ref "main")
```

## Display Example

```
  5.2K 2024/01/09 10:30:00 Mon M file1.lisp
  1.0K 2024/01/09 09:00:00 Mon A new-file.lisp
       2024/01/09 11:00:00 Mon M subdir/        <- shows M if any file inside changed
       2024/01/09 11:00:00 Mon ? untracked/
```

## Test plan

- [x] All existing tests pass
- [x] New tests for `parse-git-status-porcelain` (7 tests)
- [x] New tests for `status-to-display` (7 tests)
- [x] New tests for `find-status-in-directory` (6 tests)
- [ ] Manual testing: enable git-gutter-mode and open directory in git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)