### PR TITLE
fix: describe-bindings freeze and crash

### DIFF
--- a/lem-tests.asd
+++ b/lem-tests.asd
@@ -58,6 +58,7 @@
                (:file "syntax-test")
                (:file "syntax-scanner")
                (:file "buffer-list-test")
+               (:file "keymap")
                (:file "popup-window")
                (:file "prompt")
                (:file "cursors")

--- a/src/commands/help.lisp
+++ b/src/commands/help.lisp
@@ -38,6 +38,7 @@
                                            column-width
                                            (keyseq-to-string kseq)
                                            (symbol-name command)))))
+              (setf keymap nil)
               (terpri s))))
 
 (define-command describe-bindings () ()

--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -594,7 +594,7 @@ higher-priority keymap (e.g. vi normal mode remaps self-insert to undefined-key)
                (cond ((or (typep suffix 'keymap)
                           (typep suffix 'prefix))
                       (traverse-node suffix (cons key prefix)))
-                     (t
+                     ((symbolp suffix)
                       (funcall fun (reverse (cons key prefix)) suffix)))))
            (traverse-node (node prefix)
              (cond ((typep node 'keymap)

--- a/tests/keymap.lisp
+++ b/tests/keymap.lisp
@@ -1,0 +1,49 @@
+(defpackage :lem-tests/keymap-test
+  (:use :cl :rove)
+  (:import-from :lem-core
+                :make-keymap
+                :make-prefix
+                :keymap-add-prefix
+                :make-key
+                :traverse-keymap))
+(in-package :lem-tests/keymap-test)
+
+(defun make-test-keymap-with-closure-suffix ()
+  "A keymap holding one normal symbol binding and one prefix whose
+suffix is a closure -- the shape produced by transient toggle/choice
+infixes."
+  (let ((keymap (make-keymap :description 'test-keymap))
+        (closure (lambda () 'transient-thunk)))
+    (keymap-add-prefix keymap (make-prefix :key (make-key :sym "a")
+                                           :suffix 'real-command))
+    (keymap-add-prefix keymap (make-prefix :key (make-key :sym "b")
+                                           :suffix closure))
+    (values keymap closure)))
+
+(deftest traverse-keymap-skips-non-symbol-suffixes
+  (multiple-value-bind (keymap closure) (make-test-keymap-with-closure-suffix)
+    (let ((yielded '()))
+      (traverse-keymap keymap
+                       (lambda (kseq cmd)
+                         (declare (ignore kseq))
+                         (push cmd yielded)))
+      (ok (every #'symbolp yielded))
+      (ok (member 'real-command yielded))
+      (ng (member closure yielded)))))
+
+#+sbcl
+(deftest describe-bindings-internal-terminates
+  (let ((keymap (make-test-keymap-with-closure-suffix))
+        (output nil))
+    (let ((result
+            (handler-case
+                (bordeaux-threads:with-timeout (5)
+                  (setf output
+                        (with-output-to-string (s)
+                          (lem-core/commands/help::describe-bindings-internal
+                           s "test" keymap t)))
+                  :ok)
+              (bordeaux-threads:timeout () :timed-out)
+              (error (e) (cons :error e)))))
+      (ok (eq result :ok))
+      (ok (search "real-command" (or output ""))))))

--- a/tests/keymap.lisp
+++ b/tests/keymap.lisp
@@ -21,6 +21,10 @@ infixes."
     (values keymap closure)))
 
 (deftest traverse-keymap-skips-non-symbol-suffixes
+  "Regression test for #2100: transient closures (toggle/choice infix
+suffixes) must not be yielded to traverse-keymap callbacks, since
+callers like describe-bindings-internal call symbol-name on the
+result and would signal a type-error on function objects."
   (multiple-value-bind (keymap closure) (make-test-keymap-with-closure-suffix)
     (let ((yielded '()))
       (traverse-keymap keymap
@@ -33,6 +37,10 @@ infixes."
 
 #+sbcl
 (deftest describe-bindings-internal-terminates
+  "Regression test for #2100: describe-bindings-internal used to loop
+forever because the keymap-walk advance was removed but the
+surrounding (loop :while keymap ...) was kept.  Wrap the call in a
+timeout so a regression fails CI cleanly instead of hanging it."
   (let ((keymap (make-test-keymap-with-closure-suffix))
         (output nil))
     (let ((result
@@ -40,6 +48,11 @@ infixes."
                 (bordeaux-threads:with-timeout (5)
                   (setf output
                         (with-output-to-string (s)
+                          ;; Internal access: this helper is intentionally
+                          ;; not exported (-internal suffix); the test pins
+                          ;; down the regression at the unit level rather
+                          ;; than committing to its stream-printing shape
+                          ;; as a public contract.
                           (lem-core/commands/help::describe-bindings-internal
                            s "test" keymap t)))
                   :ok)


### PR DESCRIPTION
# Fix: `describe-bindings` freezes and crashes

## Summary

Running `M-x describe-bindings` would freeze LEM (infinite loop) and, once that was fixed, crash with a type error on buffers with transient keybindings.

## Root Cause

Two bugs, both regressions from PR [#2100](https://github.com/lem-project/lem/pull/2100) ("rewrite keymap system, introduce transient-like functionality"), merged 2026-04-24.

### Bug 1: Infinite loop in `describe-bindings-internal`

**File:** `src/commands/help.lisp`

Commit `3793971c` removed the line `(setf keymap (keymap-parent keymap))` from the loop body in `describe-bindings-internal` because `keymap-parent` no longer existed after the keymap rewrite. However, the surrounding `(loop :while keymap ...)` was left in place, so `keymap` was never set to `nil` and the loop never terminated.

**Fix:** Added `(setf keymap nil)` at the end of the loop body to terminate after one iteration.

### Bug 2: Type error on transient closures in `traverse-keymap`

**File:** `src/keymap.lisp`

The transient keymap system allows `prefix-suffix` to return closures (for `toggle` and `choice` infixes) rather than command symbols. `traverse-keymap` passed these to its callback unconditionally, and callers like `describe-bindings-internal` called `(symbol-name command)` on the result — which fails on function objects with: `The value #<FUNCTION ...> is not of type SYMBOL`.

**Fix:** Changed the catch-all `t` branch in `traverse-prefix` (within `traverse-keymap`) to `(symbolp suffix)`, so only symbol commands are yielded to callbacks. This protects all callers at the contract boundary rather than requiring guards at each call site.

## Files Changed

| File | Change |
|------|--------|
| `src/commands/help.lisp` | Added `(setf keymap nil)` to terminate the loop |
| `src/keymap.lisp` | Changed `traverse-keymap` to skip non-symbol suffixes |
