### PR TITLE
feat(dashboard): Fix dashboard section hover highlighting

### DIFF
--- a/extensions/lem-dashboard/dashboard-items.lisp
+++ b/extensions/lem-dashboard/dashboard-items.lisp
@@ -1,29 +1,5 @@
 (in-package :lem-dashboard)
 
-(defun split-display-text (text)
-  "Splits TEXT into three parts: a leading icon/glyph prefix, the main text,
-and a trailing keymap hint suffix like \" (x)\".
-Returns three values: prefix, main-text, suffix."
-  (let* (;; Strip leading icons and spaces
-         (start (or (position-if (lambda (c)
-                                   (not (or (lem/common/character/icon:icon-code-p (char-code c))
-                                            (char= c #\Space))))
-                                 text)
-                    (length text)))
-         (prefix (subseq text 0 start))
-         (after-prefix (subseq text start))
-         ;; Strip trailing " (x)" keymap hint
-         (len (length after-prefix))
-         (suffix-start (if (and (>= len 4)
-                                (char= (char after-prefix (- len 1)) #\))
-                                (char= (char after-prefix (- len 3)) #\()
-                                (char= (char after-prefix (- len 4)) #\Space))
-                           (- len 4)
-                           len))
-         (main-text (subseq after-prefix 0 suffix-start))
-         (suffix (subseq after-prefix suffix-start)))
-    (values prefix main-text suffix)))
-
 ;; Splash
 (defclass dashboard-splash (dashboard-item)
   ((splash-texts :initarg :splash-texts :accessor splash-texts 
@@ -155,8 +131,8 @@ Returns three values: prefix, main-text, suffix."
         (let* ((longest-project (reduce #'(lambda (a b) (if (> (length a) (length b)) a b)) display-projects))
                (max-length (length longest-project))
                (left-padding (floor (- (window-width (current-window)) max-length) 2)))
-          (loop for project in display-projects
-                do (let ((line-start (copy-point point :temporary)))
+          (loop :for project :in display-projects
+                :do (let ((line-start (copy-point point :temporary)))
                      (insert-string point (str:fit left-padding " ") :attribute (item-attribute item))
                      (let ((text-start (copy-point point :temporary)))
                        (insert-string point (format nil "~A" project) :attribute (item-attribute item))
@@ -169,7 +145,29 @@ Returns three values: prefix, main-text, suffix."
                               (uiop:with-current-directory (p)
                                 (project:project-find-file p)))))))
                      (insert-character point #\Newline))))))))
-
+(defun split-display-text (text)
+  "Splits TEXT into three parts: a leading icon/glyph prefix, the main text,
+and a trailing keymap hint suffix like \" (x)\".
+Returns three values: prefix, main-text, suffix."
+  (let* (;; Strip leading icons and spaces
+         (start (or (position-if (lambda (c)
+                                   (not (or (lem/common/character/icon:icon-code-p (char-code c))
+                                            (char= c #\Space))))
+                                 text)
+                    (length text)))
+         (prefix (subseq text 0 start))
+         (after-prefix (subseq text start))
+         ;; Strip trailing " (x)" keymap hint
+         (len (length after-prefix))
+         (suffix-start (if (and (>= len 4)
+                                (char= (char after-prefix (- len 1)) #\))
+                                (char= (char after-prefix (- len 3)) #\()
+                                (char= (char after-prefix (- len 4)) #\Space))
+                           (- len 4)
+                           len))
+         (main-text (subseq after-prefix 0 suffix-start))
+         (suffix (subseq after-prefix suffix-start)))
+    (values prefix main-text suffix)))
 ;; Recent files
 (defclass dashboard-recent-files (dashboard-item)
   ((file-count :initarg :file-count :accessor file-count :initform 5))
@@ -201,8 +199,8 @@ Returns three values: prefix, main-text, suffix."
         (let* ((longest-file (reduce #'(lambda (a b) (if (> (length a) (length b)) a b)) display-files))
                (max-length (length longest-file))
                (left-padding (floor (- (window-width (current-window)) max-length) 2)))
-          (loop for file in display-files
-                do (let ((line-start (copy-point point :temporary)))
+          (loop :for file :in display-files
+                :do (let ((line-start (copy-point point :temporary)))
                      (insert-string point (str:fit left-padding " ") :attribute (item-attribute item))
                      (let ((text-start (copy-point point :temporary)))
                        (insert-string point (format nil "~A" file) :attribute (item-attribute item))

--- a/extensions/lem-dashboard/dashboard-items.lisp
+++ b/extensions/lem-dashboard/dashboard-items.lisp
@@ -1,5 +1,29 @@
 (in-package :lem-dashboard)
 
+(defun split-display-text (text)
+  "Splits TEXT into three parts: a leading icon/glyph prefix, the main text,
+and a trailing keymap hint suffix like \" (x)\".
+Returns three values: prefix, main-text, suffix."
+  (let* (;; Strip leading icons and spaces
+         (start (or (position-if (lambda (c)
+                                   (not (or (lem/common/character/icon:icon-code-p (char-code c))
+                                            (char= c #\Space))))
+                                 text)
+                    (length text)))
+         (prefix (subseq text 0 start))
+         (after-prefix (subseq text start))
+         ;; Strip trailing " (x)" keymap hint
+         (len (length after-prefix))
+         (suffix-start (if (and (>= len 4)
+                                (char= (char after-prefix (- len 1)) #\))
+                                (char= (char after-prefix (- len 3)) #\()
+                                (char= (char after-prefix (- len 4)) #\Space))
+                           (- len 4)
+                           len))
+         (main-text (subseq after-prefix 0 suffix-start))
+         (suffix (subseq after-prefix suffix-start)))
+    (values prefix main-text suffix)))
+
 ;; Splash
 (defclass dashboard-splash (dashboard-item)
   ((splash-texts :initarg :splash-texts :accessor splash-texts 
@@ -31,10 +55,18 @@
     (setf action (lambda () (open-external-file url)))))
 
 (defmethod draw-dashboard-item ((item dashboard-url) point)
-  (button:insert-button point 
-                        (create-centered-string (display-text item))
-                        (lambda () (open-external-file (url item)))
-                        :attribute (item-attribute item)))
+  (let* ((text (display-text item))
+         (padding (max 0 (floor (- (window-width (current-window)) (length text)) 2))))
+    (insert-string point (make-string padding :initial-element #\Space) :attribute (item-attribute item))
+    (multiple-value-bind (icon-prefix main-text suffix) (split-display-text text)
+      (when (plusp (length icon-prefix))
+        (insert-string point icon-prefix :attribute (item-attribute item)))
+      (button:insert-button point
+                            main-text
+                            (lambda () (open-external-file (url item)))
+                            :attribute (item-attribute item))
+      (when (plusp (length suffix))
+        (insert-string point suffix :attribute (item-attribute item))))))
 
 ;; Working dir
 (defclass dashboard-working-dir (dashboard-item)
@@ -78,10 +110,18 @@
     (setf action (lambda () (funcall action-command)))))
 
 (defmethod draw-dashboard-item ((item dashboard-command) point)
-  (button:insert-button point 
-                        (create-centered-string (display-text item))
-                        (lambda () (funcall (action-command item)))
-                        :attribute (item-attribute item)))
+  (let* ((text (display-text item))
+         (padding (max 0 (floor (- (window-width (current-window)) (length text)) 2))))
+    (insert-string point (make-string padding :initial-element #\Space) :attribute (item-attribute item))
+    (multiple-value-bind (icon-prefix main-text suffix) (split-display-text text)
+      (when (plusp (length icon-prefix))
+        (insert-string point icon-prefix :attribute (item-attribute item)))
+      (button:insert-button point
+                            main-text
+                            (lambda () (funcall (action-command item)))
+                            :attribute (item-attribute item))
+      (when (plusp (length suffix))
+        (insert-string point suffix :attribute (item-attribute item))))))
 
 ;; Recent projects
 (defclass dashboard-recent-projects (dashboard-item)
@@ -117,9 +157,18 @@
                (left-padding (floor (- (window-width (current-window)) max-length) 2)))
           (loop for project in display-projects
                 do (let ((line-start (copy-point point :temporary)))
-                     (insert-string point (str:fit left-padding " "))
-                     (insert-string point (format nil "~A~%" project))
-                     (put-text-property line-start point :project-path project))))))))
+                     (insert-string point (str:fit left-padding " ") :attribute (item-attribute item))
+                     (let ((text-start (copy-point point :temporary)))
+                       (insert-string point (format nil "~A" project) :attribute (item-attribute item))
+                       (let ((text-end (copy-point point :temporary)))
+                         (put-text-property line-start text-end :project-path project)
+                         (button:apply-button-between-points
+                          text-start text-end
+                          (let ((p project))
+                            (lambda ()
+                              (uiop:with-current-directory (p)
+                                (project:project-find-file p)))))))
+                     (insert-character point #\Newline))))))))
 
 ;; Recent files
 (defclass dashboard-recent-files (dashboard-item)
@@ -154,6 +203,14 @@
                (left-padding (floor (- (window-width (current-window)) max-length) 2)))
           (loop for file in display-files
                 do (let ((line-start (copy-point point :temporary)))
-                     (insert-string point (str:fit left-padding " "))
-                     (insert-string point (format nil "~A~%" file))
-                     (put-text-property line-start point :file-path file))))))))
+                     (insert-string point (str:fit left-padding " ") :attribute (item-attribute item))
+                     (let ((text-start (copy-point point :temporary)))
+                       (insert-string point (format nil "~A" file) :attribute (item-attribute item))
+                       (let ((text-end (copy-point point :temporary)))
+                         (put-text-property line-start text-end :file-path file)
+                         (button:apply-button-between-points
+                          text-start text-end
+                          (let ((f file))
+                            (lambda ()
+                              (find-file f))))))
+                     (insert-character point #\Newline))))))))


### PR DESCRIPTION
## Fix dashboard section hover highlighting

### Problem

Dashboard items had two hover highlighting issues:

1. **Recent Projects and Recent Files entries had no hover highlight at all.** They used plain `insert-string` instead of the button API, so they never received the `:hover-callback` / `:click-callback` text properties that enable hover behavior.

2. **All clickable dashboard items (URLs, commands) highlighted the entire line on hover**, including leading whitespace padding, icon glyphs, and trailing keymap hints like `(s)`. Only the meaningful text should be highlighted.

### Changes

- **Add `split-display-text` helper** — Splits a display-text string into three parts: a leading icon/glyph prefix, the main text, and a trailing keymap hint suffix (e.g. `" (x)"`). Only the main text portion is wrapped in a button.

- **Fix `dashboard-url` and `dashboard-command`** — Instead of passing the full centered string (padding + icon + text + hint) to `insert-button`, padding and icon prefix are inserted as plain attributed text, only the main text becomes a button, and the keymap hint suffix is inserted as plain text after.

- **Fix `dashboard-recent-projects` and `dashboard-recent-files`** — Each entry now uses `button:apply-button-between-points` scoped to just the project/file path text (excluding leading padding), enabling hover highlighting and click-to-open behavior consistent with other dashboard items. Entries also now receive proper `:attribute` styling.
