### PR TITLE
chore(sprof): add lem-sprof-start-alloc, fix silent failures, portable temp path

### DIFF
--- a/src/commands/sprof.lisp
+++ b/src/commands/sprof.lisp
@@ -41,9 +41,10 @@ runs on, not just unix-like systems with a writable /tmp."
 
 (define-command lem-sprof-report () ()
   "Stop profiling, write the report to the OS temp directory, and reset.
-Reports the absolute path of the generated file via `message'.  Any
-error from `sb-sprof:report' or the underlying file write is surfaced
-through `message' rather than swallowed by the command dispatcher."
+Reports the absolute path of the generated file via `message' on
+success.  Failures (write error, missing-after-write, empty report)
+are surfaced via `editor-error' so the command dispatcher displays
+them in the echo area instead of swallowing them silently."
   (handler-case
       (progn
         (sb-sprof:stop-profiling)
@@ -57,10 +58,11 @@ through `message' rather than swallowed by the command dispatcher."
           (sb-sprof:reset)
           (cond
             ((not (probe-file file))
-             (message "sprof: write succeeded but ~A is missing" file))
+             (editor-error "sprof: write succeeded but ~A is missing" file))
             ((zerop (with-open-file (s file) (file-length s)))
-             (message "sprof: ~A is empty (no samples collected?)" file))
+             (editor-error "sprof: ~A is empty (no samples collected?)" file))
             (t
              (message "Profile written to ~A" file)))))
+    (editor-error (c) (error c))
     (error (c)
-      (message "sprof report failed: ~A: ~A" (type-of c) c))))
+      (editor-error "sprof report failed: ~A: ~A" (type-of c) c))))

--- a/src/commands/sprof.lisp
+++ b/src/commands/sprof.lisp
@@ -3,24 +3,43 @@
         :lem-core))
 (in-package :lem/commands/sprof)
 
+(defun start-profiling-in-mode (mode)
+  "Reset any prior profile and start a new one in MODE (`:alloc' or `:cpu')."
+  (sb-sprof:stop-profiling)
+  (sb-sprof:reset)
+  (sb-sprof:start-profiling :mode mode)
+  (message "Profiling started (~(~A~) mode)" mode))
+
 (define-command lem-sprof-start () ()
-  (sb-sprof:start-profiling))
+  "Start statistical profiling in CPU-sampling mode.
+
+This is the default starting point.  Use `lem-sprof-start-alloc' when
+you suspect allocation pressure rather than a CPU-bound loop.  Any
+in-progress profile is stopped and reset first, so calling this twice
+is safe."
+  (start-profiling-in-mode :cpu))
+
+(define-command lem-sprof-start-alloc () ()
+  "Start statistical profiling in allocation-sampling mode.
+
+Useful when the suspected bottleneck is heap allocation rather than CPU
+work; otherwise `lem-sprof-start' (CPU mode) is the default.  Any
+in-progress profile is stopped and reset first."
+  (start-profiling-in-mode :alloc))
 
 (define-command lem-sprof-report () ()
+  "Stop profiling, write the report to /tmp/, and reset.
+Reports the absolute path of the generated file via `message'."
+  (sb-sprof:stop-profiling)
   (multiple-value-bind (sec min hour day month year)
       (decode-universal-time (get-universal-time))
     (let ((file (format nil
-                        "lem-profile-report-~4,'0D~2,'0D~2,'0D~2,'0D~2,'0D~2,'0D"
-                        year
-                        month
-                        day
-                        hour
-                        min
-                        sec)))
-      (with-open-file (stream file 
+                        "/tmp/lem-profile-report-~4,'0D~2,'0D~2,'0D~2,'0D~2,'0D~2,'0D.txt"
+                        year month day hour min sec)))
+      (with-open-file (stream file
                               :direction :output
                               :if-exists :supersede
                               :if-does-not-exist :create)
         (sb-sprof:report :stream stream))
-      (sb-sprof:stop-profiling)
-      (sb-sprof:reset))))
+      (sb-sprof:reset)
+      (message "Profile written to ~A" file))))

--- a/src/commands/sprof.lisp
+++ b/src/commands/sprof.lisp
@@ -27,19 +27,37 @@ work; otherwise `lem-sprof-start' (CPU mode) is the default.  Any
 in-progress profile is stopped and reset first."
   (start-profiling-in-mode :alloc))
 
-(define-command lem-sprof-report () ()
-  "Stop profiling, write the report to /tmp/, and reset.
-Reports the absolute path of the generated file via `message'."
-  (sb-sprof:stop-profiling)
+(defun %sprof-report-pathname ()
+  "Return an absolute pathname for the next sprof report file."
   (multiple-value-bind (sec min hour day month year)
       (decode-universal-time (get-universal-time))
-    (let ((file (format nil
-                        "/tmp/lem-profile-report-~4,'0D~2,'0D~2,'0D~2,'0D~2,'0D~2,'0D.txt"
-                        year month day hour min sec)))
-      (with-open-file (stream file
-                              :direction :output
-                              :if-exists :supersede
-                              :if-does-not-exist :create)
-        (sb-sprof:report :stream stream))
-      (sb-sprof:reset)
-      (message "Profile written to ~A" file))))
+    (pathname
+     (format nil
+             "/tmp/lem-profile-report-~4,'0D~2,'0D~2,'0D~2,'0D~2,'0D~2,'0D.txt"
+             year month day hour min sec))))
+
+(define-command lem-sprof-report () ()
+  "Stop profiling, write the report to /tmp/, and reset.
+Reports the absolute path of the generated file via `message'.  Any
+error from `sb-sprof:report' or the underlying file write is surfaced
+through `message' rather than swallowed by the command dispatcher."
+  (handler-case
+      (progn
+        (sb-sprof:stop-profiling)
+        (let ((file (%sprof-report-pathname)))
+          (with-open-file (stream file
+                                  :direction :output
+                                  :if-exists :supersede
+                                  :if-does-not-exist :create)
+            (sb-sprof:report :stream stream)
+            (finish-output stream))
+          (sb-sprof:reset)
+          (cond
+            ((not (probe-file file))
+             (message "sprof: write succeeded but ~A is missing" file))
+            ((zerop (with-open-file (s file) (file-length s)))
+             (message "sprof: ~A is empty (no samples collected?)" file))
+            (t
+             (message "Profile written to ~A" file)))))
+    (error (c)
+      (message "sprof report failed: ~A: ~A" (type-of c) c))))

--- a/src/commands/sprof.lisp
+++ b/src/commands/sprof.lisp
@@ -28,16 +28,19 @@ in-progress profile is stopped and reset first."
   (start-profiling-in-mode :alloc))
 
 (defun %sprof-report-pathname ()
-  "Return an absolute pathname for the next sprof report file."
+  "Return an absolute pathname for the next sprof report file.
+Located in `uiop:temporary-directory' so it works on every platform Lem
+runs on, not just unix-like systems with a writable /tmp."
   (multiple-value-bind (sec min hour day month year)
       (decode-universal-time (get-universal-time))
-    (pathname
+    (merge-pathnames
      (format nil
-             "/tmp/lem-profile-report-~4,'0D~2,'0D~2,'0D~2,'0D~2,'0D~2,'0D.txt"
-             year month day hour min sec))))
+             "lem-profile-report-~4,'0D~2,'0D~2,'0D~2,'0D~2,'0D~2,'0D.txt"
+             year month day hour min sec)
+     (uiop:temporary-directory))))
 
 (define-command lem-sprof-report () ()
-  "Stop profiling, write the report to /tmp/, and reset.
+  "Stop profiling, write the report to the OS temp directory, and reset.
 Reports the absolute path of the generated file via `message'.  Any
 error from `sb-sprof:report' or the underlying file write is surfaced
 through `message' rather than swallowed by the command dispatcher."


### PR DESCRIPTION
## Summary

Quality-of-life improvements to the `lem-sprof-*` commands.

### Commands

- `lem-sprof-start` — keeps its historical **CPU-sampling** default; safe to call repeatedly (stops + resets any prior run first).
- `lem-sprof-start-alloc` — new sibling command for **allocation-sampling** profiles, useful when the bottleneck is heap pressure rather than CPU work. Shares a `start-profiling-in-mode` helper with the CPU command to avoid duplication.
- `lem-sprof-report` — stops profiling, writes the report, resets, and surfaces the absolute path in the minibuffer.

### Report file

- Written to `uiop:temporary-directory` instead of a hardcoded `/tmp/` — works on macOS (per-user temp dir, sandbox-friendly), Linux (`/tmp/`), and Windows (platform temp dir).
- Filename `lem-profile-report-<YYYYMMDDhhmmss>.txt`; `.txt` extension so editors open it in a sensible mode.
- `finish-output` on the stream before close so partial writes can't be attributed to buffering.

### Diagnostics

- `lem-sprof-report` is wrapped in `handler-case`.
- Informational success goes through `message`; failure paths use `editor-error` per `contract.yml`'s `error_handling_rule` (the command dispatcher displays them in the echo area instead of swallowing them silently).
- After write, `probe-file` + `file-length` distinguish three failure modes:
  - missing file post-write (write succeeded but file disappeared),
  - empty file (no samples were collected),
  - real success.

### Other fixes

- `lem-sprof-report` now stops profiling **before** writing the report; the original ran `sb-sprof:report` on a still-live profile and only stopped after, which could under-report final samples.
- All three commands have docstrings (was missing on `lem-sprof-start` and `lem-sprof-report`).

## Files

- `src/commands/sprof.lisp` — ~30 lines

## Test plan

- [ ] `M-x lem-sprof-start`, exercise the editor briefly, `M-x lem-sprof-report` — confirm minibuffer shows "Profile written to /.../lem-profile-report-...txt" and the file has non-trivial content.
- [ ] `M-x lem-sprof-start-alloc`, exercise briefly, `M-x lem-sprof-report` — confirm allocation-mode output in the report (look for "Number of samples" with bytes allocated rather than CPU time).
- [ ] Run `M-x lem-sprof-report` without ever calling start — confirm the diagnostic path fires as an `editor-error` ("empty (no samples collected?)") rather than a silent fail.
