### PR TITLE
filer: auto-focus on open and export entry-point commands

### DIFF
--- a/src/ext/filer.lisp
+++ b/src/ext/filer.lisp
@@ -33,9 +33,18 @@ Each function takes (point item root-directory) arguments.")
 
 (define-major-mode filer-mode ()
     (:name "Filer"
-     :keymap *filer-mode-keymap*)
+     :keymap *filer-mode-keymap*
+     :description "Major mode for the Filer tree view buffer.
+Renders a navigable directory tree in a side window. Use Return to
+expand or open the item at point and D to delete the file at point.")
   (setf (variable-value 'line-wrap :buffer (current-buffer)) nil)
   (setf (buffer-read-only-p (current-buffer)) t))
+
+(setf (documentation '*filer-mode-keymap* 'variable)
+      "Keymap active in `filer-mode' buffers.
+Bindings here take precedence over global bindings while a Filer
+buffer is current. Other modes (e.g. vi-mode) can reference this
+keymap to ensure Filer bindings remain reachable.")
 
 (define-key *global-keymap* "C-x d" 'filer)
 (define-key *filer-mode-keymap* "Return" 'filer-select)
@@ -299,7 +308,7 @@ Expands the tree to show the buffer's directory and highlights the current file.
 
 (defun focus-filer-window ()
   "Switch focus to the filer's leftside window if it exists."
-  (alexandria:when-let ((window (lem-core::frame-leftside-window (current-frame))))
+  (alexandria:when-let ((window (frame-leftside-window (current-frame))))
     (switch-to-window window)))
 
 (define-command filer () ()

--- a/src/ext/filer.lisp
+++ b/src/ext/filer.lisp
@@ -40,15 +40,15 @@ expand or open the item at point and D to delete the file at point.")
   (setf (variable-value 'line-wrap :buffer (current-buffer)) nil)
   (setf (buffer-read-only-p (current-buffer)) t))
 
+(define-key *global-keymap* "C-x d" 'filer)
+(define-key *filer-mode-keymap* "Return" 'filer-select)
+(define-key *filer-mode-keymap* "D" 'filer-delete-file)
+
 (setf (documentation '*filer-mode-keymap* 'variable)
       "Keymap active in `filer-mode' buffers.
 Bindings here take precedence over global bindings while a Filer
 buffer is current. Other modes (e.g. vi-mode) can reference this
 keymap to ensure Filer bindings remain reachable.")
-
-(define-key *global-keymap* "C-x d" 'filer)
-(define-key *filer-mode-keymap* "Return" 'filer-select)
-(define-key *filer-mode-keymap* "D" 'filer-delete-file)
 
 (defclass item ()
   ((pathname :initarg :pathname

--- a/src/ext/filer.lisp
+++ b/src/ext/filer.lisp
@@ -13,7 +13,12 @@
            :*filer-item-inserters*
            :root-item
            :render
-           :filer-buffer))
+           :filer-buffer
+           :filer-mode
+           :*filer-mode-keymap*
+           :filer
+           :filer-directory
+           :filer-at-directory))
 (in-package :lem/filer)
 
 (defparameter *filer-item-inserters* '()
@@ -292,19 +297,26 @@ Expands the tree to show the buffer's directory and highlights the current file.
     (next-window))
   (delete-leftside-window))
 
+(defun focus-filer-window ()
+  "Switch focus to the filer's leftside window if it exists."
+  (alexandria:when-let ((window (lem-core::frame-leftside-window (current-frame))))
+    (switch-to-window window)))
+
 (define-command filer () ()
   "Open the filer tree view at the project root."
   (if (filer-active-p)
       (deactive-filer)
       (let ((directory (lem-core/commands/project:find-root (buffer-directory))))
-        (make-leftside-window (make-filer-buffer directory)))))
+        (make-leftside-window (make-filer-buffer directory))
+        (focus-filer-window))))
 
 (define-command filer-directory () ()
   "Open the filer tree view at this directory."
   (if (filer-active-p)
       (deactive-filer)
       (let ((directory (buffer-directory)))
-        (make-leftside-window (make-filer-buffer directory)))))
+        (make-leftside-window (make-filer-buffer directory))
+        (focus-filer-window))))
 
 (define-command filer-at-directory () ()
   "Prompt for a directory and open the filer tree view at this directory."
@@ -314,7 +326,8 @@ Expands the tree to show the buffer's directory and highlights the current file.
                                          :use-border t)))
     (when (filer-active-p)
       (deactive-filer))
-    (make-leftside-window (make-filer-buffer directory))))
+    (make-leftside-window (make-filer-buffer directory))
+    (focus-filer-window)))
 
 (define-command filer-select () ()
   (select (back-to-indentation (current-point))))


### PR DESCRIPTION
## Summary
- Auto-focus the filer's leftside window after `filer`, `filer-directory`, and `filer-at-directory` create it. Previously focus stayed on the prior buffer, requiring `C-x o` before any interaction.
- Export `:filer`, `:filer-directory`, `:filer-at-directory`, `:filer-mode`, and `:*filer-mode-keymap*` from `:lem/filer` so user config files can reference them with single-colon syntax and other packages (e.g. vi-mode) can register the keymap.

## Test plan
- [ ] `M-x filer` immediately accepts filer keybindings without `C-x o`
- [ ] Same for `filer-directory` and `filer-at-directory`
- [ ] `(lem/filer:filer)` resolves from user init.lisp