### PR TITLE
perf(sdl2): scratch-rect to eliminate per-frame SDL_Rect allocs

### DIFF
--- a/frontends/sdl2/display.lisp
+++ b/frontends/sdl2/display.lisp
@@ -39,7 +39,10 @@
            :adapt-high-dpi-font-size
            :change-font
            :with-renderer
-           :with-display-render-target))
+           :with-display-render-target
+           :display-scratch-rect
+           :call-with-scratch-rect
+           :with-scratch-rect))
 (in-package :lem-sdl2/display)
 
 (defvar *display*)
@@ -87,7 +90,34 @@
                          :accessor display-redraw-at-least-once-p)
    (scale :initform '(1 1)
           :initarg :scale
-          :accessor display-scale)))
+          :accessor display-scale)
+   (scratch-rect :initform (sdl2:make-rect 0 0 0 0)
+                 :reader display-scratch-rect
+                 :documentation
+                 "Pre-allocated SDL_Rect reused across all render calls to
+avoid heap-allocating a new rect + Lisp wrapper on every draw-rect,
+fill-to-end-of-line, render-texture, etc.  Mutated in-place by
+`call-with-scratch-rect' / `with-scratch-rect'; do not rely on its
+contents outside the dynamic extent of that call.")))
+
+(declaim (inline call-with-scratch-rect))
+(defun call-with-scratch-rect (display x y w h function)
+  "Set the display's scratch SDL_Rect to (X Y W H) and call FUNCTION with it.
+Single mutation + funcall — no heap allocation.  Used by
+`with-scratch-rect'; expose the underlying function so callers that
+want to pass a closure directly can skip the macro."
+  (let ((rect (display-scratch-rect display)))
+    (setf (sdl2:rect-x rect) x
+          (sdl2:rect-y rect) y
+          (sdl2:rect-width rect) w
+          (sdl2:rect-height rect) h)
+    (funcall function rect)))
+
+(defmacro with-scratch-rect ((var display-form x y w h) &body body)
+  "Bind VAR to the display's pre-allocated SDL_Rect with fields set to X Y W H.
+The rect is mutated in-place — no heap allocation occurs.  Thin wrapper
+over `call-with-scratch-rect'."
+  `(call-with-scratch-rect ,display-form ,x ,y ,w ,h (lambda (,var) ,@body)))
 
 (defmethod display-latin-font ((display display))
   (font:font-latin-normal-font (display-font display)))
@@ -231,7 +261,7 @@
         (y (* y (display-char-height display)))
         (width (* width (display-char-width display)))
         (height (* height (display-char-height display))))
-    (sdl2:with-rects ((rect x y width height))
+    (with-scratch-rect (rect display x y width height)
       (set-render-color display color)
       (sdl2:render-fill-rect (display-renderer display) rect))))
 
@@ -240,7 +270,7 @@
   (sdl2:render-draw-line (display-renderer display) x1 y1 x2 y2))
 
 (defmethod render-fill-rect-by-pixels ((display display) x y width height &key color)
-  (sdl2:with-rects ((rect x y width height))
+  (with-scratch-rect (rect display x y width height)
     (set-render-color display color)
     (sdl2:render-fill-rect (display-renderer display) rect)))
 
@@ -249,7 +279,7 @@
          (y1 (- (* y (display-char-height display)) (floor (display-char-height display) 2)))
          (x2 (1- (+ x1 (* (+ w 1) (display-char-width display)))))
          (y2 (+ y1 (* (+ h 1) (display-char-height display)))))
-    (sdl2:with-rects ((rect x1 y1 (- x2 x1) (- y2 y1)))
+    (with-scratch-rect (rect display x1 y1 (- x2 x1) (- y2 y1))
       (set-render-color display (display-background-color display))
       (sdl2:render-fill-rect (display-renderer display) rect))
     (sdl2:with-points ((upleft x1 y1)

--- a/frontends/sdl2/drawing.lisp
+++ b/frontends/sdl2/drawing.lisp
@@ -144,7 +144,7 @@ Uses a sentinel key so it participates in the normal cache lifecycle
   0)
 
 (defun draw-rect (display x y width height color)
-  (sdl2:with-rects ((rect x y width height))
+  (display:with-scratch-rect (rect display x y width height)
     (display:set-render-color display color)
     (sdl2:render-fill-rect (display:display-renderer display) rect)))
 
@@ -171,12 +171,12 @@ Uses a sentinel key so it participates in the normal cache lifecycle
            (draw-cursor display x y surface-width surface-height background))
           (t
            (draw-rect display x y surface-width surface-height background)))
-    (lem-sdl2/utils:render-texture (display:display-renderer display)
-                                   texture
-                                   x
-                                   y
-                                   surface-width
-                                   surface-height)
+    (display:with-scratch-rect (dest-rect display x y surface-width surface-height)
+      (sdl2:render-copy-ex (display:display-renderer display)
+                           texture
+                           :source-rect nil
+                           :dest-rect dest-rect
+                           :flip (list :none)))
     (when (and attribute
                (lem:attribute-underline attribute))
       (display:render-line display
@@ -205,10 +205,11 @@ Uses a sentinel key so it participates in the normal cache lifecycle
 
 (defmethod draw-object ((drawing-object extend-to-eol-object) x bottom-y display view)
   (display:set-render-color display (extend-to-eol-object-color drawing-object))
-  (sdl2:with-rects ((rect x
-                          (- bottom-y (display:display-char-height display))
-                          (- (lem-if:view-width (lem-core:implementation) view) x)
-                          (display:display-char-height display)))
+  (display:with-scratch-rect (rect display
+                              x
+                              (- bottom-y (display:display-char-height display))
+                              (- (lem-if:view-width (lem-core:implementation) view) x)
+                              (display:display-char-height display))
     (sdl2:render-fill-rect (display:display-renderer display) rect))
   (object-width drawing-object display))
 
@@ -227,12 +228,12 @@ Uses a sentinel key so it participates in the normal cache lifecycle
          (texture (sdl2:create-texture-from-surface (display:display-renderer display)
                                                     (image-object-image drawing-object)))
          (y (- bottom-y surface-height)))
-    (lem-sdl2/utils:render-texture (display:display-renderer display)
-                                   texture
-                                   x
-                                   y
-                                   surface-width
-                                   surface-height)
+    (display:with-scratch-rect (dest-rect display x y surface-width surface-height)
+      (sdl2:render-copy-ex (display:display-renderer display)
+                           texture
+                           :source-rect nil
+                           :dest-rect dest-rect
+                           :flip (list :none)))
     (sdl2:destroy-texture texture)
     surface-width))
 
@@ -258,7 +259,7 @@ Uses a sentinel key so it participates in the normal cache lifecycle
             (draw-object object current-x y display view)))
 
 (defun fill-to-end-of-line (display view x y height &optional default-attribute)
-  (sdl2:with-rects ((rect x y (- (lem-if:view-width (lem-core:implementation) view) x) height))
+  (display:with-scratch-rect (rect display x y (- (lem-if:view-width (lem-core:implementation) view) x) height)
     (display:set-render-color display
                               (lem-core:attribute-background-color default-attribute))
     (sdl2:render-fill-rect (display:display-renderer display) rect)))
@@ -294,10 +295,11 @@ Uses a sentinel key so it participates in the normal cache lifecycle
   (display:with-display (display)
     (display:set-render-color display
                               (display:display-background-color display))
-    (sdl2:with-rects ((rect 0
-                            y
-                            (lem-if:view-width implementation view)
-                            (- (lem-if:view-height implementation view) y)))
+    (display:with-scratch-rect (rect display
+                                0
+                                y
+                                (lem-if:view-width implementation view)
+                                (- (lem-if:view-height implementation view) y))
       (sdl2:render-fill-rect (display:display-renderer display) rect))))
 
 (defmethod lem-core:redraw-buffer :before ((implementation lem-sdl2/sdl2:sdl2) buffer window force)


### PR DESCRIPTION
## Summary

> ⚠️ **Depends on [#2177](https://github.com/lem-project/lem/pull/2177)** (sdl2 memory-leak fixes). Stacked PRs across forks aren't supported by GitHub's base-branch picker, so this PR is opened against \`main\`. Until #2177 is merged, the diff here includes both PRs' commits — review only the **second commit** (\`perf(sdl2): scratch-rect…\`).

\`sdl2:with-rects\` heap-allocates an \`SDL_Rect\` every call. In the redraw hot path that fires thousands of times per frame. This PR puts a single \`SDL_Rect\` on the \`display\` object and provides a \`with-scratch-rect\` macro that fills it in instead of allocating.

### \`frontends/sdl2/display.lisp\`
- Add a **\`scratch-rect\`** slot to the display class
- \`with-scratch-rect\` macro
- Switch \`render-fill-rect\`, \`render-fill-rect-by-pixels\`, and \`render-border\` to the scratch rect

### \`frontends/sdl2/drawing.lisp\`
- Switch \`draw-rect\`, \`extend-to-eol\`, \`fill-to-end-of-line\`, and \`clear-to-end-of-window\` to \`with-scratch-rect\`
- Inline \`render-copy-ex\` with the scratch rect in \`draw-object\` on \`text-object\` and \`image-object\` instead of going through the \`render-texture\` helper that allocated a fresh rect

## Files (delta on top of #2177)

| File | Lines |
|---|---|
| \`frontends/sdl2/display.lisp\` | +27 |
| \`frontends/sdl2/drawing.lisp\` | +19 |

~50 lines.

## Test plan

- [ ] Smoke-test under sdl2 frontend — confirm visuals are identical
- [ ] Confirm no aliasing issues: nested rendering paths should not stomp the scratch rect mid-call
- [ ] Profile (\`/lem-sprof-start\` then exercise the editor) and confirm reduced allocation in drawing methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)