### PR TITLE
grep: export project-grep

### DIFF
--- a/src/ext/grep.lisp
+++ b/src/ext/grep.lisp
@@ -3,6 +3,7 @@
         :lem)
   (:export
    :grep
+   :project-grep
    :change-grep-command
    :*grep-command*
    :*grep-args*)


### PR DESCRIPTION
## Summary
Add `:project-grep` to the `:lem/grep` package exports so it can be referenced as `lem/grep:project-grep` from user config files. Previously it was only reachable via internal `::` syntax.

## Test plan
- [ ] `(lem/grep:project-grep)` resolves and runs from a user init.lisp