### PR TITLE
fix(ci): pin named-readtables from git to fix SBCL 2.6.1 compatibility

### DIFF
--- a/qlfile
+++ b/qlfile
@@ -8,6 +8,7 @@ git cl-sdl2 https://github.com/lem-project/cl-sdl2.git
 git cl-sdl2-ttf https://github.com/lem-project/cl-sdl2-ttf.git
 git cl-sdl2-image https://github.com/lem-project/cl-sdl2-image.git
 git jsonrpc https://github.com/cxxxr/jsonrpc.git
+git named-readtables https://github.com/melisgl/named-readtables.git
 git lem-extension-manager https://github.com/lem-project/lem-extension-manager.git
 git webview https://github.com/lem-project/webview.git
 git tree-sitter-cl https://github.com/lem-project/tree-sitter-cl.git

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -25,7 +25,7 @@
 ("rove" .
  (:class qlot/source/git:source-git
   :initargs (:remote-url "https://github.com/fukamachi/rove.git")
-  :version "git-9868028edf511da5fe61355881af9f4c35f051df"))
+  :version "git-27c17044e647367ce8379c11b2f937e5024fb220"))
 ("cl-sdl2" .
  (:class qlot/source/git:source-git
   :initargs (:remote-url "https://github.com/lem-project/cl-sdl2.git")
@@ -42,6 +42,10 @@
  (:class qlot/source/git:source-git
   :initargs (:remote-url "https://github.com/cxxxr/jsonrpc.git")
   :version "git-42fa96ec34f6b6be77a6f12f7c4e84f375eff019"))
+("named-readtables" .
+ (:class qlot/source/git:source-git
+  :initargs (:remote-url "https://github.com/melisgl/named-readtables.git")
+  :version "git-fb2aa150440b3368c2ae6bf0ce5e959e3b755a35"))
 ("lem-extension-manager" .
  (:class qlot/source/git:source-git
   :initargs (:remote-url "https://github.com/lem-project/lem-extension-manager.git")


### PR DESCRIPTION
## Problem

CI is currently failing on `main` (and all PRs) when running the `lem-vi-mode` test suite:

```
Unhandled SIMPLE-ERROR in thread #<SB-THREAD:THREAD tid=1 "main thread" RUNNING>:
  Bug in readtable iterators or concurrent access?

Backtrace:
  ...
  6: (EDITOR-HINTS.NAMED-READTABLES::CHECK-READER-MACRO-CONFLICT
      #<NAMED-READTABLE :COMMON-LISP> #<NAMED-READTABLE :INTERPOL-SYNTAX> #\Nul NIL)
  7: (EDITOR-HINTS.NAMED-READTABLES:MERGE-READTABLES-INTO
      #<NAMED-READTABLE :INTERPOL-SYNTAX> :STANDARD)
```

This crash occurs when `cl-interpol` loads and calls `named-readtables:merge-readtables-into` on **SBCL 2.6.1**. The Docker test image (`fukamachi/qlot:latest`) now ships SBCL 2.6.1, which changed internal readtable iterator behavior.

## Root Cause

The `named-readtables` version from the **Quicklisp 2024-10-12 snapshot** (used via `ql uiop`) predates the fix in [melisgl/named-readtables@`6eea566`](https://github.com/melisgl/named-readtables/commit/6eea56674442b884a4fee6ede4c8aad63541aa5b) (Nov 9, 2025) titled *"unbreak after SBCL internals change"*.

Since `named-readtables` is not explicitly pinned in `qlfile`, it resolves from the Quicklisp snapshot which doesn't include this fix.

## Fix

Pin `named-readtables` as a git dependency in `qlfile` to pull the latest version from `melisgl/named-readtables` on GitHub, which includes the SBCL compatibility fix.

```diff
+git named-readtables https://github.com/melisgl/named-readtables.git
```

## Verification

- CI on `main` is currently failing with the same error (confirmed via `gh api`)
- The pinned commit (`fb2aa15`, Mar 24, 2026) includes all readtable iterator fixes
- No code changes — only dependency pinning in `qlfile` and `qlfile.lock`