### PR TITLE
[webview] Fix height of tab bar for macOS

### DIFF
--- a/frontends/server/tabbar.lisp
+++ b/frontends/server/tabbar.lisp
@@ -85,6 +85,7 @@ html, body {
     linear-gradient(180deg, #1c1c1c, var(--bg)) /* subtle top gradient */;
   border-bottom: 1px solid var(--border);
   overflow-x: auto;         /* horizontal scroll for multiple tabs */
+  overflow-y: hidden;        /* prevent vertical scroll */
   white-space: nowrap;      /* no line wrap */
   scrollbar-width: none;    /* Firefox: hide scrollbar */
   position: relative;

--- a/frontends/server/tabbar.lisp
+++ b/frontends/server/tabbar.lisp
@@ -27,6 +27,9 @@
    (buffer-list
     :accessor tabbar-window-buffer-list)))
 
+(defmethod header-window-height ((window tabbar-window))
+  2)
+
 (defvar *tabbar* nil)
 
 (defun tabbar-init ()

--- a/src/frame.lisp
+++ b/src/frame.lisp
@@ -180,6 +180,8 @@ redraw-display関数でキャッシュを捨てて画面全体を再描画しま
 
 
 (defun topleft-window-y (frame)
+  "Return the Y coordinate where the topmost editor window begins.
+This is the sum of all header window heights in FRAME."
   (loop :for w :in (frame-header-windows frame)
         :sum (header-window-height w)))
 

--- a/src/frame.lisp
+++ b/src/frame.lisp
@@ -180,9 +180,8 @@ redraw-display関数でキャッシュを捨てて画面全体を再描画しま
 
 
 (defun topleft-window-y (frame)
-  (reduce #'+ (frame-header-windows frame)
-          :key #'header-window-height
-          :initial-value 0))
+  (loop :for w :in (frame-header-windows frame)
+        :sum (header-window-height w)))
 
 (defun topleft-window-x (frame)
   (if (null (frame-leftside-window frame))

--- a/src/frame.lisp
+++ b/src/frame.lisp
@@ -180,7 +180,9 @@ redraw-display関数でキャッシュを捨てて画面全体を再描画しま
 
 
 (defun topleft-window-y (frame)
-  (length (frame-header-windows frame)))
+  (reduce #'+ (frame-header-windows frame)
+          :key #'header-window-height
+          :initial-value 0))
 
 (defun topleft-window-x (frame)
   (if (null (frame-leftside-window frame))

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -377,6 +377,7 @@
   ;; header-window.lisp
   (:export
    :header-window
+   :header-window-height
    :header-window-p)
   ;; side-window.lisp
   (:export

--- a/src/window/header-window.lisp
+++ b/src/window/header-window.lisp
@@ -2,12 +2,20 @@
 
 (defclass header-window (window) ())
 
+(defgeneric header-window-height (window)
+  (:documentation "Return the preferred height in character cells for a header window.
+Subclasses can specialize this to request more vertical space.")
+  (:method ((window header-window))
+    1))
+
 (defmethod initialize-instance ((window header-window) &key &allow-other-keys)
   (with-slots (x y width height) window
     (setf x 0)
-    (setf y (length (frame-header-windows (current-frame))))
+    (setf y (reduce #'+ (frame-header-windows (current-frame))
+                    :key #'header-window-height
+                    :initial-value 0))
     (setf width (display-width))
-    (setf height 1))
+    (setf height (header-window-height window)))
   (add-header-window (current-frame) window)
   (notify-header-window-modified (current-frame))
   (call-next-method))

--- a/src/window/header-window.lisp
+++ b/src/window/header-window.lisp
@@ -11,9 +11,8 @@ Subclasses can specialize this to request more vertical space.")
 (defmethod initialize-instance ((window header-window) &key &allow-other-keys)
   (with-slots (x y width height) window
     (setf x 0)
-    (setf y (reduce #'+ (frame-header-windows (current-frame))
-                    :key #'header-window-height
-                    :initial-value 0))
+    (setf y (loop :for w :in (frame-header-windows (current-frame))
+                  :sum (header-window-height w)))
     (setf width (display-width))
     (setf height (header-window-height window)))
   (add-header-window (current-frame) window)

--- a/src/window/window.lisp
+++ b/src/window/window.lisp
@@ -1043,6 +1043,8 @@ You can pass in the optional argument WINDOW-LIST to replace the default
 
 ;;;
 (defun adjust-all-window-size ()
+  "Resize all windows to fit the current display dimensions.
+Each header window is set to full display width and its preferred height."
   (dolist (window (frame-header-windows (current-frame)))
     (window-set-size window (display-width) (header-window-height window)))
   (alexandria:when-let (window (frame-rightside-window (current-frame)))

--- a/src/window/window.lisp
+++ b/src/window/window.lisp
@@ -1044,7 +1044,7 @@ You can pass in the optional argument WINDOW-LIST to replace the default
 ;;;
 (defun adjust-all-window-size ()
   (dolist (window (frame-header-windows (current-frame)))
-    (window-set-size window (display-width) 1))
+    (window-set-size window (display-width) (header-window-height window)))
   (alexandria:when-let (window (frame-rightside-window (current-frame)))
     (resize-rightside-window window))
   (balance-windows))


### PR DESCRIPTION
# Summary

Header windows were previously hardcoded to a height of 1 character cell. This PR introduces a `header-window-height` generic function that subclasses can specialize to request more vertical space, and updates all layout calculations to respect it.

# Motivation

The server frontend's tabbar needs more than a single row to render properly (e.g., taller tab styling, padding). With a fixed height of 1, there was no way for a header window subclass to claim additional space without breaking the layout of editor windows below it.

Before:
<img width="461" height="359" alt="Screenshot 2026-04-13 at 19 29 45" src="https://github.com/user-attachments/assets/772281c4-b1a4-4623-ad37-b42ff72322cc" />
After:
<img width="445" height="340" alt="Screenshot 2026-04-13 at 19 24 03" src="https://github.com/user-attachments/assets/530c0814-57b2-41c7-ba2a-0c1ccdaae539" />

# Changes

Core (4 files):

- `header-window.lisp` — Add `defgeneric header-window-height` with a default method returning 1. Update `initialize-instance` to compute the y-position by summing existing header heights (using `loop :sum`) and to set height from the generic.
- `internal-packages.lisp` — Export `:header-window-height`.
- `frame.lisp` — `topleft-window-y` now sums header heights with `loop :sum` instead of `length`.
- `window.lisp` — `adjust-all-window-size` passes `(header-window-height window)` instead of 1.

Server frontend (1 file):

- `tabbar.lisp` — Specialize `header-window-height` to 2 for `tabbar-window`. Add `overflow-y: hidden` to prevent vertical scroll in the tab container.

### Backward compatibility

The default method returns 1, so all existing header window subclasses behave identically without changes.

### Style

Height summation uses `loop :for w :in ... :sum` per `contract.yml` `loop_keywords_rule`.