### PR TITLE
docs(tabbar): add docstring to exported enable-tabbar function

### DIFF
--- a/frontends/server/tabbar.lisp
+++ b/frontends/server/tabbar.lisp
@@ -328,6 +328,10 @@ buttons.forEach(button => {
       (change-to-buffer buffer))))
 
 (defun enable-tabbar ()
+  "Enable the tabbar by setting the global `tabbar' editor variable to T.
+The change observer on that variable creates the tabbar window. This is
+the programmatic counterpart to `M-x toggle-tabbar' and is invoked
+automatically after init when `*enable-tabbar-on-startup*' is non-NIL."
   (setf (variable-value 'tabbar :global) t))
 
 (add-hook *after-init-hook*


### PR DESCRIPTION
## Summary

Follow-up to #2166. Adds the missing docstring on the exported `enable-tabbar` function that the code-contractor bot flagged.

## Why

The bot's `docstring_rule` requires exported functions to have docstrings. `enable-tabbar` was exported in #2166 but its body was a single `setf` and got pushed without one. This adds a short docstring that also clarifies the three-symbol relationship for readers landing on this code:

- `tabbar` — editor variable (current state)
- `enable-tabbar` — programmatic action
- `*enable-tabbar-on-startup*` — startup config flag

No behavior change.

## Notes on the bot's other violation

The bot also flagged `file_structure_rule` (a top-level function-call form added after `defun enable-tabbar`). The new `add-hook` call lives next to the function it references; reordering it earlier in the file would either separate it from `enable-tabbar` (less readable) or require also moving the `defun` (a bigger churn for no real benefit). Treating that one as a false positive given the existing file has many top-level forms after function definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)