### PR TITLE
fix(macos): enhance deployment and packaging for macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ TODO
 artifacts/
 logs/
 .serena/
+
+# macOS deploy artifacts
+resources/lem.icns
+lem-macos.zip
+lem-macos/

--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,17 @@ install-bin:
 	install -m 755 lem $(PREFIX)/bin
 
 # TODO: on the fly edit lem.desktop depends on $(PREFIX)
-install-desktop: 
+install-desktop:
 	install -m 644 scripts/install/lem.svg /usr/share/icons/hicolor/scalable/apps/
 	gtk-update-icon-cache /usr/share/icons/hicolor
 	install -m 644 scripts/install/lem-$(VARIANT).desktop /usr/share/applications/lem.desktop
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+install: install-bin
+else
 install: install-bin install-desktop
+endif
 	@echo "+--------------------------------+"
 	@echo "|   Lem installation complete!   |"
 	@echo "+--------------------------------+"
@@ -143,6 +148,23 @@ lint:
 	.qlot/bin/sblint extensions/xml-mode/lem-xml-mode.asd
 	.qlot/bin/sblint extensions/yaml-mode/lem-yaml-mode.asd
 	.qlot/bin/sblint extensions/ruby-mode/lem-ruby-mode.asd
+
+resources/lem.icns: resources/lem.png
+	mkdir -p resources/lem.iconset
+	sips -z 16 16     $< --out resources/lem.iconset/icon_16x16.png
+	sips -z 32 32     $< --out resources/lem.iconset/icon_16x16@2x.png
+	sips -z 32 32     $< --out resources/lem.iconset/icon_32x32.png
+	sips -z 64 64     $< --out resources/lem.iconset/icon_32x32@2x.png
+	sips -z 128 128   $< --out resources/lem.iconset/icon_128x128.png
+	sips -z 256 256   $< --out resources/lem.iconset/icon_128x128@2x.png
+	sips -z 256 256   $< --out resources/lem.iconset/icon_256x256.png
+	sips -z 256 256   $< --out resources/lem.iconset/icon_256x256@2x.png
+	sips -z 256 256   $< --out resources/lem.iconset/icon_512x512.png
+	sips -z 256 256   $< --out resources/lem.iconset/icon_512x512@2x.png
+	iconutil -c icns resources/lem.iconset -o $@
+	rm -rf resources/lem.iconset
+
+icns: resources/lem.icns
 
 AppImage:
 	docker buildx build -f docker/Dockerfile-AppImage --progress=plain --target artifact --output type=local,dest=./artifacts .

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,10 @@ lint:
 	.qlot/bin/sblint extensions/yaml-mode/lem-yaml-mode.asd
 	.qlot/bin/sblint extensions/ruby-mode/lem-ruby-mode.asd
 
+# Generate macOS .icns from resources/lem.png. The source PNG is currently
+# 256x256, which is the largest entry we can include without upscaling.
+# Replace lem.png with a 1024x1024 source to also produce 256@2x/512/512@2x
+# entries for Retina-quality dock and Finder icons.
 resources/lem.icns: resources/lem.png
 	mkdir -p resources/lem.iconset
 	sips -z 16 16     $< --out resources/lem.iconset/icon_16x16.png
@@ -158,9 +162,6 @@ resources/lem.icns: resources/lem.png
 	sips -z 128 128   $< --out resources/lem.iconset/icon_128x128.png
 	sips -z 256 256   $< --out resources/lem.iconset/icon_128x128@2x.png
 	sips -z 256 256   $< --out resources/lem.iconset/icon_256x256.png
-	sips -z 256 256   $< --out resources/lem.iconset/icon_256x256@2x.png
-	sips -z 256 256   $< --out resources/lem.iconset/icon_512x512.png
-	sips -z 256 256   $< --out resources/lem.iconset/icon_512x512@2x.png
 	iconutil -c icns resources/lem.iconset -o $@
 	rm -rf resources/lem.iconset
 

--- a/scripts/macos-deploy.bash
+++ b/scripts/macos-deploy.bash
@@ -11,7 +11,8 @@ cd "$parent_dir"
 qlot install
 qlot exec sbcl --eval '(ql:quickload :lem)' --eval '(asdf:make :lem)'
 
-# アイコン（存在しなくても続行）
+# アイコン（.icns for macOS dock/taskbar icon, .png as fallback）
+cp resources/lem.icns bin/lem.app/Contents/Resources/ || true
 cp resources/lem.png bin/lem.app/Contents/Resources/ || true
 
 # ===== 2) OpenSSL を同梱し、参照先を @loader_path 化 =====

--- a/scripts/macos-deploy.bash
+++ b/scripts/macos-deploy.bash
@@ -12,7 +12,10 @@ qlot install
 qlot exec sbcl --eval '(ql:quickload :lem)' --eval '(asdf:make :lem)'
 
 # アイコン（.icns for macOS dock/taskbar icon, .png as fallback）
-cp resources/lem.icns bin/lem.app/Contents/Resources/ || true
+# Generate the .icns first so a missing icon is a hard failure rather than
+# silently shipping an iconless .app.
+make icns
+cp resources/lem.icns bin/lem.app/Contents/Resources/
 cp resources/lem.png bin/lem.app/Contents/Resources/ || true
 
 # ===== 2) OpenSSL を同梱し、参照先を @loader_path 化 =====

--- a/src/macosx.lisp
+++ b/src/macosx.lisp
@@ -1,5 +1,15 @@
 (in-package :lem-core)
 
+;; Tell the deploy library not to bundle tree-sitter native libraries.
+;; They are optional and loaded at runtime only when available.
+(when (find-package :tree-sitter/ffi)
+  (let ((ts (find-symbol "TREE-SITTER" :tree-sitter/ffi))
+        (tw (find-symbol "TS-WRAPPER" :tree-sitter/ffi)))
+    (when ts
+      (setf (deploy:library-dont-deploy-p (deploy:ensure-library ts)) T))
+    (when tw
+      (setf (deploy:library-dont-deploy-p (deploy:ensure-library tw)) T))))
+
 (add-hook *after-init-hook*
           (lambda ()
             ;; PATH injection for macOS

--- a/src/macosx.lisp
+++ b/src/macosx.lisp
@@ -1,15 +1,5 @@
 (in-package :lem-core)
 
-;; Tell the deploy library not to bundle tree-sitter native libraries.
-;; They are optional and loaded at runtime only when available.
-(when (find-package :tree-sitter/ffi)
-  (let ((ts (find-symbol "TREE-SITTER" :tree-sitter/ffi))
-        (tw (find-symbol "TS-WRAPPER" :tree-sitter/ffi)))
-    (when ts
-      (setf (deploy:library-dont-deploy-p (deploy:ensure-library ts)) T))
-    (when tw
-      (setf (deploy:library-dont-deploy-p (deploy:ensure-library tw)) T))))
-
 (add-hook *after-init-hook*
           (lambda ()
             ;; PATH injection for macOS
@@ -20,3 +10,13 @@
               (let ((dir (user-homedir-pathname)))
                 (setq *default-pathname-defaults* dir)
                 (uiop:chdir dir)))))
+
+;; Tell the deploy library not to bundle tree-sitter native libraries.
+;; They are optional and loaded at runtime only when available.
+(when (find-package :tree-sitter/ffi)
+  (let ((ts (find-symbol "TREE-SITTER" :tree-sitter/ffi))
+        (tw (find-symbol "TS-WRAPPER" :tree-sitter/ffi)))
+    (when ts
+      (setf (deploy:library-dont-deploy-p (deploy:ensure-library ts)) T))
+    (when tw
+      (setf (deploy:library-dont-deploy-p (deploy:ensure-library tw)) T))))

--- a/src/macosx.lisp
+++ b/src/macosx.lisp
@@ -13,10 +13,13 @@
 
 ;; Tell the deploy library not to bundle tree-sitter native libraries.
 ;; They are optional and loaded at runtime only when available.
-(when (find-package :tree-sitter/ffi)
-  (let ((ts (find-symbol "TREE-SITTER" :tree-sitter/ffi))
-        (tw (find-symbol "TS-WRAPPER" :tree-sitter/ffi)))
-    (when ts
-      (setf (deploy:library-dont-deploy-p (deploy:ensure-library ts)) T))
-    (when tw
-      (setf (deploy:library-dont-deploy-p (deploy:ensure-library tw)) T))))
+;; Only relevant while building; skip when running inside the deployed
+;; binary so we don't mutate deploy state on every startup.
+(unless (deploy:deployed-p)
+  (when (find-package :tree-sitter/ffi)
+    (let ((ts (find-symbol "TREE-SITTER" :tree-sitter/ffi))
+          (tw (find-symbol "TS-WRAPPER" :tree-sitter/ffi)))
+      (when ts
+        (setf (deploy:library-dont-deploy-p (deploy:ensure-library ts)) t))
+      (when tw
+        (setf (deploy:library-dont-deploy-p (deploy:ensure-library tw)) t)))))


### PR DESCRIPTION
Improves macOS deployment and packaging:

- **Icon support**: Added `make icns` target to generate macOS `.icns` icon from PNG, and copy it into the app bundle during deployment
- **Platform-aware install**: `make install` now skips Linux desktop integration steps on macOS
- **Tree-sitter deploy fix**: Excludes optional tree-sitter libraries from bundling since they are loaded at runtime when available