### PR TITLE
Add lem-if:set-frame-color protocol and macOS webview implementation

### DIFF
--- a/frontends/server/color-picker.lisp
+++ b/frontends/server/color-picker.lisp
@@ -48,7 +48,7 @@ update();
     (add-hook *editor-abort-hook*
               'delete-color-picker-window)))
 
-(defmethod lem-color-preview:invoke-color-picker ((frontend lem-server::jsonrpc) callback)
+(defmethod lem-color-preview:invoke-color-picker ((frontend lem-server:jsonrpc) callback)
   (setf *callback* callback)
   (make-color-picker-window))
 

--- a/frontends/server/main.lisp
+++ b/frontends/server/main.lisp
@@ -5,7 +5,8 @@
   (:local-nicknames (:display :lem-core/display)
                     (:queue :lem/common/queue)
                     (:mouse :lem-server/mouse))
-  (:export :register-method
+  (:export :jsonrpc
+           :register-method
            :run-tcp-server
            :run-stdio-server
            :run-websocket-server

--- a/frontends/webview/darwin.lisp
+++ b/frontends/webview/darwin.lisp
@@ -1,0 +1,68 @@
+(in-package :lem-webview)
+
+;;; macOS window appearance via Objective-C runtime
+;;;
+;;; Uses objc_msgSend to set NSAppearance on the NSWindow returned by
+;;; webview_get_window. This controls the window frame (titlebar, traffic
+;;; lights) color independent of the HTML content rendering.
+
+#+darwin
+(progn
+
+(cffi:define-foreign-library libobjc
+  (:os-macosx "libobjc.dylib"))
+
+(cffi:use-foreign-library libobjc)
+
+(cffi:defcfun ("objc_getClass" objc-get-class) :pointer
+  (name :string))
+
+(cffi:defcfun ("sel_registerName" sel-register-name) :pointer
+  (name :string))
+
+;; Fixed-arity objc_msgSend wrappers — avoids ARM64 variadic ABI issues.
+;; objc_msgSend is not truly variadic; it uses the callee's ABI, so we
+;; must declare the exact parameter types.
+
+(cffi:defcfun ("objc_msgSend" objc-msg-send/ptr) :pointer
+  (self :pointer)
+  (sel :pointer)
+  (arg :pointer))
+
+(cffi:defcfun ("objc_msgSend" objc-msg-send/str) :pointer
+  (self :pointer)
+  (sel :pointer)
+  (arg :string))
+
+(defun set-window-appearance (webview-handle mode)
+  "Set the macOS window frame appearance for WEBVIEW-HANDLE.
+MODE should be :dark or :light."
+  (let ((nswindow (webview:webview-get-window webview-handle)))
+    (when (cffi:null-pointer-p nswindow)
+      (return-from set-window-appearance nil))
+    (let* ((appearance-name (ecase mode
+                              (:dark "NSAppearanceNameDarkAqua")
+                              (:light "NSAppearanceNameAqua")))
+           (ns-appearance-class (objc-get-class "NSAppearance"))
+           (ns-name (objc-msg-send/str
+                     (objc-get-class "NSString")
+                     (sel-register-name "stringWithUTF8String:")
+                     appearance-name))
+           (appearance (objc-msg-send/ptr
+                        ns-appearance-class
+                        (sel-register-name "appearanceNamed:")
+                        ns-name)))
+      (when (cffi:null-pointer-p appearance)
+        (return-from set-window-appearance nil))
+      (objc-msg-send/ptr nswindow
+                         (sel-register-name "setAppearance:")
+                         appearance)
+      mode)))
+
+) ; end #+darwin progn
+
+#-darwin
+(defun set-window-appearance (webview-handle mode)
+  "No-op: window appearance is only supported on macOS."
+  (declare (ignore webview-handle mode))
+  nil)

--- a/frontends/webview/darwin.lisp
+++ b/frontends/webview/darwin.lisp
@@ -1,6 +1,8 @@
-;;; Package :lem-webview is defined in main.lisp; this file is loaded
-;;; after it via :serial t in lem-webview.asd.
-(in-package :lem-webview)
+(defpackage :lem-webview/darwin
+  (:use :cl)
+  (:export :set-window-appearance
+           :dispatch-set-window-appearance))
+(in-package :lem-webview/darwin)
 
 ;;; macOS window appearance via Objective-C runtime
 ;;;

--- a/frontends/webview/darwin.lisp
+++ b/frontends/webview/darwin.lisp
@@ -4,9 +4,10 @@
 
 ;;; macOS window appearance via Objective-C runtime
 ;;;
-;;; Uses objc_msgSend to set NSAppearance on the NSWindow returned by
-;;; webview_get_window. This controls the window frame (titlebar, traffic
-;;; lights) color independent of the HTML content rendering.
+;;; Uses objc_msgSend to set NSAppearance on the key window.
+;;; set-window-appearance takes a webview handle (for pre-event-loop use).
+;;; dispatch-set-window-appearance uses GCD + [NSApp keyWindow] so the
+;;; editor thread can change appearance without holding a native handle.
 
 #+darwin
 (progn
@@ -26,6 +27,10 @@
 ;; objc_msgSend is not truly variadic; it uses the callee's ABI, so we
 ;; must declare the exact parameter types.
 
+(cffi:defcfun ("objc_msgSend" objc-msg-send/no-arg) :pointer
+  (self :pointer)
+  (sel :pointer))
+
 (cffi:defcfun ("objc_msgSend" objc-msg-send/ptr) :pointer
   (self :pointer)
   (sel :pointer)
@@ -36,56 +41,73 @@
   (sel :pointer)
   (arg :string))
 
-(defun %apply-window-appearance (webview-handle mode)
-  "Apply appearance MODE (:dark or :light) to the window.
+;; Grand Central Dispatch — dispatch work to the main thread without
+;; needing a webview handle.
+(cffi:defcfun ("dispatch_async_f" dispatch-async-f) :void
+  (queue :pointer)
+  (context :pointer)
+  (work :pointer))
+
+(defun main-dispatch-queue ()
+  "Return the main dispatch queue (dispatch_get_main_queue)."
+  (cffi:foreign-symbol-pointer "_dispatch_main_q"))
+
+(defun %get-key-window ()
+  "Return the NSWindow that is the current key window, or a null pointer."
+  (let* ((nsapp (objc-msg-send/no-arg
+                 (objc-get-class "NSApplication")
+                 (sel-register-name "sharedApplication")))
+         (window (objc-msg-send/no-arg nsapp (sel-register-name "keyWindow"))))
+    window))
+
+(defun %set-nswindow-appearance (nswindow mode)
+  "Set NSAppearance on NSWINDOW to MODE (:dark or :light).
 Must be called on the main thread."
-  (let ((nswindow (webview:webview-get-window webview-handle)))
-    (when (cffi:null-pointer-p nswindow)
-      (return-from %apply-window-appearance nil))
-    (let* ((appearance-name (ecase mode
-                              (:dark "NSAppearanceNameDarkAqua")
-                              (:light "NSAppearanceNameAqua")))
-           (ns-appearance-class (objc-get-class "NSAppearance"))
-           (ns-name (objc-msg-send/str
-                     (objc-get-class "NSString")
-                     (sel-register-name "stringWithUTF8String:")
-                     appearance-name))
-           (appearance (objc-msg-send/ptr
-                        ns-appearance-class
-                        (sel-register-name "appearanceNamed:")
-                        ns-name)))
-      (when (cffi:null-pointer-p appearance)
-        (return-from %apply-window-appearance nil))
-      (objc-msg-send/ptr nswindow
-                         (sel-register-name "setAppearance:")
-                         appearance)
-      mode)))
+  (when (or (null nswindow) (cffi:null-pointer-p nswindow))
+    (return-from %set-nswindow-appearance nil))
+  (let* ((appearance-name (ecase mode
+                            (:dark "NSAppearanceNameDarkAqua")
+                            (:light "NSAppearanceNameAqua")))
+         (ns-appearance-class (objc-get-class "NSAppearance"))
+         (ns-name (objc-msg-send/str
+                   (objc-get-class "NSString")
+                   (sel-register-name "stringWithUTF8String:")
+                   appearance-name))
+         (appearance (objc-msg-send/ptr
+                      ns-appearance-class
+                      (sel-register-name "appearanceNamed:")
+                      ns-name)))
+    (when (cffi:null-pointer-p appearance)
+      (return-from %set-nswindow-appearance nil))
+    (objc-msg-send/ptr nswindow
+                       (sel-register-name "setAppearance:")
+                       appearance)
+    mode))
 
-(cffi:defcallback dispatch-set-dark-appearance :void
-    ((webview-handle :pointer) (arg :pointer))
-  (declare (ignore arg))
-  (%apply-window-appearance webview-handle :dark))
+;; GCD callbacks — dispatch_async_f signature: void (*)(void *)
+(cffi:defcallback gcd-set-dark-appearance :void ((context :pointer))
+  (declare (ignore context))
+  (%set-nswindow-appearance (%get-key-window) :dark))
 
-(cffi:defcallback dispatch-set-light-appearance :void
-    ((webview-handle :pointer) (arg :pointer))
-  (declare (ignore arg))
-  (%apply-window-appearance webview-handle :light))
+(cffi:defcallback gcd-set-light-appearance :void ((context :pointer))
+  (declare (ignore context))
+  (%set-nswindow-appearance (%get-key-window) :light))
 
 (defun set-window-appearance (webview-handle mode)
   "Set the macOS window frame appearance for WEBVIEW-HANDLE.
 MODE should be :dark or :light. Called before the event loop starts,
-so it runs directly on the main thread."
-  (%apply-window-appearance webview-handle mode))
+so it runs directly on the main thread with the handle available."
+  (%set-nswindow-appearance (webview:webview-get-window webview-handle) mode))
 
-(defun dispatch-set-window-appearance (webview-handle mode)
-  "Set the macOS window frame appearance via webview_dispatch.
-Use this when the event loop is already running to ensure the
-Cocoa API calls execute on the main thread."
-  (webview:webview-dispatch webview-handle
-                            (ecase mode
-                              (:dark (cffi:callback dispatch-set-dark-appearance))
-                              (:light (cffi:callback dispatch-set-light-appearance)))
-                            (cffi:null-pointer))
+(defun dispatch-set-window-appearance (mode)
+  "Set the macOS window frame appearance via GCD main queue dispatch.
+Uses [NSApp keyWindow] to find the window, so no webview handle is needed.
+Safe to call from any thread."
+  (dispatch-async-f (main-dispatch-queue)
+                    (cffi:null-pointer)
+                    (ecase mode
+                      (:dark (cffi:callback gcd-set-dark-appearance))
+                      (:light (cffi:callback gcd-set-light-appearance))))
   mode)
 
 ) ; end #+darwin progn
@@ -96,8 +118,8 @@ Cocoa API calls execute on the main thread."
   "No-op: window appearance is only supported on macOS."
   (declare (ignore webview-handle mode))
   nil)
-(defun dispatch-set-window-appearance (webview-handle mode)
+(defun dispatch-set-window-appearance (mode)
   "No-op: window appearance is only supported on macOS."
-  (declare (ignore webview-handle mode))
+  (declare (ignore mode))
   nil)
 )

--- a/frontends/webview/darwin.lisp
+++ b/frontends/webview/darwin.lisp
@@ -9,6 +9,10 @@
 #+darwin
 (progn
 
+;; The C callback for webview_dispatch has a fixed signature (handle, arg),
+;; so we use a dynamic variable to pass the desired appearance mode.
+(defvar *pending-appearance-mode* :dark)
+
 (cffi:define-foreign-library libobjc
   (:os-macosx "libobjc.dylib"))
 
@@ -34,12 +38,16 @@
   (sel :pointer)
   (arg :string))
 
-(defun %apply-appearance (webview-handle appearance-name)
-  "Apply the named appearance to the window. Must be called on the main thread."
+(defun %apply-window-appearance (webview-handle)
+  "Apply the appearance in *pending-appearance-mode* to the window.
+Must be called on the main thread."
   (let ((nswindow (webview:webview-get-window webview-handle)))
     (when (cffi:null-pointer-p nswindow)
-      (return-from %apply-appearance nil))
-    (let* ((ns-appearance-class (objc-get-class "NSAppearance"))
+      (return-from %apply-window-appearance nil))
+    (let* ((appearance-name (ecase *pending-appearance-mode*
+                              (:dark "NSAppearanceNameDarkAqua")
+                              (:light "NSAppearanceNameAqua")))
+           (ns-appearance-class (objc-get-class "NSAppearance"))
            (ns-name (objc-msg-send/str
                      (objc-get-class "NSString")
                      (sel-register-name "stringWithUTF8String:")
@@ -49,44 +57,31 @@
                         (sel-register-name "appearanceNamed:")
                         ns-name)))
       (when (cffi:null-pointer-p appearance)
-        (return-from %apply-appearance nil))
+        (return-from %apply-window-appearance nil))
       (objc-msg-send/ptr nswindow
                          (sel-register-name "setAppearance:")
                          appearance)
-      t)))
+      *pending-appearance-mode*)))
 
-(cffi:defcallback dispatch-set-dark-appearance :void
+(cffi:defcallback dispatch-set-appearance :void
     ((webview-handle :pointer) (arg :pointer))
   (declare (ignore arg))
-  (%apply-appearance webview-handle "NSAppearanceNameDarkAqua"))
-
-(cffi:defcallback dispatch-set-light-appearance :void
-    ((webview-handle :pointer) (arg :pointer))
-  (declare (ignore arg))
-  (%apply-appearance webview-handle "NSAppearanceNameAqua"))
-
-(defun mode-appearance-name (mode)
-  (ecase mode
-    (:dark "NSAppearanceNameDarkAqua")
-    (:light "NSAppearanceNameAqua")))
-
-(defun mode-dispatch-callback (mode)
-  (ecase mode
-    (:dark (cffi:callback dispatch-set-dark-appearance))
-    (:light (cffi:callback dispatch-set-light-appearance))))
+  (%apply-window-appearance webview-handle))
 
 (defun set-window-appearance (webview-handle mode)
   "Set the macOS window frame appearance for WEBVIEW-HANDLE.
 MODE should be :dark or :light. Called before the event loop starts,
 so it runs directly on the main thread."
-  (%apply-appearance webview-handle (mode-appearance-name mode)))
+  (setf *pending-appearance-mode* mode)
+  (%apply-window-appearance webview-handle))
 
 (defun dispatch-set-window-appearance (webview-handle mode)
   "Set the macOS window frame appearance via webview_dispatch.
 Use this when the event loop is already running to ensure the
 Cocoa API calls execute on the main thread."
+  (setf *pending-appearance-mode* mode)
   (webview:webview-dispatch webview-handle
-                            (mode-dispatch-callback mode)
+                            (cffi:callback dispatch-set-appearance)
                             (cffi:null-pointer))
   mode)
 

--- a/frontends/webview/darwin.lisp
+++ b/frontends/webview/darwin.lisp
@@ -1,3 +1,5 @@
+;;; Package :lem-webview is defined in main.lisp; this file is loaded
+;;; after it via :serial t in lem-webview.asd.
 (in-package :lem-webview)
 
 ;;; macOS window appearance via Objective-C runtime

--- a/frontends/webview/darwin.lisp
+++ b/frontends/webview/darwin.lisp
@@ -9,10 +9,6 @@
 #+darwin
 (progn
 
-;; The C callback for webview_dispatch has a fixed signature (handle, arg),
-;; so we use a dynamic variable to pass the desired appearance mode.
-(defvar *pending-appearance-mode* :dark)
-
 (cffi:define-foreign-library libobjc
   (:os-macosx "libobjc.dylib"))
 
@@ -38,13 +34,13 @@
   (sel :pointer)
   (arg :string))
 
-(defun %apply-window-appearance (webview-handle)
-  "Apply the appearance in *pending-appearance-mode* to the window.
+(defun %apply-window-appearance (webview-handle mode)
+  "Apply appearance MODE (:dark or :light) to the window.
 Must be called on the main thread."
   (let ((nswindow (webview:webview-get-window webview-handle)))
     (when (cffi:null-pointer-p nswindow)
       (return-from %apply-window-appearance nil))
-    (let* ((appearance-name (ecase *pending-appearance-mode*
+    (let* ((appearance-name (ecase mode
                               (:dark "NSAppearanceNameDarkAqua")
                               (:light "NSAppearanceNameAqua")))
            (ns-appearance-class (objc-get-class "NSAppearance"))
@@ -61,27 +57,32 @@ Must be called on the main thread."
       (objc-msg-send/ptr nswindow
                          (sel-register-name "setAppearance:")
                          appearance)
-      *pending-appearance-mode*)))
+      mode)))
 
-(cffi:defcallback dispatch-set-appearance :void
+(cffi:defcallback dispatch-set-dark-appearance :void
     ((webview-handle :pointer) (arg :pointer))
   (declare (ignore arg))
-  (%apply-window-appearance webview-handle))
+  (%apply-window-appearance webview-handle :dark))
+
+(cffi:defcallback dispatch-set-light-appearance :void
+    ((webview-handle :pointer) (arg :pointer))
+  (declare (ignore arg))
+  (%apply-window-appearance webview-handle :light))
 
 (defun set-window-appearance (webview-handle mode)
   "Set the macOS window frame appearance for WEBVIEW-HANDLE.
 MODE should be :dark or :light. Called before the event loop starts,
 so it runs directly on the main thread."
-  (setf *pending-appearance-mode* mode)
-  (%apply-window-appearance webview-handle))
+  (%apply-window-appearance webview-handle mode))
 
 (defun dispatch-set-window-appearance (webview-handle mode)
   "Set the macOS window frame appearance via webview_dispatch.
 Use this when the event loop is already running to ensure the
 Cocoa API calls execute on the main thread."
-  (setf *pending-appearance-mode* mode)
   (webview:webview-dispatch webview-handle
-                            (cffi:callback dispatch-set-appearance)
+                            (ecase mode
+                              (:dark (cffi:callback dispatch-set-dark-appearance))
+                              (:light (cffi:callback dispatch-set-light-appearance)))
                             (cffi:null-pointer))
   mode)
 

--- a/frontends/webview/darwin.lisp
+++ b/frontends/webview/darwin.lisp
@@ -34,16 +34,12 @@
   (sel :pointer)
   (arg :string))
 
-(defun set-window-appearance (webview-handle mode)
-  "Set the macOS window frame appearance for WEBVIEW-HANDLE.
-MODE should be :dark or :light."
+(defun %apply-appearance (webview-handle appearance-name)
+  "Apply the named appearance to the window. Must be called on the main thread."
   (let ((nswindow (webview:webview-get-window webview-handle)))
     (when (cffi:null-pointer-p nswindow)
-      (return-from set-window-appearance nil))
-    (let* ((appearance-name (ecase mode
-                              (:dark "NSAppearanceNameDarkAqua")
-                              (:light "NSAppearanceNameAqua")))
-           (ns-appearance-class (objc-get-class "NSAppearance"))
+      (return-from %apply-appearance nil))
+    (let* ((ns-appearance-class (objc-get-class "NSAppearance"))
            (ns-name (objc-msg-send/str
                      (objc-get-class "NSString")
                      (sel-register-name "stringWithUTF8String:")
@@ -53,16 +49,57 @@ MODE should be :dark or :light."
                         (sel-register-name "appearanceNamed:")
                         ns-name)))
       (when (cffi:null-pointer-p appearance)
-        (return-from set-window-appearance nil))
+        (return-from %apply-appearance nil))
       (objc-msg-send/ptr nswindow
                          (sel-register-name "setAppearance:")
                          appearance)
-      mode)))
+      t)))
+
+(cffi:defcallback dispatch-set-dark-appearance :void
+    ((webview-handle :pointer) (arg :pointer))
+  (declare (ignore arg))
+  (%apply-appearance webview-handle "NSAppearanceNameDarkAqua"))
+
+(cffi:defcallback dispatch-set-light-appearance :void
+    ((webview-handle :pointer) (arg :pointer))
+  (declare (ignore arg))
+  (%apply-appearance webview-handle "NSAppearanceNameAqua"))
+
+(defun mode-appearance-name (mode)
+  (ecase mode
+    (:dark "NSAppearanceNameDarkAqua")
+    (:light "NSAppearanceNameAqua")))
+
+(defun mode-dispatch-callback (mode)
+  (ecase mode
+    (:dark (cffi:callback dispatch-set-dark-appearance))
+    (:light (cffi:callback dispatch-set-light-appearance))))
+
+(defun set-window-appearance (webview-handle mode)
+  "Set the macOS window frame appearance for WEBVIEW-HANDLE.
+MODE should be :dark or :light. Called before the event loop starts,
+so it runs directly on the main thread."
+  (%apply-appearance webview-handle (mode-appearance-name mode)))
+
+(defun dispatch-set-window-appearance (webview-handle mode)
+  "Set the macOS window frame appearance via webview_dispatch.
+Use this when the event loop is already running to ensure the
+Cocoa API calls execute on the main thread."
+  (webview:webview-dispatch webview-handle
+                            (mode-dispatch-callback mode)
+                            (cffi:null-pointer))
+  mode)
 
 ) ; end #+darwin progn
 
 #-darwin
+(progn
 (defun set-window-appearance (webview-handle mode)
   "No-op: window appearance is only supported on macOS."
   (declare (ignore webview-handle mode))
   nil)
+(defun dispatch-set-window-appearance (webview-handle mode)
+  "No-op: window appearance is only supported on macOS."
+  (declare (ignore webview-handle mode))
+  nil)
+)

--- a/frontends/webview/lem-webview.asd
+++ b/frontends/webview/lem-webview.asd
@@ -3,5 +3,5 @@
                "float-features"
                "lem-server")
   :serial t
-  :components ((:file "main")
-               (:file "darwin")))
+  :components ((:file "darwin")
+               (:file "main")))

--- a/frontends/webview/lem-webview.asd
+++ b/frontends/webview/lem-webview.asd
@@ -3,4 +3,5 @@
                "float-features"
                "lem-server")
   :serial t
-  :components ((:file "main")))
+  :components ((:file "main")
+               (:file "darwin")))

--- a/frontends/webview/main.lisp
+++ b/frontends/webview/main.lisp
@@ -7,10 +7,16 @@
            :*webview-handle*))
 (in-package :lem-webview)
 
-(defclass webview (lem-server:jsonrpc lem-core:implementation) ())
+(defclass webview (lem-server:jsonrpc lem-core:implementation)
+  ()
+  (:documentation "Webview frontend implementation.
+Combines the JSON-RPC server protocol with a native webview window."))
 
 (defvar *webview-handle* nil
-  "The native webview handle, set during run-webview.")
+  "The native webview handle, set during run-webview.
+This must be a dynamic variable because it is set on the main thread
+(inside run-webview) and read from the editor thread (via set-frame-color).
+The webview pointer is written once at startup and cleared on shutdown.")
 
 (defmethod lem-if:invoke ((implementation webview) function)
   (main)

--- a/frontends/webview/main.lisp
+++ b/frontends/webview/main.lisp
@@ -3,7 +3,6 @@
   (:export :main
            :webview-main
            :webview
-           :set-frame-color
            :*webview-handle*))
 (in-package :lem-webview)
 
@@ -31,11 +30,10 @@
         (setf *webview-handle* nil)
         (webview:webview-destroy w)))))
 
-(defun set-frame-color (mode)
-  "Set the macOS window frame to :dark or :light mode.
-Can be called at any time while the webview is running."
+(defmethod lem-if:set-frame-color ((implementation webview) mode)
+  "Set the macOS window frame to :dark or :light mode."
   (when *webview-handle*
-    (set-window-appearance *webview-handle* mode)))
+    (dispatch-set-window-appearance *webview-handle* mode)))
 
 (defun main (&optional (args (uiop:command-line-arguments)))
   (let ((port (lem/common/socket:random-available-port)))

--- a/frontends/webview/main.lisp
+++ b/frontends/webview/main.lisp
@@ -1,5 +1,8 @@
 (uiop:define-package :lem-webview
   (:use :cl)
+  (:import-from :lem-webview/darwin
+   :set-window-appearance
+   :dispatch-set-window-appearance)
   (:export :main
            :webview-main
            :webview))

--- a/frontends/webview/main.lisp
+++ b/frontends/webview/main.lisp
@@ -28,8 +28,9 @@ Combines the JSON-RPC server protocol with a native webview window."))
         (webview:webview-destroy w)))))
 
 (defmethod lem-if:set-frame-color ((implementation lem-server:jsonrpc) mode)
-  "Set the macOS window frame to :dark or :light mode.
-Can be called at any time from any thread."
+  "Set the window frame to :dark or :light mode.
+Currently implemented for macOS via darwin.lisp; on other platforms this
+is a no-op. Can be called from any thread."
   (dispatch-set-window-appearance mode))
 
 (defun main (&optional (args (uiop:command-line-arguments)))

--- a/frontends/webview/main.lisp
+++ b/frontends/webview/main.lisp
@@ -7,7 +7,7 @@
            :*webview-handle*))
 (in-package :lem-webview)
 
-(defclass webview (lem-server::jsonrpc lem-core:implementation) ())
+(defclass webview (lem-server:jsonrpc lem-core:implementation) ())
 
 (defvar *webview-handle* nil
   "The native webview handle, set during run-webview.")
@@ -31,16 +31,13 @@
         (setf *webview-handle* nil)
         (webview:webview-destroy w)))))
 
-;; FIXME: This doesn't seem to work unlike the set-frame-color below.
-(defmethod lem-if:set-frame-color ((implementation webview) mode)
+;; The editor thread's *implementation* is a jsonrpc instance (not webview),
+;; because run-websocket-server passes --interface JSONRPC.  We specialize
+;; on jsonrpc and guard with *webview-handle* so plain server frontends
+;; get a no-op.
+(defmethod lem-if:set-frame-color ((implementation lem-server:jsonrpc) mode)
   "Set the macOS window frame to :dark or :light mode.
 Can be called at any time while the webview is running."
-  (when *webview-handle*
-    (dispatch-set-window-appearance *webview-handle* mode)))
-
-(defun set-frame-color (mode)
-  "Set the macOS window frame to :dark or :light mode.
-Deprecated: use (lem:set-frame-color mode) instead."
   (when *webview-handle*
     (dispatch-set-window-appearance *webview-handle* mode)))
 

--- a/frontends/webview/main.lisp
+++ b/frontends/webview/main.lisp
@@ -3,6 +3,7 @@
   (:export :main
            :webview-main
            :webview
+           :set-frame-color
            :*webview-handle*))
 (in-package :lem-webview)
 
@@ -30,8 +31,16 @@
         (setf *webview-handle* nil)
         (webview:webview-destroy w)))))
 
+;; FIXME: This doesn't seem to work unlike the set-frame-color below.
 (defmethod lem-if:set-frame-color ((implementation webview) mode)
-  "Set the macOS window frame to :dark or :light mode."
+  "Set the macOS window frame to :dark or :light mode.
+Can be called at any time while the webview is running."
+  (when *webview-handle*
+    (dispatch-set-window-appearance *webview-handle* mode)))
+
+(defun set-frame-color (mode)
+  "Set the macOS window frame to :dark or :light mode.
+Deprecated: use (lem:set-frame-color mode) instead."
   (when *webview-handle*
     (dispatch-set-window-appearance *webview-handle* mode)))
 

--- a/frontends/webview/main.lisp
+++ b/frontends/webview/main.lisp
@@ -2,25 +2,40 @@
   (:use :cl)
   (:export :main
            :webview-main
-           :webview))
+           :webview
+           :set-frame-color
+           :*webview-handle*))
 (in-package :lem-webview)
 
 (defclass webview (lem-server::jsonrpc lem-core:implementation) ())
+
+(defvar *webview-handle* nil
+  "The native webview handle, set during run-webview.")
 
 (defmethod lem-if:invoke ((implementation webview) function)
   (main)
   (call-next-method))
 
-(defun run-webview (&key title url width height)
+(defun run-webview (&key title url width height (frame-color :dark))
+  "Run the webview window. FRAME-COLOR is :dark or :light (macOS only)."
   (float-features:with-float-traps-masked t
     (let ((w (webview:webview-create 0 (cffi:null-pointer))))
+      (setf *webview-handle* w)
       (unwind-protect
            (progn
              (webview:webview-set-title w title)
              (webview:webview-set-size w width height 0)
+             (set-window-appearance w frame-color)
              (webview:webview-navigate w url)
              (webview:webview-run w))
+        (setf *webview-handle* nil)
         (webview:webview-destroy w)))))
+
+(defun set-frame-color (mode)
+  "Set the macOS window frame to :dark or :light mode.
+Can be called at any time while the webview is running."
+  (when *webview-handle*
+    (set-window-appearance *webview-handle* mode)))
 
 (defun main (&optional (args (uiop:command-line-arguments)))
   (let ((port (lem/common/socket:random-available-port)))

--- a/frontends/webview/main.lisp
+++ b/frontends/webview/main.lisp
@@ -2,21 +2,13 @@
   (:use :cl)
   (:export :main
            :webview-main
-           :webview
-           :set-frame-color
-           :*webview-handle*))
+           :webview))
 (in-package :lem-webview)
 
 (defclass webview (lem-server:jsonrpc lem-core:implementation)
   ()
   (:documentation "Webview frontend implementation.
 Combines the JSON-RPC server protocol with a native webview window."))
-
-(defvar *webview-handle* nil
-  "The native webview handle, set during run-webview.
-This must be a dynamic variable because it is set on the main thread
-(inside run-webview) and read from the editor thread (via set-frame-color).
-The webview pointer is written once at startup and cleared on shutdown.")
 
 (defmethod lem-if:invoke ((implementation webview) function)
   (main)
@@ -26,7 +18,6 @@ The webview pointer is written once at startup and cleared on shutdown.")
   "Run the webview window. FRAME-COLOR is :dark or :light (macOS only)."
   (float-features:with-float-traps-masked t
     (let ((w (webview:webview-create 0 (cffi:null-pointer))))
-      (setf *webview-handle* w)
       (unwind-protect
            (progn
              (webview:webview-set-title w title)
@@ -34,18 +25,12 @@ The webview pointer is written once at startup and cleared on shutdown.")
              (set-window-appearance w frame-color)
              (webview:webview-navigate w url)
              (webview:webview-run w))
-        (setf *webview-handle* nil)
         (webview:webview-destroy w)))))
 
-;; The editor thread's *implementation* is a jsonrpc instance (not webview),
-;; because run-websocket-server passes --interface JSONRPC.  We specialize
-;; on jsonrpc and guard with *webview-handle* so plain server frontends
-;; get a no-op.
 (defmethod lem-if:set-frame-color ((implementation lem-server:jsonrpc) mode)
   "Set the macOS window frame to :dark or :light mode.
-Can be called at any time while the webview is running."
-  (when *webview-handle*
-    (dispatch-set-window-appearance *webview-handle* mode)))
+Can be called at any time from any thread."
+  (dispatch-set-window-appearance mode))
 
 (defun main (&optional (args (uiop:command-line-arguments)))
   (let ((port (lem/common/socket:random-available-port)))

--- a/lem-tests.asd
+++ b/lem-tests.asd
@@ -75,6 +75,7 @@
                (:file "window")
                (:file "legit")
                (:file "filer")
-               (:file "listener-mode"))
+               (:file "listener-mode")
+               (:file "interface"))
   :perform (test-op (o c)
                     (symbol-call :rove :run c)))

--- a/src/interface.lisp
+++ b/src/interface.lisp
@@ -192,7 +192,8 @@ PIXEL-X, PIXEL-Y, PIXEL-WIDTH, PIXEL-HEIGHT are in pixels (may be nil for auto-c
 
 (defgeneric lem-if:set-frame-color (implementation mode)
   (:documentation "Set the window frame appearance to MODE (:dark or :light).
-Frontends that do not support frame color should use the default no-op.")
+Frontends on any platform may implement this to control the native window
+chrome. The default method is a no-op for frontends that do not support it.")
   (:method (implementation mode)
     (declare (ignore implementation mode))
     nil))

--- a/src/interface.lisp
+++ b/src/interface.lisp
@@ -224,7 +224,7 @@ Frontends that do not support frame color should use the default no-op.")
   (check-type mode (member :light :dark nil))
   (setf *display-background-mode* mode)
   (when mode
-    (lem-if:set-frame-color (implementation) mode)))
+    (set-frame-color mode)))
 
 (defun set-foreground (name)
   (when name

--- a/src/interface.lisp
+++ b/src/interface.lisp
@@ -197,6 +197,10 @@ Frontends that do not support frame color should use the default no-op.")
     (declare (ignore implementation mode))
     nil))
 
+(defun set-frame-color (&optional (mode :dark))
+  "Set the window frame appearance to MODE (:dark or :light)."
+  (lem-if:set-frame-color (implementation) mode))
+
 (defvar *display-background-mode* nil)
 
 (defun implementation ()

--- a/src/interface.lisp
+++ b/src/interface.lisp
@@ -190,6 +190,13 @@ PIXEL-X, PIXEL-Y, PIXEL-WIDTH, PIXEL-HEIGHT are in pixels (may be nil for auto-c
     (declare (ignore wait))
     (error "unimplemented")))
 
+(defgeneric lem-if:set-frame-color (implementation mode)
+  (:documentation "Set the window frame appearance to MODE (:dark or :light).
+Frontends that do not support frame color should use the default no-op.")
+  (:method (implementation mode)
+    (declare (ignore implementation mode))
+    nil))
+
 (defvar *display-background-mode* nil)
 
 (defun implementation ()

--- a/src/interface.lisp
+++ b/src/interface.lisp
@@ -222,7 +222,9 @@ Frontends that do not support frame color should use the default no-op.")
 
 (defun set-display-background-mode (mode)
   (check-type mode (member :light :dark nil))
-  (setf *display-background-mode* mode))
+  (setf *display-background-mode* mode)
+  (when mode
+    (lem-if:set-frame-color (implementation) mode)))
 
 (defun set-foreground (name)
   (when name

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -654,7 +654,8 @@
    :get-font
    :set-font
    :set-font-name
-   :set-font-size)
+   :set-font-size
+   :set-frame-color)
   ;; color-theme.lisp
   (:export
    :color-theme-names

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -783,4 +783,5 @@
    :render-line
    :render-line-on-modeline
    :object-width
-   :object-height))
+   :object-height
+   :set-frame-color))

--- a/tests/interface.lisp
+++ b/tests/interface.lisp
@@ -1,0 +1,10 @@
+(defpackage :lem-tests/interface
+  (:use :cl :rove :lem))
+(in-package :lem-tests/interface)
+
+(deftest set-frame-color-default-is-noop
+  (lem-fake-interface:with-fake-interface ()
+    (ok (null (set-frame-color :dark))
+        "set-frame-color returns NIL on frontends that don't implement it")
+    (ok (null (set-frame-color :light))
+        "set-frame-color returns NIL for :light as well")))


### PR DESCRIPTION
## Summary

Adds `lem-if:set-frame-color` as a frontend protocol generic so any frontend can control the window frame appearance (dark/light). The webview frontend implements it via Objective-C runtime calls to set NSAppearance on macOS.

## Changes

### Core (`src/interface.lisp`, `src/internal-packages.lisp`)
- Add `lem-if:set-frame-color` generic with default no-op method
- Add `lem:set-frame-color` convenience function
- Export from both `lem-if` and `lem-core` packages
- Integrate with `set-display-background-mode` so frame color auto-syncs when themes set `:display-background-mode`

### Webview frontend (`frontends/webview/`)
- New `darwin.lisp`: macOS-specific Objective-C FFI to set NSAppearance on the webview window
  - Uses fixed-arity `objc_msgSend` wrappers (avoids ARM64 variadic ABI issues)
  - Two separate callbacks (`dispatch-set-dark/light-appearance`) instead of shared mutable state
  - No-op stubs on non-Darwin platforms
- `main.lisp`: Implement `lem-if:set-frame-color` on `lem-server:jsonrpc`, guarded by `*webview-handle*`
- `lem-webview.asd`: Load `darwin.lisp`

### Server frontend (`frontends/server/`)
- Export `jsonrpc` from `lem-server` package (was internal-only)
- Update `color-picker.lisp` to use exported symbol

### Tests
- Add `tests/interface.lisp`: verify `set-frame-color` returns NIL on `fake-interface`
- Register in `lem-tests.asd`

## Behavior

- Themes that set `:display-background-mode` automatically sync the frame color
- Users can still call `(lem:set-frame-color :dark)` explicitly
- Frontends that don't implement it get a silent no-op