### PR TITLE
The function `completion-symbol-async` always calls the `then` that is passed to it.

### DIFF
--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -856,26 +856,27 @@
 (defun completion-symbol-async (point then)
   (check-connection)
   (let ((string (symbol-string-at-point point)))
-    (when string
-      (remote-eval-from-string
-       (current-connection)
-       (lem-lisp-mode/completion:make-completions-form-string string (current-package))
-       :continuation (lambda (result)
-                       (alexandria:destructuring-ecase result
-                         ((:ok completions)
-                          (with-point ((start (current-point))
-                                       (end (current-point)))
-                            (skip-symbol-backward start)
-                            (skip-symbol-forward end)
-                            (funcall then
-                                     (lem-lisp-mode/completion:make-completion-items
-                                      completions
-                                      start
-                                      end))))
-                         ((:abort condition)
-                          (editor-error "abort ~A" condition))))
-       :thread (current-micros-thread)
-       :package (current-package)))))
+    (if string
+        (remote-eval-from-string
+         (current-connection)
+         (lem-lisp-mode/completion:make-completions-form-string string (current-package))
+         :continuation (lambda (result)
+                         (alexandria:destructuring-ecase result
+                           ((:ok completions)
+                            (with-point ((start (current-point))
+                                         (end (current-point)))
+                              (skip-symbol-backward start)
+                              (skip-symbol-forward end)
+                              (funcall then
+                                       (lem-lisp-mode/completion:make-completion-items
+                                        completions
+                                        start
+                                        end))))
+                           ((:abort condition)
+                            (editor-error "abort ~A" condition))))
+         :thread (current-micros-thread)
+         :package (current-package))
+        (funcall then '()))))
 
 (defun describe-symbol (symbol-name)
   (when symbol-name


### PR DESCRIPTION
When the cursor was at a position where the function `lem/buffer/internal:symbol-string-at-point` would return `nil`, such as immediately after a closing parenthesis, calling `indent-line-and-complete-symbol` in `lisp-mode` caused an issue where completion candidates were not passed to the callback, and the spinner did not disappear.

Therefore, we changed `completion-symbol-async` to always call `then`.