### PR TITLE
filer: handle mouse button-1 clicks on side-window

### DIFF
--- a/src/mouse.lisp
+++ b/src/mouse.lisp
@@ -96,6 +96,12 @@
     (when callback
       (funcall callback window point))))
 
+(defmethod handle-button-1 ((window side-window) x y clicks)
+  (let* ((point (get-point-from-window-with-coordinates window x y))
+         (callback (text-property-at point :click-callback)))
+    (when callback
+      (funcall callback window point))))
+
 (defmethod handle-button-1 ((window floating-window) x y clicks)
   (if (floating-window-focusable-p window)
       (call-next-method)))


### PR DESCRIPTION
## Summary
Mouse clicks on the filer were silently swallowed because `handle-button-1` had no specialization for `side-window`. The filer lives in a side-window, so directory expand/collapse and file selection via the mouse did not work in any frontend.

This adds a `handle-button-1` method for `side-window` that invokes the `:click-callback` text-property at the clicked point — the same mechanism already used by the regular window method.

## Test plan
- [ ] Open the filer (`M-x filer`) and click a directory: it expands/collapses
- [ ] Click a file: it opens
- [ ] Verify on both SDL2 and ncurses frontends