### PR TITLE
removed code that conflicts with qlot asdf environment

### DIFF
--- a/extensions/lisp-mode/lisp-mode.lisp
+++ b/extensions/lisp-mode/lisp-mode.lisp
@@ -236,11 +236,6 @@
       (connect-to-micros *localhost* port)
       (update-buffer-package)
 
-      ;; XXX:
-      ;; Systems added after lem initialization are not visible from within this process and must
-      ;; be re-initialized.
-      (asdf:clear-source-registry)
-
       (setf *self-connected-port* port))))
 
 (defun self-connection ()

--- a/src/lem.lisp
+++ b/src/lem.lisp
@@ -47,20 +47,12 @@
       (unless (uiop:pathname-equal current-dir (user-homedir-pathname))
         (maybe-load (merge-pathnames ".lemrc" current-dir))))))
 
-(defun initialize-source-registry ()
-  (asdf:initialize-source-registry
-   `(:source-registry
-     :inherit-configuration
-     (:also-exclude ".qlot")
-     (:tree ,(asdf:system-source-directory :lem)))))
-
 (defun init-at-build-time ()
   "This function is called when an lem executable file is built.
 If a file named $HOME/.lem/build-init.lisp exists, it is loaded.
 The difference is that init.lisp loading is called when the editor is started,
 while build-init.lisp is called when the binary file is created.
 See scripts/build-ncurses.lisp or scripts/build-sdl2.lisp"
-  (initialize-source-registry)
   (let ((file (merge-pathnames "build-init.lisp" (lem-home))))
     (when (uiop:file-exists-p file)
       (load file))))


### PR DESCRIPTION
# Overview 
qlot establishes an ASFD environment to find and use project-local packages.  As I have been tinkering with Lem, I have also been messing with Lem's dependencies as well.  The best method I have found to incorporate my changes locally is to fork/clone the code of the dependency, then in the `qlfile` change the dependency from `git [system] [url]` to `local [system] [pathname]`. 

For a while now, this has allowed me to compile Lem with my changes baked in.  There has always been weird behavior when trying to add packages in after compiling, however.  This is especially a problem when adding new dependencies that no extensions or subsystems depend on yet.  Even if I specified a local installation in the qlfile, asdf and quicklisp would reach out and download the existing version if I tried to load it after starting lem.

The problem seems to be that qlots configuration is being overwritten at some point.  I tracked down two places where this was happening:

## src/lem.lisp

the function `initialize-source-registry` is called during end of the build.  I'm not exactly sure of the details of initializing the source registry, but it had the effect of clearing the configuration done by qlot.

## extensions/lisp-mode/lisp-mode.lisp

the `self-connect` function, called when opening a new lisp-repl, cleared the `asdf:source-registry`.  This line was written before Lem was using qlot, I think the problem it was trying to solve is no longer relevant.
