### PR TITLE
feat(vi-mode): add dashboard-mode keybinding support

### DIFF
--- a/extensions/vi-mode/lem-vi-mode.asd
+++ b/extensions/vi-mode/lem-vi-mode.asd
@@ -8,6 +8,7 @@
                "alexandria"
                "split-sequence"
                "lem-lisp-mode"
+               "lem-dashboard"
                "trivial-types")
   :components ((:file "core")
                (:file "leader" :depends-on ("core"))

--- a/extensions/vi-mode/special-binds.lisp
+++ b/extensions/vi-mode/special-binds.lisp
@@ -10,7 +10,10 @@
                 :*sldb-keymap*)
   (:import-from :lem-lisp-mode/inspector
                 :lisp-inspector-mode
-                :*lisp-inspector-keymap*))
+                :*lisp-inspector-keymap*)
+  (:import-from :lem-dashboard
+                :dashboard-mode
+                :*dashboard-mode-keymap*))
 (in-package :lem-vi-mode/special-binds)
 
 (defmethod mode-specific-keymaps ((mode directory-mode))
@@ -21,3 +24,6 @@
 
 (defmethod mode-specific-keymaps ((mode lisp-inspector-mode))
   (list *lisp-inspector-keymap*))
+
+(defmethod mode-specific-keymaps ((mode dashboard-mode))
+  (list *dashboard-mode-keymap*))


### PR DESCRIPTION
## Summary

Teaches vi-mode's special-binds machinery about `dashboard-mode` so the dashboard buffer behaves correctly when vi-mode is active.

## Changes

**`extensions/vi-mode/lem-vi-mode.asd`**
- Adds `lem-dashboard` to the system's `:depends-on` list.

**`extensions/vi-mode/special-binds.lisp`**
- Imports `dashboard-mode` and `*dashboard-mode-keymap*` from `lem-dashboard`.
- Adds a `mode-specific-keymaps` method for `dashboard-mode` that returns `*dashboard-mode-keymap*`, matching the existing pattern for `directory-mode`, `sldb-mode`, and `lisp-inspector-mode`.

## Effect

Without this change, pressing a key in the dashboard buffer under vi-mode could fail to find the correct keymap, causing silent no-ops or wrong dispatches. With the change, vi-mode correctly delegates to the dashboard's own keymap when the dashboard is the active buffer.