### PR TITLE
fix(html-mode): add missing dependency on lem-js-mode

### DIFF
--- a/extensions/html-mode/lem-html-mode.asd
+++ b/extensions/html-mode/lem-html-mode.asd
@@ -1,6 +1,7 @@
 (defsystem "lem-html-mode"
   :depends-on ("lem/core"
                "lem-xml-mode"
+               "lem-js-mode"
                "cl-ppcre")
   :serial t
   :components ((:file "html-mode")))


### PR DESCRIPTION
## Description

Fix missing dependency declaration for `lem-js-mode` in `lem-html-mode.asd`.

### Problem

`lem-html-mode` uses `lem-js-mode::make-tm-patterns-js` at `html-mode.lisp:23` for JavaScript syntax highlighting within `<script>` tags:

```lisp
:patterns (lem-js-mode::make-tm-patterns-js)
```

However, the ASDF system definition was missing this dependency, causing `UNDEFINED-FUNCTION` errors when loading `lem-html-mode` without first loading `lem-js-mode`.

### Solution

Add `"lem-js-mode"` to the `:depends-on` list in `lem-html-mode.asd`.

Fixes #2044

## AI Usage Disclosure
**Did you use LLMs/AI tools for this PR?**
- [ ] No, this is 100% human-authored.
- [ ] Yes, AI-assisted (Human-led logic, AI-assisted implementation).
- [x] Yes, AI-generated (Logic primarily derived from prompt/vibe).

**Tooling Used:** Claude Code

---

## The "Human-in-the-Loop" Verification

### 1. Logic Walkthrough

1. ASDF loads dependencies before the system's own components
2. Adding `lem-js-mode` ensures `make-tm-patterns-js` is defined before `html-mode.lisp` is loaded
3. This is a minimal, isolated change with no side effects

### 2. Reviewer's Guide
- **High-risk areas:** None - simple dependency addition
- **Suggested focus for reviewer:** Verify the dependency is correct and necessary

## Test Plan
- [ ] Build Lem (`make sdl2` or `make ncurses`)
- [ ] Load `lem-html-mode` - should not produce UNDEFINED-FUNCTION errors
- [ ] Open an HTML file with `<script>` tags
- [ ] Verify JavaScript code inside `<script>` tags has syntax highlighting