### PR TITLE
skk-mode: okurigana behaviour

### DIFF
--- a/extensions/skk-mode/conversion.lisp
+++ b/extensions/skk-mode/conversion.lisp
@@ -84,7 +84,11 @@ Returns :handled if the input was consumed, NIL otherwise."
     ((and (alpha-char-p char)
           (upper-case-p char)
           (skk-henkan-mode-p state)
-          (not (skk-okurigana-consonant state)))
+          (not (skk-okurigana-consonant state))
+          ;; Okurigana start is valid only after a reading exists and
+          ;; no pending preedit remains (e.g. KiI -> き*i, but KI -> き).
+          (plusp (length (skk-henkan-key state)))
+          (zerop (length (skk-preedit state))))
      (handle-okurigana state char mode)
      :handled)
     ;; Uppercase in okurigana mode - continue okurigana input

--- a/extensions/skk-mode/skk-mode.lisp
+++ b/extensions/skk-mode/skk-mode.lisp
@@ -381,8 +381,27 @@ If in henkan mode without candidates, first try to convert, then commit."
     (cond
       ;; Has preedit - remove last char from preedit
       ((plusp (length (skk-preedit state)))
-       (setf (skk-preedit state)
-             (subseq (skk-preedit state) 0 (1- (length (skk-preedit state)))))
+       (let ((new-preedit
+               (subseq (skk-preedit state) 0 (1- (length (skk-preedit state))))))
+         (setf (skk-preedit state) new-preedit)
+         ;; If we were only holding the initial okurigana consonant (e.g. KiI),
+         ;; deleting it should leave normal henkan input instead of "き*".
+         (when (and (lem-skk-mode/state:skk-okurigana-consonant state)
+                    (zerop (length new-preedit))
+                    (zerop (length (lem-skk-mode/state:skk-okurigana-kana state))))
+           (setf (lem-skk-mode/state:skk-okurigana-consonant state) nil)))
+       (update-skk-display)
+       (update-skk-cursor))
+      ;; In okurigana mode with converted okurigana-kana
+      ((and (lem-skk-mode/state:skk-okurigana-consonant state)
+            (plusp (length (lem-skk-mode/state:skk-okurigana-kana state))))
+       (let ((okuri (lem-skk-mode/state:skk-okurigana-kana state)))
+         (setf (lem-skk-mode/state:skk-okurigana-kana state)
+               (subseq okuri 0 (1- (length okuri)))))
+       ;; If okurigana text is now empty and no preedit remains, cancel okurigana mode.
+       (when (and (zerop (length (lem-skk-mode/state:skk-okurigana-kana state)))
+                  (zerop (length (skk-preedit state))))
+         (setf (lem-skk-mode/state:skk-okurigana-consonant state) nil))
        (update-skk-display)
        (update-skk-cursor))
       ;; In henkan mode with henkan-key

--- a/extensions/skk-mode/tests/main.lisp
+++ b/extensions/skk-mode/tests/main.lisp
@@ -1364,7 +1364,7 @@ Uppercase starts henkan, Space would trigger conversion (simulated as henkan bou
         (kill-buffer buf)))))
 
 (deftest test-delete-cancels-initial-okurigana
-  (testing "KiI then delete keeps henkan-key and cancels okurigana-start"
+  (testing "KiR then delete keeps henkan-key and cancels okurigana-start"
     (with-fake-interface ()
       (let ((buf (make-buffer "*skk-delete-okurigana-test*" :temporary t)))
         (switch-to-buffer buf)
@@ -1372,13 +1372,13 @@ Uppercase starts henkan, Space would trigger conversion (simulated as henkan bou
         (let ((state (make-instance 'skk-state)))
           (setf (buffer-value buf 'lem-skk-mode/state::skk-state) state)
 
-          ;; KiI -> henkan-key: "き", okurigana starts with consonant "i".
+          ;; KiR -> henkan-key: "き", okurigana starts with consonant "r".
           (lem-skk-mode/conversion::process-skk-char #\K)
           (lem-skk-mode/conversion::process-skk-char #\i)
-          (lem-skk-mode/conversion::process-skk-char #\I)
+          (lem-skk-mode/conversion::process-skk-char #\R)
           (ok (equal (skk-henkan-key state) "き"))
-          (ok (equal (skk-okurigana-consonant state) "i"))
-          (ok (equal (skk-preedit state) "i"))
+          (ok (equal (skk-okurigana-consonant state) "r"))
+          (ok (equal (skk-preedit state) "r"))
 
           ;; DEL should cancel initial okurigana start and keep only henkan reading.
           (lem-skk-mode::skk-delete-backward)
@@ -1393,3 +1393,62 @@ Uppercase starts henkan, Space would trigger conversion (simulated as henkan bou
           (ok (equal (lem-skk-mode/display::build-preedit-display state) "▽き")
               "display should be plain henkan key without okurigana marker"))
         (kill-buffer buf)))))
+
+(deftest test-uppercase-vowel-does-not-start-okurigana
+  (testing "KI should stay normal henkan input, not okurigana-only conversion"
+    (with-fake-interface ()
+      (let ((buf (make-buffer "*skk-uppercase-vowel-test*" :temporary t)))
+        (switch-to-buffer buf)
+        (erase-buffer buf)
+        (let ((state (make-instance 'skk-state)))
+          (setf (buffer-value buf 'lem-skk-mode/state::skk-state) state)
+
+          (lem-skk-mode/conversion::process-skk-char #\K)
+          (lem-skk-mode/conversion::process-skk-char #\I)
+
+          (ok (equal (skk-henkan-key state) "き")
+              "KI should produce reading 'き'")
+          (ok (null (skk-okurigana-consonant state))
+              "uppercase vowel must not start okurigana")
+          (ok (equal (skk-okurigana-kana state) "")
+              "okurigana-kana should remain empty")
+          (ok (equal (skk-preedit state) "")
+              "preedit should be empty after KI conversion")
+          (ok (equal (lem-skk-mode/display::build-preedit-display state) "▽き")
+              "display should be normal henkan display"))
+        (kill-buffer buf)))))
+
+(deftest test-kii-equivalent-to-kii-mixed
+  (testing "KII should be handled the same as KiI"
+    (with-fake-interface ()
+      (let ((buf1 (make-buffer "*skk-kii-upper*" :temporary t))
+            (buf2 (make-buffer "*skk-kii-mixed*" :temporary t)))
+        (unwind-protect
+             (let ((state1 (make-instance 'skk-state))
+                   (state2 (make-instance 'skk-state)))
+               (switch-to-buffer buf1)
+               (erase-buffer buf1)
+               (setf (buffer-value buf1 'lem-skk-mode/state::skk-state) state1)
+               (lem-skk-mode/conversion::process-skk-char #\K)
+               (lem-skk-mode/conversion::process-skk-char #\I)
+               (lem-skk-mode/conversion::process-skk-char #\I)
+
+               (switch-to-buffer buf2)
+               (erase-buffer buf2)
+               (setf (buffer-value buf2 'lem-skk-mode/state::skk-state) state2)
+               (lem-skk-mode/conversion::process-skk-char #\K)
+               (lem-skk-mode/conversion::process-skk-char #\i)
+               (lem-skk-mode/conversion::process-skk-char #\I)
+
+               (ok (equal (skk-henkan-key state1) "き"))
+               (ok (equal (skk-henkan-key state2) "き"))
+               (ok (equal (skk-henkan-key state1) (skk-henkan-key state2))
+                   "KII and KiI should produce the same reading")
+               (ok (equal (skk-okurigana-consonant state1) "i"))
+               (ok (equal (skk-okurigana-consonant state2) "i"))
+               (ok (equal (skk-preedit state1) "i"))
+               (ok (equal (skk-preedit state2) "i"))
+               (ok (equal (lem-skk-mode/display::build-preedit-display state1) "▽き*i"))
+               (ok (equal (lem-skk-mode/display::build-preedit-display state2) "▽き*i")))
+          (kill-buffer buf1)
+          (kill-buffer buf2))))))

--- a/extensions/skk-mode/tests/main.lisp
+++ b/extensions/skk-mode/tests/main.lisp
@@ -1362,3 +1362,34 @@ Uppercase starts henkan, Space would trigger conversion (simulated as henkan bou
             (delete-point (skk-henkan-start state))))
 
         (kill-buffer buf)))))
+
+(deftest test-delete-cancels-initial-okurigana
+  (testing "KiI then delete keeps henkan-key and cancels okurigana-start"
+    (with-fake-interface ()
+      (let ((buf (make-buffer "*skk-delete-okurigana-test*" :temporary t)))
+        (switch-to-buffer buf)
+        (erase-buffer buf)
+        (let ((state (make-instance 'skk-state)))
+          (setf (buffer-value buf 'lem-skk-mode/state::skk-state) state)
+
+          ;; KiI -> henkan-key: "き", okurigana starts with consonant "i".
+          (lem-skk-mode/conversion::process-skk-char #\K)
+          (lem-skk-mode/conversion::process-skk-char #\i)
+          (lem-skk-mode/conversion::process-skk-char #\I)
+          (ok (equal (skk-henkan-key state) "き"))
+          (ok (equal (skk-okurigana-consonant state) "i"))
+          (ok (equal (skk-preedit state) "i"))
+
+          ;; DEL should cancel initial okurigana start and keep only henkan reading.
+          (lem-skk-mode::skk-delete-backward)
+          (ok (equal (skk-henkan-key state) "き")
+              "henkan-key should stay as 'き'")
+          (ok (null (skk-okurigana-consonant state))
+              "okurigana start should be canceled")
+          (ok (equal (skk-okurigana-kana state) "")
+              "okurigana-kana should be empty")
+          (ok (equal (skk-preedit state) "")
+              "preedit should be empty after delete")
+          (ok (equal (lem-skk-mode/display::build-preedit-display state) "▽き")
+              "display should be plain henkan key without okurigana marker"))
+        (kill-buffer buf)))))


### PR DESCRIPTION
## Summary

This PR includes the last two commits and fixes SKK state transitions around okurigana and backspace behavior.
Note that I use AI to write the code. Thanks.

## What Changed

- Fixed skk-delete-backward so deleting during early okurigana state restores expected henkan state instead of leaving inconsistent marker/preedit state.
- Refined uppercase/okurigana start conditions:
    - okurigana start happens only after a reading segment exists and preedit is empty.
- Added regression tests covering:
    - delete behavior after starting okurigana,
    - uppercase vowel behavior,
    - KII vs KiI consistency.

## Examples

- `KI`
    - Before: could incorrectly enter okurigana flow in some paths
    - After: stays normal henkan reading (`▽き`)
- `KiI` / `KII`
    - After: both are treated consistently and show `▽き*i`
- `KiR<DEL>`
    - After: delete cancels initial okurigana-start cleanly and returns to plain henkan reading
      (`▽き`)

## Validation

- Ran asdf:test-system "lem-skk-mode/tests" in Nix dev shell.
- Tests pass.