### PR TITLE
html-mode: add missing lem-css-mode dependency

### DIFF
--- a/extensions/html-mode/lem-html-mode.asd
+++ b/extensions/html-mode/lem-html-mode.asd
@@ -2,6 +2,7 @@
   :depends-on ("lem/core"
                "lem-xml-mode"
                "lem-js-mode"
+               "lem-css-mode"
                "cl-ppcre")
   :serial t
   :components ((:file "html-mode")))

--- a/src/ext/image-buffer.lisp
+++ b/src/ext/image-buffer.lisp
@@ -53,6 +53,8 @@ function resetImage() {
                   :html
                   (mustache:render* *html-template*
                                     `((image . ,(namestring pathname)))))
+    (setf (lem:buffer-filename buffer) (namestring pathname))
+    (lem:update-changed-disk-date buffer)
     (lem:change-buffer-mode buffer 'image-viewer-mode)))
 
 (defclass find-file-executor (lem:find-file-executor) ())


### PR DESCRIPTION
## Description
`html-mode.lisp` calls `lem-css-mode::make-tm-css-patterns` but
`lem-html-mode.asd` didn't declare `lem-css-mode` as a dependency.
Depending on load order, this raises:

  Unhandled UNDEFINED-FUNCTION: The function LEM-CSS-MODE::MAKE-TM-CSS-PATTERNS is undefined.

## Fix
Added `"lem-css-mode"` to `:depends-on` in `lem-html-mode.asd`.

## Related Issues
Fixes #2133