### PR TITLE
[BUGFIX] Fix cursor entering read-only prompt area in listener-mode

### DIFF
--- a/lem-tests.asd
+++ b/lem-tests.asd
@@ -74,6 +74,7 @@
                (:file "command-line-arguments")
                (:file "window")
                (:file "legit")
-               (:file "filer"))
+               (:file "filer")
+               (:file "listener-mode"))
   :perform (test-op (o c)
                     (symbol-call :rove :run c)))

--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -9,6 +9,7 @@
    :listener-start
    :change-input-start-point
    :refresh-prompt
+   :clamp-cursor-to-input-area
    :clear-listener-using-mode
    :clear-listener
    ;; editor variables
@@ -70,11 +71,22 @@
     (add-hook (variable-value 'kill-buffer-hook :buffer (current-buffer))
               'save-history))
   (add-hook *exit-editor-hook* 'save-all-histories)
+  (add-hook *post-command-hook* 'clamp-cursor-to-input-area)
   (unless (input-start-point (current-buffer))
     (change-input-start-point (current-point))))
 
 (defun listener-buffer-p (buffer)
   (mode-active-p buffer 'listener-mode))
+
+(defun clamp-cursor-to-input-area ()
+  "Prevent the cursor from entering the read-only prompt region."
+  (let* ((buffer (current-buffer))
+         (start (input-start-point buffer)))
+    (when (and start
+               (listener-buffer-p buffer)
+               (same-line-p (current-point) start)
+               (point< (current-point) start))
+      (move-point (current-point) start))))
 
 (defun save-history (buffer)
   (assert (listener-buffer-p buffer))

--- a/tests/listener-mode.lisp
+++ b/tests/listener-mode.lisp
@@ -1,0 +1,62 @@
+(defpackage :lem-tests/listener-mode
+  (:use :cl
+        :rove
+        :lem)
+  (:import-from :lem-fake-interface
+                :with-fake-interface)
+  (:import-from :lem/listener-mode
+                :listener-mode
+                :input-start-point
+                :listener-set-prompt-function
+                :listener-check-input-function
+                :listener-execute-function
+                :start-listener-mode
+                :refresh-prompt
+                :clamp-cursor-to-input-area))
+(in-package :lem-tests/listener-mode)
+
+(defun setup-listener-buffer ()
+  "Create a buffer with listener-mode and a simple prompt."
+  (let ((buffer (make-buffer "listener-test")))
+    (setf (current-buffer) buffer)
+    (setf (variable-value 'listener-set-prompt-function :buffer buffer)
+          (lambda (point)
+            (insert-string point "> ")))
+    (setf (variable-value 'listener-check-input-function :buffer buffer)
+          (lambda (point) (declare (ignore point)) t))
+    (setf (variable-value 'listener-execute-function :buffer buffer)
+          (lambda (point string) (declare (ignore point string))))
+    (start-listener-mode)
+    (refresh-prompt buffer)
+    buffer))
+
+(deftest clamp-cursor-to-input-area
+  (with-fake-interface ()
+    (with-current-buffers ()
+      (let ((buffer (setup-listener-buffer)))
+        (testing "cursor at input-start-point is not moved"
+          (move-point (current-point) (input-start-point buffer))
+          (lem/listener-mode:clamp-cursor-to-input-area)
+          (ok (point= (current-point) (input-start-point buffer))))
+
+        (testing "cursor before input-start-point on same line is clamped"
+          (line-start (current-point))
+          (ok (point< (current-point) (input-start-point buffer)))
+          (lem/listener-mode:clamp-cursor-to-input-area)
+          (ok (point= (current-point) (input-start-point buffer))))
+
+        (testing "cursor after input-start-point is not moved"
+          (buffer-end (current-point))
+          (insert-string (current-point) "hello")
+          (let ((pos (copy-point (current-point) :temporary)))
+            (lem/listener-mode:clamp-cursor-to-input-area)
+            (ok (point= (current-point) pos))))
+
+        (testing "cursor on previous line is not clamped"
+          ;; Add a newline in the input area so cursor can go to a previous line
+          (move-point (current-point) (input-start-point buffer))
+          (character-offset (current-point) -1)
+          ;; cursor is now on a line before input-start-point's line
+          (unless (same-line-p (current-point) (input-start-point buffer))
+            (lem/listener-mode:clamp-cursor-to-input-area)
+            (ok (not (point= (current-point) (input-start-point buffer))))))))))


### PR DESCRIPTION
## Problem

In listener-mode (REPL), backward movement commands can move the cursor into the read-only prompt region on the current input line. This affects any editing mode — vi-mode (`h`, `b`, `0`), emacs-mode (`C-b`), etc.

## Fix

Add `clamp-cursor-to-input-area` as a `*post-command-hook*` in `listener-mode`. After every command, if the cursor is on the same line as `input-start-point` but before it, the cursor is moved forward to the input start. Navigation to previous lines (scrolling through history) is unaffected.

## Changes

- `src/ext/listener-mode.lisp`: Add `clamp-cursor-to-input-area` function, register it via `*post-command-hook*` in `start-listener-mode`
- `tests/listener-mode.lisp`: New test file with unit tests for cursor clamping behavior
- `lem-tests.asd`: Register new test file