### PR TITLE
vi-mode: give filer-mode keymap priority over vi-state keymaps

### DIFF
--- a/extensions/vi-mode/special-binds.lisp
+++ b/extensions/vi-mode/special-binds.lisp
@@ -5,6 +5,9 @@
   (:import-from :lem/directory-mode
                 :directory-mode
                 :*directory-mode-keymap*)
+  (:import-from :lem/filer
+                :filer-mode
+                :*filer-mode-keymap*)
   (:import-from :lem-lisp-mode/sldb
                 :sldb-mode
                 :*sldb-keymap*)
@@ -24,6 +27,9 @@
 
 (defmethod mode-specific-keymaps ((mode lisp-inspector-mode))
   (list *lisp-inspector-keymap*))
+
+(defmethod mode-specific-keymaps ((mode filer-mode))
+  (list *filer-mode-keymap*))
 
 (defmethod mode-specific-keymaps ((mode dashboard-mode))
   (list *dashboard-mode-keymap*))


### PR DESCRIPTION
## Summary
In vi-mode, the normal-state keymap was shadowing the filer's own keybindings (e.g. `Return` to expand, `D` to delete), making the filer largely unusable when vi-mode is active.

This adds a `mode-specific-keymaps` method for `filer-mode` that injects `*filer-mode-keymap*` ahead of the vi-state keymaps in the lookup chain — same pattern already used for `directory-mode`, `sldb-mode`, `lisp-inspector-mode`, and `dashboard-mode`.

Depends conceptually on the filer exports in #2185 (separate PR) but works independently since `lem/filer` already exports `filer-mode` and `*filer-mode-keymap*` after that change lands.

## Test plan
- [ ] Enable vi-mode, open the filer, press `Return` on a directory → expands
- [ ] Press `D` on a file → delete prompt
- [ ] Verify non-vi-mode behavior is unchanged