### PR TITLE
refactor(tabbar): expose *enable-tabbar-on-startup* for init-file control

### DIFF
--- a/frontends/server/main.lisp
+++ b/frontends/server/main.lisp
@@ -830,9 +830,7 @@
 
 (defun init ()
   ;; TODO: Fix this problem: frame-multiplexer cannot be used with lem-server, disable them for now.
-  (lem:remove-hook lem:*after-init-hook* 'lem/frame-multiplexer::enable-frame-multiplexer)
-  ;; Enable tabbar instead of the above issue
-  (lem:add-hook lem:*after-init-hook* (find-symbol "ENABLE-TABBAR" :lem/tabbar)))
+  (lem:remove-hook lem:*after-init-hook* 'lem/frame-multiplexer::enable-frame-multiplexer))
 
 (defun run-websocket-server (&key (port 50000) (hostname "127.0.0.1") args)
   (let ((*server-runner*

--- a/frontends/server/tabbar.lisp
+++ b/frontends/server/tabbar.lisp
@@ -1,6 +1,8 @@
 (defpackage :lem/tabbar
   (:use :cl :lem :lem/button)
-  (:export :tabbar-active-tab-attribute
+  (:export :*enable-tabbar-on-startup*
+           :enable-tabbar
+           :tabbar-active-tab-attribute
            :tabbar-attribute
            :tabbar-background-attribute
            :tabbar)
@@ -31,6 +33,12 @@
   2)
 
 (defvar *tabbar* nil)
+
+(defvar *enable-tabbar-on-startup* t
+  "When non-NIL (default), the tabbar is enabled automatically after init.
+Set this in your init file to opt out:
+
+  (setf lem/tabbar:*enable-tabbar-on-startup* nil)")
 
 (defun tabbar-init ()
   (let ((buffer (make-buffer "*tabbar*" :temporary t :enable-undo-p nil)))
@@ -321,3 +329,8 @@ buttons.forEach(button => {
 
 (defun enable-tabbar ()
   (setf (variable-value 'tabbar :global) t))
+
+(add-hook *after-init-hook*
+          (lambda ()
+            (when *enable-tabbar-on-startup*
+              (enable-tabbar))))


### PR DESCRIPTION
## Summary

Make the webview/server tabbar opt-out-able from a user's init file with a single `setf`, instead of requiring users to surgically remove an after-init hook.

## Before

To disable the tabbar at startup, users had to write:

```lisp
(lem:remove-hook lem:*after-init-hook*
                 (find-symbol "ENABLE-TABBAR" :lem/tabbar))
```

The `find-symbol` workaround is needed because the hook was added by `lem-server`'s `init` function in `frontends/server/main.lisp`, which forcibly enabled the tabbar with no opt-out.

## After

```lisp
;; ~/.lemrc
(setf lem/tabbar:*enable-tabbar-on-startup* nil)
```

Discoverable via `apropos`, documented in the `defvar` docstring, and uses no internal symbols.

## Changes

- **`frontends/server/tabbar.lisp`**: add `*enable-tabbar-on-startup*` (defaults to `t`), export it and `enable-tabbar`, and move the auto-enable `add-hook` into this file (next to `enable-tabbar`).
- **`frontends/server/main.lisp`**: remove the manual `add-hook` line that reached across packages via `find-symbol`. `lem-server`'s `init` no longer wires up tabbar startup.

## Backwards compatibility

`*enable-tabbar-on-startup*` defaults to `t`, so users who never touch their init file see no change. `M-x toggle-tabbar` and `(lem/tabbar:enable-tabbar)` continue to work.

## Test plan

- [ ] Launch lem (webview/server) with no init file ⇒ tabbar appears (existing default)
- [ ] Add `(setf lem/tabbar:*enable-tabbar-on-startup* nil)` to `~/.lemrc`, relaunch ⇒ tabbar does not appear
- [ ] With tabbar disabled, run `M-x toggle-tabbar` ⇒ tabbar appears
- [ ] `M-x apropos *enable-tabbar-on-startup*` finds the variable with its docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)