### PR TITLE
Fix recursive redraw crash when loading color theme

### DIFF
--- a/frontends/server/tabbar.lisp
+++ b/frontends/server/tabbar.lisp
@@ -54,7 +54,10 @@
       (message "~A" e))))
 
 (defun generate-html ()
-  (let ((editor-bg (lem:color-to-hex-string (lem:parse-color (lem:background-color)))))
+  (let ((editor-bg (let ((bg (lem:background-color)))
+                    (if bg
+                        (lem:color-to-hex-string (lem:parse-color bg))
+                        "#2d2d2d"))))
     (with-output-to-string (out)
     (format out "<head>")
     (format out "<style>

--- a/src/color-theme.lisp
+++ b/src/color-theme.lisp
@@ -96,9 +96,9 @@ for example, to maintain an attribute like CURSOR.")
     (unless theme
       (editor-error "undefined color theme: ~A" name))
     (apply-theme theme)
+    (setf (current-theme) name)
     (message nil)
     (redraw-display :force t)
-    (setf (current-theme) name)
     (when save-theme
       (setf (config :color-theme) (current-theme))))
   (run-hooks *after-load-theme-hook*))


### PR DESCRIPTION
## Problem

`load-theme` called `redraw-display` **before** setting `current-theme`. During that redraw, the tabbar's `generate-html` called `(background-color)`, which returned `NIL` because `current-theme` was unset. Then `(color-to-hex-string (parse-color nil))` crashed.

The crash was silently swallowed by `with-error-handler`, but the error handler itself called `redraw-display` to show a backtrace — hitting the same crash recursively. The initial redraw never completed, leaving the screen blank.

## Fix

**`src/color-theme.lisp`**: Move `(setf (current-theme) name)` before `(redraw-display :force t)` so that `background-color` can look up the theme during redraw.

**`frontends/server/tabbar.lisp`**: Guard `generate-html` against a `NIL` return from `(background-color)`, falling back to a default color. This prevents the recursive crash even if a theme lacks a `:background` spec.