### PR TITLE
feat(filer): add git status display integration

### DIFF
--- a/tests/filer.lisp
+++ b/tests/filer.lisp
@@ -80,6 +80,27 @@
     (let ((root (create-directory-item #P"/tmp/")))
       (ng (expand-to-directory root #P"/var/")))))
 
+;;; Test *filer-item-inserters*
+(deftest filer-item-inserters-test
+  (testing "*filer-item-inserters* exists and is initially empty"
+    (ok (boundp 'lem/filer:*filer-item-inserters*))
+    (ok (listp lem/filer:*filer-item-inserters*)))
+
+  (testing "inserters can be added and removed"
+    (let ((original-value lem/filer:*filer-item-inserters*))
+      (unwind-protect
+          (let ((test-inserter (lambda (point item root-directory)
+                                 (declare (ignore point item root-directory)))))
+            ;; Add inserter
+            (push test-inserter lem/filer:*filer-item-inserters*)
+            (ok (member test-inserter lem/filer:*filer-item-inserters*))
+            ;; Remove inserter
+            (setf lem/filer:*filer-item-inserters*
+                  (remove test-inserter lem/filer:*filer-item-inserters*))
+            (ok (not (member test-inserter lem/filer:*filer-item-inserters*))))
+        ;; Restore original value
+        (setf lem/filer:*filer-item-inserters* original-value)))))
+
 ;;; Note: Tests for filer-active-p, filer-buffer, filer-current-directory,
 ;;; and highlight-file-in-filer are not included here because they require
 ;;; a full editor environment with *implementation* bound.


### PR DESCRIPTION
## Description

Add git status indicators (M, A, D, ?) to the filer tree view when `git-gutter-mode` is enabled.

This follows the same pluggable inserter pattern used by `directory-mode`, allowing git-gutter to seamlessly integrate with filer without tight coupling.

### Changes

| File | Changes |
|------|---------|
| `src/ext/filer.lisp` | Add `*filer-item-inserters*` parameter and modify `insert-item` to call registered inserters |
| `extensions/git-gutter/git-gutter.lisp` | Add `insert-filer-git-status`, registration functions, and filer update support |
| `tests/filer.lisp` | Add tests for `*filer-item-inserters*` |
| `extensions/git-gutter/tests/git-gutter-tests.lisp` | Add filer integration tests |

### How it works

1. Filer exports `*filer-item-inserters*` - a list of functions called before inserting each item
2. When `git-gutter-mode` is enabled, it registers `insert-filer-git-status` to the list
3. Each inserter receives `(point item root-directory)` and can insert status indicators
4. When `git-gutter-mode` is disabled, the inserter is removed and filer is refreshed

## AI Usage Disclosure
**Did you use LLMs/AI tools for this PR?**
- [ ] No, this is 100% human-authored.
- [ ] Yes, AI-assisted (Human-led logic, AI-assisted implementation).
- [x] Yes, AI-generated (Logic primarily derived from prompt/vibe).

**Tooling Used:** Claude Code

---

## The "Human-in-the-Loop" Verification

### 1. Logic Walkthrough

1. `*filer-item-inserters*` provides extension point for filer item rendering
2. `insert-item` iterates through registered inserters before rendering the item
3. `insert-filer-git-status` uses existing `get-file-git-status` to get status and `status-to-display` to format it
4. Registration is done via `add-filer-inserter`/`remove-filer-inserter` which safely check package existence
5. `update-filer-buffer` re-renders the filer to reflect changes

### 2. Reviewer's Guide
- **High-risk areas:** The `insert-item` modification in filer.lisp - ensure inserters don't break existing rendering
- **Suggested focus for reviewer:** Verify the pluggable pattern matches directory-mode's approach

## Test Plan
- [x] Run `make test` - all tests pass
- [ ] Enable `M-x git-gutter-mode` and open filer with `C-x d`
- [ ] Verify M/A/D/? indicators appear next to modified/added/deleted/untracked files
- [ ] Disable `git-gutter-mode` and verify indicators disappear
- [ ] Run `M-x git-gutter-refresh-directory-status` to verify filer updates