### PR TITLE
Fix display cache hash

### DIFF
--- a/lem-tests.asd
+++ b/lem-tests.asd
@@ -78,6 +78,7 @@
                (:file "legit")
                (:file "filer")
                (:file "listener-mode")
-               (:file "interface"))
+               (:file "interface")
+               (:file "display-cache"))
   :perform (test-op (o c)
                     (symbol-call :rove :run c)))

--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -420,7 +420,6 @@ no longer reflect the current layout."
 (defun djb2 (hash item)
   "Hash with seed and item using djb2 hash algorithm"
   (declare (type fixnum hash))
-
   (logand most-positive-fixnum
           (+ (* hash 33)
              (sxhash item))))
@@ -431,12 +430,11 @@ over the top-level spine and tolerant of improper (dotted) lists."
   (declare (dynamic-extent items))
   (let ((hash 5381))
     (labels ((mix-list (x)
-               (loop while (consp x)
-                     do (setf hash (djb2 hash (car x)))
-                        (setf x (cdr x)))
+               (loop :while (consp x)
+                     :do (setf hash (djb2 hash (car x)))
+                         (setf x (cdr x)))
                (when x
                  (setf hash (djb2 hash x)))))
-      
       (dolist (item items)
         (if (consp item)
             (mix-list item)

--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -417,15 +417,32 @@ no longer reflect the current layout."
   (alexandria:when-let ((cache (window-parameter window 'line-fingerprint-cache)))
     (clrhash cache)))
 
+
+(defun djb2 (hash item)
+  (logand most-positive-fixnum
+          (+ (* hash 33)
+             (sxhash item))))
+
+(defun mix-hashes (&rest items)
+  "Mixes multiple hashes using a DJB2-style algorithm to prevent logxor collisions."
+  (let ((hash 5381))
+    (dolist (item items)
+      (if (listp item)
+          (setf hash (djb2 hash (apply #'mix-hashes item)))
+          (setf hash (djb2 hash item))))
+    hash))
+
+
 (defun compute-line-fingerprint (logical-line scroll-start left-side-width)
   "Compute a cheap fingerprint for a logical line's display state."
-  (logxor (sxhash (logical-line-string logical-line))
-          (sxhash (logical-line-attributes logical-line))
-          (sxhash (logical-line-end-of-line-cursor-attribute logical-line))
-          (sxhash (logical-line-extend-to-end logical-line))
-          (sxhash (logical-line-line-end-overlay logical-line))
-          (sxhash scroll-start)
-          (sxhash left-side-width)))
+    (mix-hashes
+     (logical-line-string logical-line)
+     (logical-line-attributes logical-line)
+     (logical-line-end-of-line-cursor-attribute logical-line)
+     (logical-line-extend-to-end logical-line)
+     (logical-line-line-end-overlay logical-line)
+     scroll-start
+     left-side-width))
 
 (defun check-line-fingerprint (window y fingerprint)
   "Check if the fingerprint for line at Y matches. Returns cached height or NIL."

--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -419,6 +419,7 @@ no longer reflect the current layout."
 
 
 (defun djb2 (hash item)
+  "Hash with seed and item using djb2 hash algorithm"
   (logand most-positive-fixnum
           (+ (* hash 33)
              (sxhash item))))

--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -417,33 +417,42 @@ no longer reflect the current layout."
   (alexandria:when-let ((cache (window-parameter window 'line-fingerprint-cache)))
     (clrhash cache)))
 
-
 (defun djb2 (hash item)
   "Hash with seed and item using djb2 hash algorithm"
+  (declare (type fixnum hash))
+
   (logand most-positive-fixnum
           (+ (* hash 33)
              (sxhash item))))
 
 (defun mix-hashes (&rest items)
-  "Mixes multiple hashes using a DJB2-style algorithm to prevent logxor collisions."
+  "Fold ITEMS into one fixnum hash, descending into nested lists. Iterative
+over the top-level spine and tolerant of improper (dotted) lists."
+  (declare (dynamic-extent items))
   (let ((hash 5381))
-    (dolist (item items)
-      (if (listp item)
-          (setf hash (djb2 hash (apply #'mix-hashes item)))
-          (setf hash (djb2 hash item))))
-    hash))
-
+    (labels ((mix-list (x)
+               (loop while (consp x)
+                     do (setf hash (djb2 hash (car x)))
+                        (setf x (cdr x)))
+               (when x
+                 (setf hash (djb2 hash x)))))
+      
+      (dolist (item items)
+        (if (consp item)
+            (mix-list item)
+            (setf hash (djb2 hash item))))
+      hash)))
 
 (defun compute-line-fingerprint (logical-line scroll-start left-side-width)
   "Compute a cheap fingerprint for a logical line's display state."
-    (mix-hashes
-     (logical-line-string logical-line)
-     (logical-line-attributes logical-line)
-     (logical-line-end-of-line-cursor-attribute logical-line)
-     (logical-line-extend-to-end logical-line)
-     (logical-line-line-end-overlay logical-line)
-     scroll-start
-     left-side-width))
+  (mix-hashes
+   (logical-line-string logical-line)
+   (logical-line-attributes logical-line)
+   (logical-line-end-of-line-cursor-attribute logical-line)
+   (logical-line-extend-to-end logical-line)
+   (logical-line-line-end-overlay logical-line)
+   scroll-start
+   left-side-width))
 
 (defun check-line-fingerprint (window y fingerprint)
   "Check if the fingerprint for line at Y matches. Returns cached height or NIL."
@@ -569,8 +578,8 @@ creating zero temporary letter-objects."
                                                    left-side-width)
   (let* ((scroll-before (horizontal-scroll-start window))
          (fingerprint (compute-line-fingerprint logical-line
-                                                 scroll-before
-                                                 left-side-width)))
+                                                scroll-before
+                                                left-side-width)))
     ;; Early exit if line content unchanged
     (alexandria:when-let ((cached-height (check-line-fingerprint window y fingerprint)))
       (return-from redraw-logical-line-when-horizontal-scroll cached-height))
@@ -604,8 +613,8 @@ creating zero temporary letter-objects."
        (if (eql scroll-before (horizontal-scroll-start window))
            fingerprint
            (compute-line-fingerprint logical-line
-                                      (horizontal-scroll-start window)
-                                      left-side-width))
+                                     (horizontal-scroll-start window)
+                                     left-side-width))
        height)
       height)))
 

--- a/tests/display-cache.lisp
+++ b/tests/display-cache.lisp
@@ -1,0 +1,53 @@
+(defpackage :lem-tests/display-cache
+  (:use :cl :rove :lem-core))
+(in-package :lem-tests/display-cache)
+
+
+(deftest test-mix-hashes
+  ;; 1. The Commutativity Check (Does order matter?)
+  (ok (not (= (lem-core::mix-hashes 1 2 3)
+              (lem-core::mix-hashes 3 2 1))))
+  
+  ;; 2. The Cancellation Check (Do duplicate values erase each other?)
+  (ok (not (= (lem-core::mix-hashes 42 42)
+              (lem-core::mix-hashes 0))))
+  
+  ;; 3. Type Safety Check (Does it always evaluate to a raw machine integer?)
+  (ok (typep (lem-core::mix-hashes "string" 100 'lem-symbol '(:keyword 5))
+             'integer)))
+
+(deftest test-compute-line-fingerprint
+  (let* ((line-base (lem-core::make-logical-line :string "foo"
+                                                 :attributes nil
+                                                 :end-of-line-cursor-attribute nil
+                                                 :extend-to-end nil
+                                                 :line-end-overlay nil))
+         (line-a (lem-core::copy-logical-line line-base))
+         (line-b (lem-core::copy-logical-line line-base))
+         (line-c (lem-core::copy-logical-line line-base)))
+    
+    ;; Set up line-a and line-b to be deep, structural twins
+    (setf (lem-core::logical-line-attributes line-a) 
+          '((0 1 color) (0 2 color) (0 3 color) (0 4 color) (0 5 color) (0 6 no-highlight)))
+    (setf (lem-core::logical-line-attributes line-b) 
+          '((0 1 color) (0 2 color) (0 3 color) (0 4 color) (0 5 color) (0 6 no-highlight)))
+    
+    ;; Set up line-c to diverge past the 5th element (Old sxhash shallow-hash limit)
+    (setf (lem-core::logical-line-attributes line-c) 
+          '((0 1 color) (0 2 color) (0 3 color) (0 4 color) (0 5 color) (0 6 paredit-highlight)))
+    
+    ;; 1. Identity Check: Twin lines under twin scroll values must yield twin hashes
+    (ok (= (lem-core::compute-line-fingerprint line-a 10 5)
+           (lem-core::compute-line-fingerprint line-b 10 5)))
+    
+    ;; 2. Shallow Hash Fix Check: Verifies deep changes (like Paredit) are caught
+    (ok (not (= (lem-core::compute-line-fingerprint line-a 10 5)
+                (lem-core::compute-line-fingerprint line-c 10 5))))
+    
+    ;; 3. Parameter Commutativity Check: Swapping scroll-start and layout widths shifts the hash
+    (ok (not (= (lem-core::compute-line-fingerprint line-a 10 5)
+                (lem-core::compute-line-fingerprint line-a 5 10))))
+    
+    ;; 4. Parameter Cancellation Check: Matching coordinate variables don't zero out
+    (ok (not (= (lem-core::compute-line-fingerprint line-a 15 15)
+                (lem-core::compute-line-fingerprint line-a 30 30))))))

--- a/tests/display-cache.lisp
+++ b/tests/display-cache.lisp
@@ -13,7 +13,7 @@
               (lem-core::mix-hashes 0))))
   
   ;; 3. Type Safety Check (Does it always evaluate to a raw machine integer?)
-  (ok (typep (lem-core::mix-hashes "string" 100 'lem-symbol '(:keyword 5))
+  (ok (typep (lem-core::mix-hashes "string" 100 'some-symbol '(:keyword 5))
              'integer)))
 
 (deftest test-compute-line-fingerprint


### PR DESCRIPTION
Fix display cache hash collisions and structural overlay ghosting using [DJB2](http://www.cse.yorku.ca/~oz/hash.html). 

1. `logxor` ignores parameter positions, causing identical coordinate pairs to yield identical hashes.
2. SBCL's native `sxhash` gives up scanning lists after the 5th element. Structural text properties (like deep Paredit overlays/highlights) occurring deep in an attribute list are completely invisible to the cache, resulting in visual "ghosting" glitches.

I were having issues with the buffer and the display desyncing. The current implementation worked in most cases but when navigating over parameters or the d in `defun` the display and buffer desynced. You could also tell that the paredit were matching on the wrong parens sometimes, for example with multiple parens in function params.