### PR TITLE
fix: set-font-size respects high-DPI scaling on macOS

### DIFF
--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -424,10 +424,14 @@
 (defmethod lem-if:set-font-size ((implementation sdl2) size)
   (display:with-display (display)
     (display:with-renderer (display)
-      (let ((font-config (display:display-font-config display)))
+      (let* ((font-config (display:display-font-config display))
+             (ratio (round (first (display:display-scale display))))
+             (scaled-size (* ratio size)))
+        (setf (lem:config :sdl2-font-size) size)
         (display:change-font
          display
-         (change-size font-config size))))))
+         (change-size font-config scaled-size)
+         nil)))))
 
 (defmethod lem-if:resize-display-before ((implementation sdl2))
   (with-debug ("resize-display-before")


### PR DESCRIPTION
## Problem

On macOS with Retina displays, `(set-font-size N)` does not work correctly. The font briefly changes, then reverts to a different size on the next redisplay.

### Root cause

`adapt-high-dpi-font-size` runs on every redisplay (via `notify-required-redisplay`) on Darwin and resets the font to:

```lisp
(* ratio (lem:config :sdl2-font-size (font:default-font-size)))
```

However, `lem-if:set-font-size` was passing the user's size directly to `change-font`, which internally called `save-font-size` dividing by the display ratio. This caused:

1. **Rounding errors**: `(set-font-size 12)` on Retina (ratio=2) → `save-font-size` stores `round(12/2) = 6` → next redisplay applies `6 × 2 = 12` (happens to be correct only by luck with even numbers)
2. **Semantic mismatch**: The user's size was treated as a physical pixel size rather than a logical font size, so the stored config value was always wrong. With odd sizes like 15: `round(15/2) = 8` → `8 × 2 = 16` (not 15)

### Example

```lisp
;; In .lemrc on a Retina Mac:
(set-font-size 12)
;; Expected: font stays at logical size 12
;; Actual: save-font-size stores round(12/2) = 6
;; Next redisplay: adapt-high-dpi-font-size applies 6 × 2 = 12
;; Works by luck for even numbers, but odd sizes like 15 drift to 16
```

## Fix

Treat the `size` parameter as a **logical font size**:
- Store it directly to `:sdl2-font-size` config (the source of truth for `adapt-high-dpi-font-size`)
- Scale it by the display ratio for the actual font rendering
- Pass `nil` to `change-font` to skip its redundant `save-font-size` call

This ensures `(set-font-size N)` persists correctly across redisplays and produces the exact font size the user requested.

## Testing

- Built and tested on macOS with Retina display (scale ratio = 2)
- `(set-font-size 12)` now correctly persists across redisplays
- `increase-font-size` / `decrease-font-size` continue to work (they use a different code path)
- All existing tests pass