### PR TITLE
fix(window): allow floating-window to display modeline when use-modeline-p is set

### DIFF
--- a/src/window/floating-window.lisp
+++ b/src/window/floating-window.lisp
@@ -95,6 +95,9 @@ If pixel coordinates are nil, frontends may calculate from character units."
                  :background-color background-color
                  :border (if use-border 1 0)))
 
+(defmethod window-use-modeline-p ((window floating-window))
+  (slot-value window 'use-modeline-p))
+
 (defmethod %delete-window ((window floating-window))
   (when (eq window (current-window))
     (editor-error "Can not delete this window"))


### PR DESCRIPTION
## Description

Fix typeout-window not displaying its modeline/underline at the bottom.

### Problem

The `window-use-modeline-p` method in `window.lisp` unconditionally excluded all floating-windows from displaying modeline:

```lisp
(defmethod window-use-modeline-p ((window window))
  (and (not (header-window-p window))
       (not (floating-window-p window))     ;; ← All floating-windows excluded
       (not (attached-window-p window))
       (frame-enable-window-modeline-per-window (current-frame))))
```

This prevented typeout-window (which is created with `use-modeline-p t`) from showing its underline at the bottom.

### Solution

Add a specialized `window-use-modeline-p` method for `floating-window` class that respects the `use-modeline-p` slot value:

```lisp
(defmethod window-use-modeline-p ((window floating-window))
  (slot-value window 'use-modeline-p))
```

### Impact

| Class | use-modeline-p | Before | After |
|-------|---------------|--------|-------|
| typeout-window | t | No modeline ❌ | Shows modeline ✅ |
| popup-window | nil (default) | No modeline | No modeline (unchanged) |
| Other floating-windows | nil (default) | No modeline | No modeline (unchanged) |

## AI Usage Disclosure
**Did you use LLMs/AI tools for this PR?**
- [ ] No, this is 100% human-authored.
- [ ] Yes, AI-assisted (Human-led logic, AI-assisted implementation).
- [x] Yes, AI-generated (Logic primarily derived from prompt/vibe).

**Tooling Used:** Claude Code

---

## The "Human-in-the-Loop" Verification

### 1. Logic Walkthrough

1. CLOS method dispatch will call the more specific `floating-window` method for floating-windows
2. The method simply returns the slot value, allowing typeout-window to display its modeline
3. Other floating-window subclasses default to `nil` so they remain unchanged

### 2. Reviewer's Guide
- **High-risk areas:** None - minimal change with clear scope
- **Suggested focus for reviewer:** Verify no other floating-window subclasses rely on having a modeline

## Test Plan
- [x] Run `make test` - all tests pass
- [ ] Start Lem (`make sdl2` or `make ncurses`)
- [ ] Run `M-x describe-bindings` or `C-h b`
- [ ] Verify typeout-window shows underline/modeline at the bottom with position info
- [ ] Press `Space` for page-down, `q` to close
- [ ] Verify completion popups still have no modeline