### PR TITLE
fix(terminal): render prompt immediately after long commands

### DIFF
--- a/extensions/terminal/terminal.lisp
+++ b/extensions/terminal/terminal.lisp
@@ -129,7 +129,11 @@ Avoids an O(rows) scan in the hot update loop.")
                  :documentation "Number of consecutive frames skipped since last render.")
    (attribute-cache :initform (make-hash-table :test #'eql)
                     :accessor terminal-attribute-cache
-                    :documentation "Cache of packed-fixnum-key -> attribute.")))
+                    :documentation "Cache of packed-fixnum-key -> attribute.")
+   (render-deferred :initform nil
+                    :accessor terminal-render-deferred
+                    :type boolean
+                    :documentation "T when a deferred render event is already in the queue.")))
 
 (defun mark-all-rows-dirty (terminal)
   "Mark every row as dirty so the next render redraws the full screen."
@@ -155,22 +159,26 @@ Avoids an O(rows) scan in the hot update loop.")
 
 (defun update (terminal)
   (process-input terminal)
-  (when (and (= 0 (event-queue-length))
-             (not (terminal-copy-mode terminal))
+  (when (and (not (terminal-copy-mode terminal))
              (any-rows-dirty-p terminal))
-    (let* ((now (get-internal-real-time))
-           (elapsed-ms (* 1000 (/ (- now (terminal-last-render-time terminal))
-                                  internal-time-units-per-second))))
-      (cond
-        ;; Throttle: at most ~60fps unless we've already skipped 3 frames.
-        ((and (< elapsed-ms 16)
-              (< (terminal-render-skips terminal) 3))
-         (incf (terminal-render-skips terminal)))
-        (t
-         (setf (terminal-last-render-time terminal) now
-               (terminal-render-skips terminal) 0)
-         (render terminal)
-         (redraw-display))))))
+    (cond
+      ;; Other events pending — defer render to avoid starving key handling.
+      ;; Schedule a retry event so dirty rows are rendered even if no more
+      ;; PTY data arrives (fixes missing prompt after command finishes).
+      ((> (event-queue-length) 0)
+       (unless (terminal-render-deferred terminal)
+         (setf (terminal-render-deferred terminal) t)
+         (send-event (lambda ()
+                       (setf (terminal-render-deferred terminal) nil)
+                       (ignore-errors (update terminal))))))
+      (t
+       ;; Render immediately.  Previous versions skipped frames when the
+       ;; throttle interval hadn't elapsed, but that caused the final frame
+       ;; (e.g. shell prompt) to be lost when no more PTY data followed.
+       (setf (terminal-last-render-time terminal) (get-internal-real-time)
+             (terminal-render-skips terminal) 0)
+       (render terminal)
+       (redraw-display)))))
 
 (defun create (&key (rows (alexandria:required-argument :rows))
                     (cols (alexandria:required-argument :cols))


### PR DESCRIPTION
## Summary

> ⚠️ **Depends on [#2175](https://github.com/lem-project/lem/pull/2175)** (terminal overhaul). Stacked PRs across forks aren't supported by GitHub's base-branch picker, so this PR is opened against \`main\`. Until #2175 is merged, the diff here includes both PRs' commits — review only the **second commit** (\`fix(terminal): render prompt immediately…\`).

When a long-running command finishes, the final shell prompt was sometimes not rendered until the user pressed a key. The throttle-skip path in \`update\` (introduced by #2175) could swallow the last frame if no further PTY data arrived within the skip window.

This PR replaces the throttle-skip branch with a deferred-render mechanism:

- Add a **\`render-deferred\`** slot to the terminal class so only one retry event is enqueued at a time.
- When the editor's event queue is non-empty, **schedule a retry event** instead of rendering immediately — keeps key handling responsive.
- When the queue is empty, **render immediately**. (The previous throttle \`setf\` is left in place as a no-op without the skip check; can be cleaned up in a follow-up.)

## Files (delta on top of #2175)

- \`extensions/terminal/terminal.lisp\` — ~20 lines

## Test plan

- [ ] Run \`yes | head -50\` in the terminal; confirm prompt appears immediately when the command exits
- [ ] Hit Enter on an empty prompt — should render instantly
- [ ] Spam keystrokes while output is streaming; verify no lost keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)