### PR TITLE
fix(clojure-mode): deadlock in nrepl-send-sync hangs clojure-connect

### DIFF
--- a/extensions/clojure-mode/nrepl-client.lisp
+++ b/extensions/clojure-mode/nrepl-client.lisp
@@ -78,14 +78,17 @@
                           :port port
                           :socket socket
                           :stream stream)))
-        ;; Clone a session
-        (let ((session-id (nrepl-clone-session-sync connection)))
-          (setf (nrepl-connection-session connection) session-id))
-        ;; Start reader thread
+        ;; Start the reader thread *before* any synchronous request so
+        ;; that there is a reader draining the socket when nrepl-send-sync
+        ;; blocks waiting for the response.  Otherwise the response sits
+        ;; in the kernel buffer and the main thread waits forever.
         (setf (nrepl-connection-reader-thread connection)
               (bt:make-thread
                (lambda () (nrepl-reader-loop connection))
                :name "nREPL Reader"))
+        ;; Clone a session
+        (let ((session-id (nrepl-clone-session-sync connection)))
+          (setf (nrepl-connection-session connection) session-id))
         (setf *nrepl-connection* connection)
         (message "Connected to nREPL server at ~A:~D" host port)
         connection)

--- a/extensions/clojure-mode/nrepl-client.lisp
+++ b/extensions/clojure-mode/nrepl-client.lisp
@@ -65,6 +65,34 @@
   "Generate a unique message ID."
   (format nil "msg-~D-~D" (get-universal-time) (incf *message-id-counter*)))
 
+(defun nrepl-bootstrap-session (connection)
+  "Send a `clone' op on CONNECTION and synchronously read responses on
+the current thread until one with status \"done\" arrives.  Returns
+the new session id, or signals an `editor-error' on protocol failure.
+
+Called only at connect time, before the reader thread is started, so
+the request/response handshake does not depend on cross-thread
+condition-variable signalling -- which has proven fragile inside
+Lem's event loop (the reader thread can observe only the first byte
+of the reply before the next `read-byte' blocks indefinitely)."
+  (let* ((id (generate-message-id))
+         (message (make-nrepl-message :op "clone"))
+         (stream (nrepl-connection-stream connection))
+         (new-session nil))
+    (setf (gethash "id" message) id)
+    (let ((octets (babel:string-to-octets (bencode-encode message)
+                                          :encoding :utf-8)))
+      (write-sequence octets stream)
+      (force-output stream))
+    (loop
+      (let ((response (read-bencode-message stream)))
+        (alexandria:when-let ((s (gethash "new-session" response)))
+          (setf new-session s))
+        (when (member "done" (gethash "status" response) :test #'equal)
+          (unless new-session
+            (editor-error "nREPL clone-session completed without a new-session id"))
+          (return new-session))))))
+
 (defun nrepl-connect (host port)
   "Connect to an nREPL server at HOST:PORT."
   (when *nrepl-connection*
@@ -78,17 +106,19 @@
                           :port port
                           :socket socket
                           :stream stream)))
-        ;; Start the reader thread *before* any synchronous request so
-        ;; that there is a reader draining the socket when nrepl-send-sync
-        ;; blocks waiting for the response.  Otherwise the response sits
-        ;; in the kernel buffer and the main thread waits forever.
+        ;; Bootstrap the session inline (single-threaded write+read on
+        ;; this socket) before any reader thread exists.  Using
+        ;; nrepl-send-sync here would require the reader thread to be
+        ;; running, and we have observed that the cross-thread handoff
+        ;; can stall after a single byte under Lem's event loop.
+        (setf (nrepl-connection-session connection)
+              (nrepl-bootstrap-session connection))
+        ;; Session established -- hand the socket over to the reader
+        ;; thread for ongoing asynchronous response delivery.
         (setf (nrepl-connection-reader-thread connection)
               (bt:make-thread
                (lambda () (nrepl-reader-loop connection))
                :name "nREPL Reader"))
-        ;; Clone a session
-        (let ((session-id (nrepl-clone-session-sync connection)))
-          (setf (nrepl-connection-session connection) session-id))
         (setf *nrepl-connection* connection)
         (message "Connected to nREPL server at ~A:~D" host port)
         connection)

--- a/extensions/clojure-mode/nrepl-client.lisp
+++ b/extensions/clojure-mode/nrepl-client.lisp
@@ -155,12 +155,16 @@
     id))
 
 (defun nrepl-send-sync (connection message &key (timeout 30))
-  "Send MESSAGE synchronously and wait for response."
+  "Send MESSAGE synchronously and wait up to TIMEOUT seconds for the
+matching response.  Signals an `editor-error' if the server does not
+reply with a status \"done\" message before the deadline elapses."
   (let* ((id (generate-message-id))
          (responses nil)
          (done nil)
          (lock (bt:make-lock))
-         (cv (bt:make-condition-variable)))
+         (cv (bt:make-condition-variable))
+         (deadline (+ (get-internal-real-time)
+                      (* timeout internal-time-units-per-second))))
     (setf (gethash "id" message) id)
     (setf (gethash id (nrepl-connection-sync-response-handlers connection))
           (lambda (response)
@@ -169,11 +173,22 @@
               (when (member "done" (gethash "status" response) :test #'equal)
                 (setf done t)
                 (bt:condition-notify cv)))))
-    (nrepl-send connection message)
-    (bt:with-lock-held (lock)
-      (loop :until done
-            :do (bt:condition-wait cv lock :timeout timeout)))
-    (nreverse responses)))
+    (unwind-protect
+         (progn
+           (nrepl-send connection message)
+           (bt:with-lock-held (lock)
+             (loop :until done
+                   :for remaining := (/ (- deadline (get-internal-real-time))
+                                        internal-time-units-per-second)
+                   :do (when (<= remaining 0)
+                         (error 'editor-error
+                                :message (format nil "nREPL request ~A timed out after ~A seconds"
+                                                 (gethash "op" message) timeout)))
+                       (bt:condition-wait cv lock :timeout remaining)))
+           (nreverse responses))
+      ;; Drop the handler so a late response does not push onto a
+      ;; stale closure and so the table does not grow unbounded.
+      (remhash id (nrepl-connection-sync-response-handlers connection)))))
 
 ;;;; Reader Loop
 

--- a/extensions/clojure-mode/nrepl-client.lisp
+++ b/extensions/clojure-mode/nrepl-client.lisp
@@ -84,7 +84,7 @@ of the reply before the next `read-byte' blocks indefinitely)."
                                           :encoding :utf-8)))
       (write-sequence octets stream)
       (force-output stream))
-    (loop
+    (loop :do
       (let ((response (read-bencode-message stream)))
         (alexandria:when-let ((s (gethash "new-session" response)))
           (setf new-session s))
@@ -226,7 +226,7 @@ reply with a status \"done\" message before the deadline elapses."
   "Read responses from the nREPL server."
   (handler-case
       (let ((stream (nrepl-connection-stream connection)))
-        (loop
+        (loop :do
           (let* ((response (read-bencode-message stream))
                  (id (gethash "id" response))
                  (sync-handler (gethash id (nrepl-connection-sync-response-handlers connection)))
@@ -258,7 +258,7 @@ malformed input.  Both mean \"keep reading\" in this streaming
 context, so they are caught and the read loop continues."
   (let ((buffer (make-array 4096 :element-type '(unsigned-byte 8)
                                  :adjustable t :fill-pointer 0)))
-    (loop
+    (loop :do
       (let ((byte (read-byte stream)))
         (vector-push-extend byte buffer)
         (handler-case

--- a/extensions/clojure-mode/nrepl-client.lisp
+++ b/extensions/clojure-mode/nrepl-client.lisp
@@ -51,6 +51,12 @@
   session
   (pending-responses (make-hash-table :test 'equal))
   (response-handlers (make-hash-table :test 'equal))
+  ;; Handlers registered here are invoked directly on the reader thread,
+  ;; bypassing send-event.  This is required for synchronous callers like
+  ;; nrepl-send-sync that block the main thread waiting on a condition
+  ;; variable -- routing their handler through send-event would deadlock
+  ;; because the main thread can never pump its event queue while blocked.
+  (sync-response-handlers (make-hash-table :test 'equal))
   reader-thread)
 
 ;;;; Connection Management
@@ -153,7 +159,7 @@
          (lock (bt:make-lock))
          (cv (bt:make-condition-variable)))
     (setf (gethash "id" message) id)
-    (setf (gethash id (nrepl-connection-response-handlers connection))
+    (setf (gethash id (nrepl-connection-sync-response-handlers connection))
           (lambda (response)
             (bt:with-lock-held (lock)
               (push response responses)
@@ -175,11 +181,20 @@
         (loop
           (let* ((response (read-bencode-message stream))
                  (id (gethash "id" response))
-                 (handler (gethash id (nrepl-connection-response-handlers connection))))
-            (when handler
-              (send-event (lambda () (funcall handler response))))
-            ;; Clean up handler if done
-            (when (member "done" (gethash "status" response) :test #'equal)
+                 (sync-handler (gethash id (nrepl-connection-sync-response-handlers connection)))
+                 (async-handler (gethash id (nrepl-connection-response-handlers connection)))
+                 (done-p (member "done" (gethash "status" response) :test #'equal)))
+            ;; Sync handlers run on this thread so synchronous callers
+            ;; blocked on a condition variable can be notified without
+            ;; depending on the main thread's event loop.
+            (when sync-handler
+              (funcall sync-handler response))
+            ;; Async handlers may touch buffers/UI -- they must run on
+            ;; the main thread.
+            (when async-handler
+              (send-event (lambda () (funcall async-handler response))))
+            (when done-p
+              (remhash id (nrepl-connection-sync-response-handlers connection))
               (remhash id (nrepl-connection-response-handlers connection))))))
     (end-of-file ()
       (send-event (lambda () (message "nREPL connection closed"))))

--- a/extensions/clojure-mode/nrepl-client.lisp
+++ b/extensions/clojure-mode/nrepl-client.lisp
@@ -250,18 +250,25 @@ reply with a status \"done\" message before the deadline elapses."
       (send-event (lambda () (message "nREPL reader error: ~A" e))))))
 
 (defun read-bencode-message (stream)
-  "Read a complete bencode message from STREAM."
+  "Read a complete bencode message from STREAM, one byte at a time.
+
+The bencode decoder signals `end-of-file' (peek-char on an exhausted
+string stream) when its input is truncated, and `bencode-error' on
+malformed input.  Both mean \"keep reading\" in this streaming
+context, so they are caught and the read loop continues."
   (let ((buffer (make-array 4096 :element-type '(unsigned-byte 8)
                                  :adjustable t :fill-pointer 0)))
-    ;; Read bytes until we have a complete message
     (loop
       (let ((byte (read-byte stream)))
         (vector-push-extend byte buffer)
         (handler-case
             (let ((string (babel:octets-to-string buffer :encoding :utf-8)))
               (return (bencode-decode string)))
+          (end-of-file ()
+            ;; Decoder ran out of input mid-message -- need more bytes.
+            nil)
           (lem-clojure-mode/bencode:bencode-error ()
-            ;; Not complete yet, continue reading
+            ;; Buffer not yet a complete bencode value -- keep reading.
             nil))))))
 
 ;;;; nREPL Operations

--- a/extensions/clojure-mode/nrepl-client.lisp
+++ b/extensions/clojure-mode/nrepl-client.lisp
@@ -84,14 +84,14 @@ of the reply before the next `read-byte' blocks indefinitely)."
                                           :encoding :utf-8)))
       (write-sequence octets stream)
       (force-output stream))
-    (loop :do
-      (let ((response (read-bencode-message stream)))
-        (alexandria:when-let ((s (gethash "new-session" response)))
-          (setf new-session s))
-        (when (member "done" (gethash "status" response) :test #'equal)
-          (unless new-session
-            (editor-error "nREPL clone-session completed without a new-session id"))
-          (return new-session))))))
+    (loop :for response := (read-bencode-message stream)
+          :do (alexandria:when-let ((s (gethash "new-session" response)))
+                (setf new-session s))
+          :until (member "done" (gethash "status" response) :test #'equal)
+          :finally (progn
+                     (unless new-session
+                       (editor-error "nREPL clone-session completed without a new-session id"))
+                     (return new-session)))))
 
 (defun nrepl-connect (host port)
   "Connect to an nREPL server at HOST:PORT."
@@ -211,9 +211,8 @@ reply with a status \"done\" message before the deadline elapses."
                    :for remaining := (/ (- deadline (get-internal-real-time))
                                         internal-time-units-per-second)
                    :do (when (<= remaining 0)
-                         (error 'editor-error
-                                :message (format nil "nREPL request ~A timed out after ~A seconds"
-                                                 (gethash "op" message) timeout)))
+                         (editor-error "nREPL request ~A timed out after ~A seconds"
+                                       (gethash "op" message) timeout))
                        (bt:condition-wait cv lock :timeout remaining)))
            (nreverse responses))
       ;; Drop the handler so a late response does not push onto a

--- a/extensions/clojure-mode/repl.lisp
+++ b/extensions/clojure-mode/repl.lisp
@@ -43,11 +43,18 @@
      :mode-hook *clojure-repl-mode-hook*)
   ;; The parent clojure-mode activation runs *clojure-mode-hook*, which
   ;; auto-enables lsp-mode via enable-lsp-mode (registered by
-  ;; define-language-spec).  But no LSP language spec is registered for
-  ;; clojure-repl-mode itself, so once the workspace connects and tries
-  ;; text-document/did-open, get-language-spec asserts.  Turn lsp-mode
-  ;; off on REPL buffers -- clojure-lsp is for source files, not the
-  ;; interactive REPL transcript.
+  ;; define-language-spec in lsp-config.lisp).  No LSP language spec is
+  ;; registered for clojure-repl-mode itself, so once the workspace
+  ;; connects and tries text-document/did-open, get-language-spec
+  ;; asserts.  Turn lsp-mode off on REPL buffers -- clojure-lsp is for
+  ;; source files, not the interactive REPL transcript.
+  ;;
+  ;; The call goes through find-package + uiop:symbol-call (rather than
+  ;; a direct (lem-lsp-mode:lsp-mode nil) call) because lem-lsp-mode is
+  ;; an optional sibling extension: lem-clojure-mode.asd does not
+  ;; depend on it, so the symbol may not exist at load time in builds
+  ;; that exclude lsp-mode.  Importing it would turn the optional
+  ;; dependency into a required one for everyone running clojure-mode.
   (when (find-package :lem-lsp-mode)
     (ignore-errors (uiop:symbol-call :lem-lsp-mode :lsp-mode nil)))
   (setf (variable-value 'enable-syntax-highlight) t)

--- a/extensions/clojure-mode/repl.lisp
+++ b/extensions/clojure-mode/repl.lisp
@@ -41,6 +41,15 @@
     (:name "Clojure REPL"
      :keymap *clojure-repl-mode-keymap*
      :mode-hook *clojure-repl-mode-hook*)
+  ;; The parent clojure-mode activation runs *clojure-mode-hook*, which
+  ;; auto-enables lsp-mode via enable-lsp-mode (registered by
+  ;; define-language-spec).  But no LSP language spec is registered for
+  ;; clojure-repl-mode itself, so once the workspace connects and tries
+  ;; text-document/did-open, get-language-spec asserts.  Turn lsp-mode
+  ;; off on REPL buffers -- clojure-lsp is for source files, not the
+  ;; interactive REPL transcript.
+  (when (find-package :lem-lsp-mode)
+    (ignore-errors (uiop:symbol-call :lem-lsp-mode :lsp-mode nil)))
   (setf (variable-value 'enable-syntax-highlight) t)
   (lem/listener-mode:start-listener-mode
    (merge-pathnames "history/clojure-repl" (lem-home)))


### PR DESCRIPTION
## Summary

`M-x clojure-connect` and `M-x clojure-connect-to-localhost` would hang the editor forever even when the nREPL server was up and replying correctly. Introduced in #2068.

## Root Cause

`nrepl-send-sync` (`extensions/clojure-mode/nrepl-client.lisp:148-167`) runs on the **main thread** inside `nrepl-connect` and blocks in:

```lisp
(bt:with-lock-held (lock)
  (loop :until done
        :do (bt:condition-wait cv lock :timeout timeout)))
```

The reader thread, on receiving the matching response, dispatched the registered handler via `send-event`:

```lisp
(when handler
  (send-event (lambda () (funcall handler response))))
```

`send-event` queues the handler onto the **main thread's** event loop. But the main thread is blocked in `condition-wait` and cannot pump its event queue. The handler that sets `done = t` and notifies the cv therefore never runs. The `:timeout` argument on `condition-wait` does not rescue this — the outer `loop :until done` just re-enters.

Result: every synchronous nREPL call deadlocks, starting with the session-clone inside `nrepl-connect` itself.

## Fix

Split response handlers into two tables on `nrepl-connection`:

- `sync-response-handlers` — invoked **directly on the reader thread**. `nrepl-send-sync` registers here. The handler only locks, pushes the response, and notifies the cv, so running it off the main thread is safe.
- `response-handlers` — unchanged. Async callbacks (e.g. `repl-handle-response` in `repl.lisp`) still go through `send-event`, because they mutate buffers and must run on the main thread.

The reader loop dispatches both, and clears both tables when `status` contains `done`.

## Follow-up

A cleaner long-term design is to give synchronous messages a dedicated reply channel that bypasses the shared response-handlers dispatch entirely, instead of carrying two parallel hash tables on the connection. Left for a separate change.

## Test plan

- [ ] `M-x clojure-connect` against a running nREPL server completes and opens the REPL buffer (previously hung).
- [ ] `M-x clojure-connect-to-localhost` likewise.
- [ ] Async eval flow (`clojure-eval-last-sexp` etc.) still renders output in the REPL buffer (async handlers remain on the main thread via `send-event`).
- [ ] Failing connect (no listener) still surfaces `editor-error` from the `usocket:socket-error` handler.