### PR TITLE
chore(terminal): add build script for lem-terminal native helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,18 @@ webview-ncurses:
 
 lem: webview
 
-.PHONY: legit
+.PHONY: legit terminal-lib
 
 legit:
 	qlot install
 	$(LISP) --load .qlot/setup.lisp \
 		--load scripts/build-legit.lisp
+
+# Build the lem-terminal native helper (terminal.so) for the current
+# platform. Requires libvterm and a C toolchain. Optional: lem-terminal
+# silently disables itself at runtime when the library is missing.
+terminal-lib:
+	$(LISP) --load scripts/build-terminal.lisp
 
 install-bin:
 	install -m 755 lem $(PREFIX)/bin

--- a/scripts/build-terminal.lisp
+++ b/scripts/build-terminal.lisp
@@ -1,0 +1,73 @@
+;;;; Build the lem-terminal native helper (terminal.so) for the current
+;;;; platform from extensions/terminal/terminal.c.
+;;;;
+;;;; Requires a C compiler and libvterm. On Linux, also requires libutil
+;;;; (for forkpty); macOS provides it via libc.
+;;;;
+;;;; Invoke via `make terminal-lib` or directly:
+;;;;   sbcl --script scripts/build-terminal.lisp
+;;;;
+;;;; The resulting .so is written under
+;;;;   extensions/terminal/lib/<os>/<arch>/terminal.so
+;;;; which matches the path lem-terminal/ffi.lisp pushes onto
+;;;; cffi:*foreign-library-directories*.
+
+(require :asdf)
+(require :uiop)
+
+(asdf:load-asd
+ (merge-pathnames "extensions/terminal/lem-terminal.asd"
+                  (uiop:getcwd)))
+
+(defun terminal-source ()
+  (asdf:system-relative-pathname :lem-terminal "terminal.c"))
+
+(defun detect-architecture ()
+  "Match ffi.lisp's runtime path resolution. Falls back to *features*
+when uiop:architecture returns NIL (older bundled UIOP on Apple Silicon)."
+  (or (uiop:architecture)
+      (cond ((member :arm64 *features*) :arm64)
+            ((member :aarch64 *features*) :arm64)
+            ((member :x86-64 *features*) :x64)
+            ((member :x86 *features*) :x86)
+            (t (error "Could not detect architecture from *features*: ~A"
+                      *features*)))))
+
+(defun terminal-lib ()
+  (asdf:system-relative-pathname
+   :lem-terminal
+   (format nil "~(lib/~A/~A/terminal.so~)"
+           (uiop:operating-system)
+           (detect-architecture))))
+
+(defun build-command (source lib)
+  (let ((cc (or (uiop:getenv "CC") "cc"))
+        (cflags (or (uiop:getenv "CFLAGS") ""))
+        (ldflags (or (uiop:getenv "LDFLAGS") "")))
+    (format nil
+            #+darwin "~A ~A ~A -I/opt/homebrew/include -L/opt/homebrew/lib -lvterm ~A -o ~A -shared -fPIC"
+            #-darwin "~A ~A ~A -lvterm -lutil ~A -o ~A -shared -fPIC"
+            cc cflags (namestring source) ldflags (namestring lib))))
+
+(defun build-terminal ()
+  (let* ((source (terminal-source))
+         (lib (terminal-lib))
+         (cmd (build-command source lib)))
+    (unless (probe-file source)
+      (error "terminal.c not found at ~A" source))
+    (ensure-directories-exist lib)
+    (format t "~&Building lem-terminal native helper:~%  ~A~%" cmd)
+    (handler-case
+        (progn
+          (uiop:run-program cmd :output t :error-output t)
+          (format t "~&Wrote ~A~%" lib))
+      (uiop:subprocess-error (c)
+        (format *error-output*
+                "~&Failed to build terminal.so: ~A~%~
+                 The lem-terminal extension will silently disable itself at~%~
+                 runtime when the shared library is missing. Install libvterm~%~
+                 (and a C toolchain) to enable it.~%"
+                c)
+        (uiop:quit 1)))))
+
+(build-terminal)


### PR DESCRIPTION
## Summary

Adds `scripts/build-terminal.lisp` and a `make terminal-lib` target that compiles `extensions/terminal/terminal.c` into the platform-specific path `extensions/terminal/lib/<os>/<arch>/terminal.so` — the same path `extensions/terminal/ffi.lisp` already pushes onto `cffi:*foreign-library-directories*` at runtime.

This is the missing build path discussed in #1964 and #2060, so the prebuilt `.so` binaries can eventually be removed from version control without breaking source installs.

## Why this scope

The target is **optional and standalone**:

- `lem-terminal/ffi.lisp` already wraps `cffi:use-foreign-library` in `ignore-errors`, so platforms without libvterm or a C toolchain continue to work — they just don't get the terminal extension.
- The main `make sdl2` / `make ncurses` / `make webview` targets are **unchanged**, so this doesn't add a hard libvterm dependency to normal builds.
- The committed `.so` binaries are **not removed** in this PR. Removing them can be done in a follow-up (or by reopening #1964) once CI is verified producing them.

## Details

- Honors `CC`, `CFLAGS`, `LDFLAGS` env vars for cross-distro / Nix / Guix friendliness.
- Uses the Guix package's `-lutil` on Linux for `forkpty`; macOS uses Homebrew's `-I/opt/homebrew/include -L/opt/homebrew/lib`.
- Falls back to deriving architecture from `*features*` when `uiop:architecture` returns `NIL` (older bundled UIOP on Apple Silicon).
- Surfaces a clear error and exits non-zero if compilation fails, so it's safe to wire into CI later.

## Test plan

- [x] `make terminal-lib` on macOS arm64 (Homebrew libvterm) produces a working `extensions/terminal/lib/macosx/arm64/terminal.so` (byte-identical size to the committed one).
- [ ] `make terminal-lib` on Linux x64 with libvterm + libutil.
- [ ] `make terminal-lib` on a host without libvterm — exits non-zero with the install hint, does not corrupt the tree.
- [ ] `make sdl2` / `make ncurses` / `make webview` still build without touching the terminal helper.
- [ ] Verify `lem-terminal` loads the freshly-built `.so` at runtime by opening a `*terminal*` buffer.

Refs #1964, #2060.