### PR TITLE
use uiop:parse-native-namestring instead of pathname

### DIFF
--- a/frontends/server/main.lisp
+++ b/frontends/server/main.lisp
@@ -62,7 +62,7 @@
                                                "frontend/dist/~A"
                                                (string-left-trim "/" path)))))
             ((alexandria:starts-with-subseq "/local/" path)
-             (let* ((file (pathname (subseq path (length "/local"))))
+             (let* ((file (uiop:parse-native-namestring (subseq path (length "/local"))))
                     (mime-type (hunchentoot:mime-type file)))
                `(200 (:content-type ,mime-type)
                      ,file)))


### PR DESCRIPTION
using `pathname` was causing errors when i tried to serve a file and view it from the webview client because the file had special characters (specifically it had `[` and it caused issues). the function `uiop:parse-native-namestring` knows to handle arbitrary chars in the filepath.