### PR TITLE
transient: add configurable delay before showing popup

### DIFF
--- a/extensions/transient/keymap.lisp
+++ b/extensions/transient/keymap.lisp
@@ -14,10 +14,32 @@
       (*transient-always-show*
        (or keymap *root-keymap*)))))
 
+(defun show-transient-with-delay (keymap)
+  "show the transient popup for KEYMAP, either immediately or after a delay.
+if the popup is already visible (e.g. navigating sub-menus), show immediately.
+otherwise, wait *transient-popup-delay* milliseconds before showing."
+  (cancel-transient-delay-timer)
+  (let ((delay *transient-popup-delay*))
+    (if (or (null delay)
+            (<= delay 0)
+            (transient-window-alive-p))
+        ;; show immediately: no delay configured, or popup already visible (sub-menu navigation)
+        (show-transient keymap)
+        ;; delayed: start a one-shot timer
+        (let ((target-keymap keymap))
+          (setf *transient-delay-timer*
+                (start-timer
+                 (make-timer (lambda ()
+                               (let ((resolved (resolve-transient-keymap target-keymap)))
+                                 (when resolved
+                                   (show-transient resolved))))
+                             :name "transient-popup-delay")
+                 delay))))))
+
 (defmethod keymap-activate ((keymap keymap))
   (let ((resolved (resolve-transient-keymap keymap)))
     (if resolved
-        (show-transient resolved)
+        (show-transient-with-delay resolved)
         (hide-transient))))
 
 (defgeneric mode-transient-keymap (mode)

--- a/extensions/transient/popup.lisp
+++ b/extensions/transient/popup.lisp
@@ -29,13 +29,18 @@
 
 (defvar *transient-popup-delay*
   500
-  "delay in milliseconds before showing the transient popup.
-set to 0 or nil to show immediately (no delay).
-default is 500ms, similar to doom emacs which-key-idle-delay.")
+  "User-configurable delay in milliseconds before the transient popup appears.
+Set to 0 or nil to show immediately (no delay). Default is 500ms.
+When the user completes a key sequence faster than this delay, the
+popup never appears, avoiding flicker for fast typists.")
 
 (defvar *transient-delay-timer*
   nil
-  "internal timer used for delayed popup display.")
+  "Internal timer scheduling the delayed popup display, or nil when idle.
+Held as global state to mirror the lifecycle of `*transient-popup-window*':
+both must be reachable from `hide-transient' and from any subsequent
+`keymap-activate' so the pending popup can be canceled regardless of
+which call site aborts the transient sequence.")
 
 (define-attribute transient-matched-key-attribute
   (t

--- a/extensions/transient/popup.lisp
+++ b/extensions/transient/popup.lisp
@@ -27,6 +27,16 @@
   nil
   "whether to always show the transient buffer. by default only keymaps that have show-p set are shown.")
 
+(defvar *transient-popup-delay*
+  500
+  "delay in milliseconds before showing the transient popup.
+set to 0 or nil to show immediately (no delay).
+default is 500ms, similar to doom emacs which-key-idle-delay.")
+
+(defvar *transient-delay-timer*
+  nil
+  "internal timer used for delayed popup display.")
+
 (define-attribute transient-matched-key-attribute
   (t
    :foreground (attribute-foreground (ensure-attribute 'syntax-string-attribute))))
@@ -513,8 +523,16 @@ prefixes marked as :intermediate-p are flattened and shown with concatenated key
             (max 0 (- current *transient-horizontal-scroll-amount*))))
     (redraw-display)))
 
+(defun cancel-transient-delay-timer ()
+  "cancel any pending delayed popup timer."
+  (when (and *transient-delay-timer*
+             (not (timer-expired-p *transient-delay-timer*)))
+    (stop-timer *transient-delay-timer*))
+  (setf *transient-delay-timer* nil))
+
 (defun hide-transient ()
   "hide (delete) the transient window."
+  (cancel-transient-delay-timer)
   (when (and *transient-popup-window*
              (not (deleted-window-p *transient-popup-window*)))
     (modeline-remove-status-list 'transient-scroll-status)

--- a/extensions/transient/transient.lisp
+++ b/extensions/transient/transient.lisp
@@ -2,6 +2,7 @@
   (:use :cl :lem)
   (:export
    :*transient-always-show*
+   :*transient-popup-delay*
    :*transient-mode-keymap*
    :define-transient
    :define-prefix


### PR DESCRIPTION
## Summary
Add a configurable delay before the transient popup appears. The popup waits 500ms by default before showing — if the user completes the key sequence before the timer fires, the popup never appears, avoiding flicker for fast typists. Once the popup is already visible (e.g. navigating sub-menus), subsequent keymaps show immediately.

New exported variable: `lem/transient:*transient-popup-delay*`

```lisp
;; Adjust delay (default 500ms)
(setf lem/transient:*transient-popup-delay* 300)

;; Disable delay (show immediately)
(setf lem/transient:*transient-popup-delay* 0)
```

## Implementation notes
- `show-transient-with-delay` schedules a one-shot timer via `start-timer`; if a popup is already alive it bypasses the delay.
- `cancel-transient-delay-timer` clears any pending timer; called from `hide-transient` and at the start of each new activation, so an aborted sequence never produces a stale popup.

## Test plan
- [ ] Press a transient prefix and hold for >500ms → popup appears
- [ ] Press a full transient binding faster than the delay → popup never shows
- [ ] Navigate a sub-menu inside an open popup → child appears immediately
- [ ] `(setf lem/transient:*transient-popup-delay* 0)` → popup shows instantly