### PR TITLE
image-buffer: set buffer-filename when opening an image

### DIFF
--- a/src/ext/image-buffer.lisp
+++ b/src/ext/image-buffer.lisp
@@ -53,6 +53,8 @@ function resetImage() {
                   :html
                   (mustache:render* *html-template*
                                     `((image . ,(namestring pathname)))))
+    (setf (lem:buffer-filename buffer) (namestring pathname))
+    (lem:update-changed-disk-date buffer)
     (lem:change-buffer-mode buffer 'image-viewer-mode)))
 
 (defclass find-file-executor (lem:find-file-executor) ())


### PR DESCRIPTION
## Description
`open-image-buffer` was setting `:directory` on the buffer but never
setting `buffer-filename`. This caused two issues:

- `(buffer-filename)` returned `nil` on image buffers
- `C-x C-j` (find-file-directory) failed with "No file at point"

The fix sets `buffer-filename` to the image path, and calls
`update-changed-disk-date` right after so Lem doesn't see the
newly-set filename as a file that changed on disk - which would
trigger an unwanted revert and an encoding error on the binary.

## Related Issues
Fixes #871