### PR TITLE
fix(tabbar): define :lem/tabbar package in core so init files load on every frontend

### DIFF
--- a/frontends/server/tabbar.lisp
+++ b/frontends/server/tabbar.lisp
@@ -1,4 +1,9 @@
-(defpackage :lem/tabbar
+;; The :lem/tabbar package + *enable-tabbar-on-startup* are defined in
+;; src/tabbar-config.lisp (loaded by lem/core) so user init files can refer
+;; to the variable on every frontend, including those (e.g. ncurses) that
+;; never load this implementation file. Here we extend the package with the
+;; symbols that only make sense when the tabbar is actually loaded.
+(uiop:define-package :lem/tabbar
   (:use :cl :lem :lem/button)
   (:export :*enable-tabbar-on-startup*
            :enable-tabbar
@@ -34,11 +39,8 @@
 
 (defvar *tabbar* nil)
 
-(defvar *enable-tabbar-on-startup* t
-  "When non-NIL (default), the tabbar is enabled automatically after init.
-Set this in your init file to opt out:
-
-  (setf lem/tabbar:*enable-tabbar-on-startup* nil)")
+;; *enable-tabbar-on-startup* is defined in src/tabbar-config.lisp so the
+;; symbol exists on every frontend's init file load.
 
 (defun tabbar-init ()
   (let ((buffer (make-buffer "*tabbar*" :temporary t :enable-undo-p nil)))

--- a/frontends/server/tabbar.lisp
+++ b/frontends/server/tabbar.lisp
@@ -10,9 +10,7 @@
            :tabbar-active-tab-attribute
            :tabbar-attribute
            :tabbar-background-attribute
-           :tabbar)
-  #+sbcl
-  (:lock t))
+           :tabbar))
 (in-package :lem/tabbar)
 
 (define-attribute tabbar-active-tab-attribute

--- a/lem.asd
+++ b/lem.asd
@@ -144,6 +144,7 @@
                (:file "html-buffer")
                (:file "site-init")
                (:file "command-line-arguments")
+               (:file "tabbar-config")
                (:file "lem")
 
                (:file "color-theme")

--- a/src/tabbar-config.lisp
+++ b/src/tabbar-config.lisp
@@ -1,0 +1,28 @@
+;; Tabbar configuration stub.
+;;
+;; The tabbar implementation lives in frontends/server/tabbar.lisp and is only
+;; loaded by frontends that depend on lem-server (webview, server). Defining
+;; the :lem/tabbar package + *enable-tabbar-on-startup* here in lem/core lets
+;; users portably write
+;;
+;;   (setf lem/tabbar:*enable-tabbar-on-startup* nil)
+;;
+;; in their init file without triggering a read-time
+;; "Package LEM/TABBAR does not exist" error on frontends (e.g. ncurses) that
+;; don't load the tabbar implementation. On those frontends the variable is
+;; just an inert defvar.
+
+(uiop:define-package :lem/tabbar
+  (:use :cl)
+  (:export :*enable-tabbar-on-startup*))
+
+(in-package :lem/tabbar)
+
+(defvar *enable-tabbar-on-startup* t
+  "When non-NIL (default), the tabbar is enabled automatically after init in
+frontends that support it (currently webview and server). Set this in your
+init file to opt out:
+
+  (setf lem/tabbar:*enable-tabbar-on-startup* nil)
+
+Setting it on a frontend without tabbar support (e.g. ncurses) is a no-op.")

--- a/src/tabbar-config.lisp
+++ b/src/tabbar-config.lisp
@@ -1,22 +1,20 @@
-;; Tabbar configuration stub.
-;;
-;; The tabbar implementation lives in frontends/server/tabbar.lisp and is only
-;; loaded by frontends that depend on lem-server (webview, server). Defining
-;; the :lem/tabbar package + *enable-tabbar-on-startup* here in lem/core lets
-;; users portably write
-;;
-;;   (setf lem/tabbar:*enable-tabbar-on-startup* nil)
-;;
-;; in their init file without triggering a read-time
-;; "Package LEM/TABBAR does not exist" error on frontends (e.g. ncurses) that
-;; don't load the tabbar implementation. On those frontends the variable is
-;; just an inert defvar.
-
 (uiop:define-package :lem/tabbar
   (:use :cl)
   (:export :*enable-tabbar-on-startup*))
 
 (in-package :lem/tabbar)
+
+;; The tabbar implementation lives in frontends/server/tabbar.lisp and is
+;; only loaded by frontends that depend on lem-server (webview, server).
+;; Defining the :lem/tabbar package + *enable-tabbar-on-startup* here in
+;; lem/core lets users portably write
+;;
+;;   (setf lem/tabbar:*enable-tabbar-on-startup* nil)
+;;
+;; in their init file without triggering a read-time
+;; "Package LEM/TABBAR does not exist" error on frontends (e.g. ncurses)
+;; that don't load the tabbar implementation. On those frontends the
+;; variable is just an inert defvar.
 
 (defvar *enable-tabbar-on-startup* t
   "When non-NIL (default), the tabbar is enabled automatically after init in


### PR DESCRIPTION
## Summary

Fixes a regression in #2166: a perfectly correct user init file containing

```lisp
(setf lem/tabbar:*enable-tabbar-on-startup* nil)
```

errors out on the **ncurses** (and any non-server) frontend with:

```
READ error during LOAD: Package LEM/TABBAR does not exist.
File: ~/.lemrc
```

The error happens at **read time** (the reader resolves the `lem/tabbar:` prefix before evaluation), so even a defensive `(when (find-package :lem/tabbar) ...)` guard wouldn't help — the file fails to parse.

`*enable-tabbar-on-startup*` was advertised as a portable user-config knob in the docstring and in the docs PR (lem-project/lem-project.github.io#66), so a `~/.lemrc` shared across frontends should not need frontend-specific carve-outs.

## Fix

Move the `:lem/tabbar` package definition and the `*enable-tabbar-on-startup*` defvar into a tiny stub file under `lem/core`:

- **New** `src/tabbar-config.lisp` — defines the package with `:use :cl` only and exports the variable. Loaded by every frontend because every frontend depends on `lem/core`.
- **`lem.asd`** — wires the new file into the `lem/core` `:components` list (just before `lem.lisp`).
- **`frontends/server/tabbar.lisp`** — switches its `defpackage` to `uiop:define-package` so it gracefully extends the existing package with symbols that only make sense when the tabbar implementation is loaded; drops its duplicate defvar.

On frontends without tabbar support, `setf` on `*enable-tabbar-on-startup*` is just inert (no auto-enable hook is registered there). On webview/server it works exactly as before.

## Verification

```
sbcl --load .qlot/setup.lisp
(asdf:load-system :lem/core)            ;; lem-server NOT loaded
(find-package :lem/tabbar)              ;; => #<PACKAGE "LEM/TABBAR">
lem/tabbar:*enable-tabbar-on-startup*   ;; => T
(read-from-string "lem/tabbar:*enable-tabbar-on-startup*")
;;  => no error  (this is the read-time path that was failing)
```

## Test plan

- [ ] `make ncurses` then run with a `~/.lemrc` containing `(setf lem/tabbar:*enable-tabbar-on-startup* nil)` — loads cleanly, no read error
- [ ] `make webview` (or sdl2/server) with the same init file — tabbar is hidden at startup; `M-x toggle-tabbar` still works
- [ ] `make webview` with no init file — tabbar appears as before (default `t`)
- [ ] `apropos *enable-tabbar-on-startup*` finds the variable on every frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)