### PR TITLE
feat(dashboard): show Lem version in dashboard modeline

### DIFF
--- a/extensions/lem-dashboard/dashboard-items.lisp
+++ b/extensions/lem-dashboard/dashboard-items.lisp
@@ -18,10 +18,10 @@
     (insert-string point (create-centered-string line) :attribute (item-attribute item))
     (insert-character point #\Newline)))
 
-;; Version (Doom Emacs style — centered below splash)
+;; Version
 (defclass dashboard-version (dashboard-item)
   ()
-  (:documentation "Displays the Lem version string centered, like Doom Emacs.")
+  (:documentation "Displays the Lem version string centered below the splash.")
   (:default-initargs
    :item-attribute 'document-header4-attribute
    :bottom-margin 1))

--- a/extensions/lem-dashboard/dashboard-items.lisp
+++ b/extensions/lem-dashboard/dashboard-items.lisp
@@ -18,20 +18,6 @@
     (insert-string point (create-centered-string line) :attribute (item-attribute item))
     (insert-character point #\Newline)))
 
-;; Version
-(defclass dashboard-version (dashboard-item)
-  ()
-  (:documentation "Displays the Lem version string centered below the splash.")
-  (:default-initargs
-   :item-attribute 'document-header4-attribute
-   :bottom-margin 1))
-
-(defmethod draw-dashboard-item ((item dashboard-version) point)
-  (let ((version-str (format nil "v~A" (asdf:component-version (asdf:find-system :lem)))))
-    (insert-string point (create-centered-string version-str)
-                   :attribute (item-attribute item))
-    (insert-character point #\Newline)))
-
 ;; Url
 (defclass dashboard-url (dashboard-item)
   ((url :initarg :url :accessor url)

--- a/extensions/lem-dashboard/dashboard-items.lisp
+++ b/extensions/lem-dashboard/dashboard-items.lisp
@@ -18,6 +18,20 @@
     (insert-string point (create-centered-string line) :attribute (item-attribute item))
     (insert-character point #\Newline)))
 
+;; Version (Doom Emacs style — centered below splash)
+(defclass dashboard-version (dashboard-item)
+  ()
+  (:documentation "Displays the Lem version string centered, like Doom Emacs.")
+  (:default-initargs
+   :item-attribute 'document-header4-attribute
+   :bottom-margin 1))
+
+(defmethod draw-dashboard-item ((item dashboard-version) point)
+  (let ((version-str (format nil "v~A" (asdf:component-version (asdf:find-system :lem)))))
+    (insert-string point (create-centered-string version-str)
+                   :attribute (item-attribute item))
+    (insert-character point #\Newline)))
+
 ;; Url
 (defclass dashboard-url (dashboard-item)
   ((url :initarg :url :accessor url)

--- a/extensions/lem-dashboard/default-dashboard.lisp
+++ b/extensions/lem-dashboard/default-dashboard.lisp
@@ -42,7 +42,7 @@
                               (splash *default-splash*)
                               (footer-messages *default-footer-messages*)
                               hide-links)
-  (let ((dashboard-items 
+  (let ((dashboard-items
           (list (make-instance 'dashboard-splash
                                :item-attribute 'document-metadata-attribute
                                :splash-texts splash)

--- a/extensions/lem-dashboard/lem-dashboard.lisp
+++ b/extensions/lem-dashboard/lem-dashboard.lisp
@@ -101,6 +101,14 @@
           (dolist (item *dashboard-layout*)
             (draw-dashboard-item item point)))
         (change-buffer-mode buffer 'dashboard-mode)
+        ;; Show the Lem version in the modeline for the dashboard buffer only
+        (setf (variable-value 'modeline-format :buffer buffer)
+              '("  " modeline-write-info modeline-name
+                (modeline-posline nil :right)
+                (modeline-position nil :right)
+                (modeline-minor-modes nil :right)
+                (modeline-major-mode nil :right)
+                (modeline-version nil :right)))
         (move-to-line (buffer-point buffer) old-line)
         (move-to-column (buffer-point buffer) old-column)))))
 

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -413,6 +413,8 @@
    :modeline-write-info
    :modeline-name
    :modeline-mode-names
+   :modeline-major-mode
+   :modeline-minor-modes
    :modeline-position
    :modeline-posline
    :modeline-name-attribute
@@ -426,6 +428,9 @@
    :inactive-modeline-position-attribute
    :inactive-modeline-name-attribute
    :inactive-modeline-posline-attribute
+   :modeline-version
+   :modeline-version-attribute
+   :inactive-modeline-version-attribute
    :convert-modeline-element)
   ;; command.lisp
   (:export

--- a/src/modeline.lisp
+++ b/src/modeline.lisp
@@ -39,6 +39,12 @@
 (define-attribute inactive-modeline-posline-attribute
   (t :foreground "black" :background "#505050"))
 
+(define-attribute modeline-version-attribute
+  (t :foreground "#6a6a6a"))
+
+(define-attribute inactive-modeline-version-attribute
+  (t :foreground "#444444"))
+
 (defvar *modeline-status-list* nil)
 
 (defun modeline-add-status-list (x &optional (buffer nil bufferp))
@@ -123,6 +129,11 @@
           (if (eq window (current-window))
               'modeline-posline-attribute
               'inactive-modeline-posline-attribute)))
+
+(defun modeline-version (window)
+  (declare (ignore window))
+  (values (format nil " v~A " (asdf:component-version (asdf:find-system :lem)))
+          'modeline-version-attribute))
 
 (defgeneric convert-modeline-element (element window))
 


### PR DESCRIPTION
## Summary

Adds the Lem version number to the modeline while the dashboard buffer is active.

## Changes

**`src/modeline.lisp`**
- Adds `modeline-version`: a modeline element that reads the version from the ASDF system definition and renders it as `v2.3.0`.
- Adds `modeline-version-attribute` / `inactive-modeline-version-attribute` with a subdued foreground so the version is visible but unobtrusive.

**`src/internal-packages.lisp`**
- Exports the new symbols (`modeline-version`, `modeline-version-attribute`, `inactive-modeline-version-attribute`) plus the previously-missing `modeline-major-mode` and `modeline-minor-modes` from `lem-core`.

**`extensions/lem-dashboard/lem-dashboard.lisp`**
- Sets a per-buffer `modeline-format` on the `*dashboard*` buffer inside `redraw-dashboard`, appending `modeline-version` on the right. This only affects the dashboard buffer; every other buffer keeps its default modeline format.

## Testing

Compiled against `lem/core` with SBCL 2.5.10 — no errors (only pre-existing style warnings).