### PR TITLE
Fix vi-mode cursor entering read-only prompt area in REPL

### DIFF
--- a/extensions/vi-mode/commands/utils.lisp
+++ b/extensions/vi-mode/commands/utils.lisp
@@ -39,6 +39,7 @@
   (:export :bolp
            :eolp
            :fall-within-line
+           :fall-within-field
            :operator-pending-mode-p
            :read-universal-argument
            :*cursor-offset*
@@ -65,6 +66,11 @@
     (line-end point)
     (unless (bolp point)
       (character-offset point *cursor-offset*))))
+
+(defun fall-within-field (point)
+  "If POINT is within a :field region, move it past the field boundary."
+  (when (text-property-at point :field)
+    (next-single-property-change point :field)))
 
 (defun operator-pending-mode-p ()
   (typep (current-state) 'operator))

--- a/extensions/vi-mode/vi-mode.lisp
+++ b/extensions/vi-mode/vi-mode.lisp
@@ -12,6 +12,7 @@
                 :vi-open-above)
   (:import-from :lem-vi-mode/commands/utils
                 :fall-within-line
+                :fall-within-field
                 :define-motion
                 :define-operator
                 :define-text-object-command)
@@ -64,6 +65,7 @@
                  (eq (vi-command-repeat command) t))
         (setf *last-repeat-keys* (vi-this-command-keys)))))
   (adjust-window-scroll)
+  (fall-within-field (current-point))
   (fall-within-line (current-point)))
 
 (defmethod post-command-hook ((state insert))


### PR DESCRIPTION
## Problem

In listener-mode (REPL) with vi-mode enabled, switching from insert mode to normal mode allows the cursor to move into the read-only prompt region via backward movement commands (`h`, `b`, `0`, etc.). The prompt is marked with `:field` and `:read-only` text properties, but vi normal mode cursor movements don't respect the field boundary.

## Fix

Add `fall-within-field` in `commands/utils.lisp` — analogous to the existing `fall-within-line` which clamps the cursor at end-of-line. When the cursor lands within a `:field` region, it is moved past the field boundary via `next-single-property-change`.

This is called from the normal mode `post-command-hook` (before `fall-within-line`), so it applies after every command.

Navigation to previous lines (viewing REPL history) remains unaffected — only field regions on the current line are clamped.

## Changes

- `extensions/vi-mode/commands/utils.lisp`: Add `fall-within-field` function and export it
- `extensions/vi-mode/vi-mode.lisp`: Call `fall-within-field` in normal mode `post-command-hook`