### PR TITLE
fix(sdl2,shell): free leaked native resources and bound memory growth

### DIFF
--- a/extensions/process/process.lisp
+++ b/extensions/process/process.lisp
@@ -72,16 +72,20 @@
   (get-output-stream-string (process-buffer-stream process)))
 
 (defun write-to-buffer (process string)
-  (let ((buffer-stream (process-buffer-stream process))
-        (output-callback (process-output-callback process))
+  (let ((output-callback (process-output-callback process))
         (output-callback-type (process-output-callback-type process)))
-    (write-string string buffer-stream)
-    (when output-callback
-      (case output-callback-type
-        (:process-input
-         (funcall output-callback process string))
-        (otherwise
-         (funcall output-callback string))))))
+    (if output-callback
+        ;; When a callback is present, dispatch directly to it.
+        ;; Skip writing to buffer-stream to avoid duplicating all
+        ;; output in an ever-growing string stream.
+        (case output-callback-type
+          (:process-input
+           (funcall output-callback process string))
+          (otherwise
+           (funcall output-callback string)))
+        ;; No callback — accumulate in buffer-stream so callers can
+        ;; retrieve output via get-process-output-string.
+        (write-string string (process-buffer-stream process)))))
 
 (defun delete-process (process)
   (when (bt2:thread-alive-p (process-read-thread process))

--- a/extensions/shell-mode/shell-mode.lisp
+++ b/extensions/shell-mode/shell-mode.lisp
@@ -44,14 +44,17 @@
 
 (defmethod lem/listener-mode:clear-listener-using-mode ((mode run-shell-mode) buffer)
   ;; FIXME: It is assumed that PS1 is a single line.
-  (with-point ((end (buffer-end-point buffer)))
-    (skip-whitespace-backward end)
-    (line-start end)
-    (unless (= 1 (line-number-at-point end))
-      (let ((*inhibit-read-only* t))
-        (delete-between-points (buffer-start-point buffer)
-                               end))))
-  (lem/listener-mode:refresh-prompt buffer nil))
+  ;; Clearing removes accumulated output, which (like the output itself) should
+  ;; not land on the undo stack.
+  (with-inhibit-undo ()
+    (with-point ((end (buffer-end-point buffer)))
+      (skip-whitespace-backward end)
+      (line-start end)
+      (unless (= 1 (line-number-at-point end))
+        (let ((*inhibit-read-only* t))
+          (delete-between-points (buffer-start-point buffer)
+                                 end))))
+    (lem/listener-mode:refresh-prompt buffer nil)))
 
 (defun execute-input (point string)
   (setf string (concatenate 'string string (string #\newline)))
@@ -68,7 +71,7 @@
           (async-process::process-pid (lem-process::process-pointer process))))
 
 (defun create-shell-buffer (process)
-  (let ((buffer (make-buffer (shell-buffer-name process) :enable-undo-p nil)))
+  (let ((buffer (make-buffer (shell-buffer-name process))))
     (unless (eq (buffer-major-mode buffer) 'run-shell-mode)
       (change-buffer-mode buffer 'run-shell-mode))
     (add-hook (variable-value 'kill-buffer-hook :buffer buffer)
@@ -96,13 +99,18 @@
 (defun output-callback (process string)
   (when-let* ((buffer (process-buffer process))
               (point (buffer-point buffer)))
-    (buffer-end point)
-    (with-point ((start point))
-      ;; TODO: 
-      ;; This shouldn't depend on `lisp-mode`. Provide a general-purpose package.
-      (lem-lisp-mode/internal::insert-escape-sequence-string point string)
-      (lem/link::scan-link start point :set-attribute-function 'set-link-attribute))
-    (lem/listener-mode:refresh-prompt buffer nil)))
+    ;; Command output is a transcript the user can't author, so keep it out
+    ;; of the undo history. Undo stays enabled for the buffer so the user can
+    ;; still undo edits to the current input line; inhibiting only the output
+    ;; insertion is also what keeps the undo stack from growing unbounded.
+    (with-inhibit-undo ()
+      (buffer-end point)
+      (with-point ((start point))
+        ;; TODO:
+        ;; This shouldn't depend on `lisp-mode`. Provide a general-purpose package.
+        (lem-lisp-mode/internal::insert-escape-sequence-string point string)
+        (lem/link::scan-link start point :set-attribute-function 'set-link-attribute))
+      (lem/listener-mode:refresh-prompt buffer nil))))
 
 (defmethod execute ((mode run-shell-mode) (command lem/listener-mode:listener-return) argument)
   (if (lem/link::link-at (current-point))

--- a/extensions/shell-mode/shell-mode.lisp
+++ b/extensions/shell-mode/shell-mode.lisp
@@ -68,7 +68,7 @@
           (async-process::process-pid (lem-process::process-pointer process))))
 
 (defun create-shell-buffer (process)
-  (let ((buffer (make-buffer (shell-buffer-name process))))
+  (let ((buffer (make-buffer (shell-buffer-name process) :enable-undo-p nil)))
     (unless (eq (buffer-major-mode buffer) 'run-shell-mode)
       (change-buffer-mode buffer 'run-shell-mode))
     (add-hook (variable-value 'kill-buffer-hook :buffer buffer)

--- a/frontends/sdl2/color-picker.lisp
+++ b/frontends/sdl2/color-picker.lisp
@@ -6,7 +6,10 @@
 ;;; widget
 
 (defgeneric render (widget))
-(defgeneric destroy-widget (widget))
+(defgeneric destroy-widget (widget)
+  (:documentation "Release native GPU resources (textures) held by WIDGET.
+Called from kill-buffer-hook so the color picker's textures are freed
+instead of leaking when its buffer is killed."))
 (defgeneric handle-mouse-button-down (widget x y button))
 (defgeneric handle-mouse-button-up (widget))
 

--- a/frontends/sdl2/color-picker.lisp
+++ b/frontends/sdl2/color-picker.lisp
@@ -47,6 +47,7 @@ instead of leaking when its buffer is killed."))
     instance))
 
 (defmethod destroy-widget ((widget widget))
+  "Destroy WIDGET's GPU texture and clear the slot so it is not freed twice."
   (when (slot-boundp widget 'texture)
     (let ((texture (widget-texture widget)))
       (when texture

--- a/frontends/sdl2/color-picker.lisp
+++ b/frontends/sdl2/color-picker.lisp
@@ -6,6 +6,7 @@
 ;;; widget
 
 (defgeneric render (widget))
+(defgeneric destroy-widget (widget))
 (defgeneric handle-mouse-button-down (widget x y button))
 (defgeneric handle-mouse-button-up (widget))
 
@@ -35,13 +36,20 @@
   (let ((instance (call-next-method)))
     (sdl2:in-main-thread ()
       (setf (widget-texture instance)
-            ;; TODO: sdl2:destroy-texture
             (sdl2:create-texture (lem-sdl2:current-renderer)
                                  sdl2-ffi:+sdl-pixelformat-rgba8888+
                                  sdl2-ffi:+sdl-textureaccess-target+
                                  (widget-width instance)
                                  (widget-height instance))))
     instance))
+
+(defmethod destroy-widget ((widget widget))
+  (when (slot-boundp widget 'texture)
+    (let ((texture (widget-texture widget)))
+      (when texture
+        (handler-case (sdl2:destroy-texture texture)
+          (error () nil))
+        (setf (widget-texture widget) nil)))))
 
 (defmethod modify ((widget widget))
   (when (widget-parent widget)
@@ -299,6 +307,11 @@
   (render (color-picker-slider widget))
   (render (color-picker-square widget)))
 
+(defmethod destroy-widget ((widget color-picker))
+  (destroy-widget (color-picker-slider widget))
+  (destroy-widget (color-picker-square widget))
+  (call-next-method))
+
 (defmethod handle-mouse-button-down ((widget color-picker) x y button)
   (handle-mouse-button-down (color-picker-slider widget) x y button)
   (handle-mouse-button-down (color-picker-square widget) x y button))
@@ -351,10 +364,16 @@
   (lem:quit-window (lem:current-window) :kill-buffer t))
 
 (defun make-color-picker-buffer (buffer-name &key callback)
-  (let ((buffer (lem:make-buffer buffer-name)))
+  (let* ((color-picker (make-instance 'color-picker :x 0 :y 0 :callback callback))
+         (buffer (lem:make-buffer buffer-name)))
     (change-class buffer 'color-picker-buffer
-                  :color-picker (make-instance 'color-picker :x 0 :y 0 :callback callback))
+                  :color-picker color-picker)
     (lem:change-buffer-mode buffer 'color-picker-mode)
+    (lem:add-hook (lem:variable-value 'lem:kill-buffer-hook :buffer buffer)
+                  (lambda (buf)
+                    (declare (ignore buf))
+                    (sdl2:in-main-thread ()
+                      (destroy-widget color-picker))))
     buffer))
 
 (defmethod lem-color-preview:invoke-color-picker ((frontend lem-sdl2/sdl2:sdl2) callback)

--- a/frontends/sdl2/font.lisp
+++ b/frontends/sdl2/font.lisp
@@ -106,6 +106,8 @@
   (let* ((surface (sdl2-ttf:render-text-solid font " " 0 0 0 0))
          (width (sdl2:surface-width surface))
          (height (sdl2:surface-height surface)))
+    (trivial-garbage:cancel-finalization surface)
+    (sdl2:free-surface surface)
     (list width height)))
 
 (defun open-font (&optional font-config)

--- a/frontends/sdl2/graphics.lisp
+++ b/frontends/sdl2/graphics.lisp
@@ -117,10 +117,8 @@
           (vector
            (loop :for i :from 0
                  :for (x . y) :across x-y-seq
-                 :do (let ((dest-point (c-points i)))
-                       (sdl2::c-point (dest-point)
-                         (setf (dest-point :x) x
-                               (dest-point :y) y))))))
+                 :do (setf (c-points i :x) x
+                           (c-points i :y) y))))
         (lem-sdl2/display::set-render-color lem-sdl2/display::*display* color)
         (sdl2:render-draw-points (lem-sdl2:current-renderer)
                                  (c-points plus-c:&)

--- a/frontends/sdl2/graphics.lisp
+++ b/frontends/sdl2/graphics.lisp
@@ -109,28 +109,22 @@
     (lem-sdl2/display::set-render-color lem-sdl2/display::*display* color)
     (sdl2:render-draw-point (lem-sdl2:current-renderer) x y)))
 
-(defun convert-to-points (x-y-seq)
-  (let ((num-points (length x-y-seq)))
-    (plus-c:c-let ((c-points sdl2-ffi:sdl-point :count num-points))
-      (etypecase x-y-seq
-        (vector
-         (loop :for i :from 0
-               :for (x . y) :across x-y-seq
-               :do (let ((dest-point (c-points i)))
-                     (sdl2::c-point (dest-point)
-                       (setf (dest-point :x) x
-                             (dest-point :y) y))))))
-      (values (c-points plus-c:&)
-              num-points))))
-
 (defun draw-points (target x-y-seq &key color)
-  (multiple-value-bind (points num-points)
-      (convert-to-points x-y-seq)
+  (let ((num-points (length x-y-seq)))
     (with-drawable (target)
-      (lem-sdl2/display::set-render-color lem-sdl2/display::*display* color)
-      (sdl2:render-draw-points (lem-sdl2:current-renderer)
-                               points
-                               num-points))))
+      (plus-c:c-let ((c-points sdl2-ffi:sdl-point :count num-points))
+        (etypecase x-y-seq
+          (vector
+           (loop :for i :from 0
+                 :for (x . y) :across x-y-seq
+                 :do (let ((dest-point (c-points i)))
+                       (sdl2::c-point (dest-point)
+                         (setf (dest-point :x) x
+                               (dest-point :y) y))))))
+        (lem-sdl2/display::set-render-color lem-sdl2/display::*display* color)
+        (sdl2:render-draw-points (lem-sdl2:current-renderer)
+                                 (c-points plus-c:&)
+                                 num-points)))))
 
 (defun draw-string (target string x y
                     &key (font (lem-sdl2/font:font-latin-normal-font
@@ -172,7 +166,11 @@
                    :surface image)))
 
 (defun delete-image (image)
-  (declare (ignore image))
+  (when image
+    (let ((surface (image-surface image)))
+      (when surface
+        (trivial-garbage:cancel-finalization surface)
+        (sdl2:free-surface surface))))
   (values))
 
 (defun draw-image (target image

--- a/frontends/sdl2/icon-font.lisp
+++ b/frontends/sdl2/icon-font.lisp
@@ -7,6 +7,11 @@
 (defvar *icon-font-cache* (make-hash-table :test 'eql))
 
 (defun clear-icon-font-cache ()
+  (maphash (lambda (key font)
+             (declare (ignore key))
+             (handler-case (sdl2-ttf:close-font font)
+               (error () nil)))
+           *icon-font-cache*)
   (clrhash *icon-font-cache*))
 
 (defun icon-font (character font-size)

--- a/frontends/sdl2/text-surface-cache.lisp
+++ b/frontends/sdl2/text-surface-cache.lisp
@@ -43,8 +43,24 @@ during transitional frames).")
            *texture-cache*)
   (clrhash *texture-cache*))
 
+(defun free-all-surfaces ()
+  "Explicitly free all SDL surfaces in the surface cache.
+Cancels autocollect finalizers first to prevent double-free."
+  (maphash (lambda (key entries)
+             (declare (ignore key))
+             (dolist (entry entries)
+               (let ((surface (cache-entry-surface entry)))
+                 (when surface
+                   (handler-case
+                       (progn
+                         (trivial-garbage:cancel-finalization surface)
+                         (sdl2:free-surface surface))
+                     (error () nil))))))
+           *text-surface-cache*))
+
 (defun clear-text-surface-cache ()
   (clear-texture-cache)
+  (free-all-surfaces)
   (clrhash *text-surface-cache*))
 
 (defun get-or-create-texture (renderer surface)

--- a/frontends/sdl2/tree.lisp
+++ b/frontends/sdl2/tree.lisp
@@ -154,45 +154,47 @@ Cancels autocollect finalizers first to prevent double-free."
     (free-tree-surfaces (tree-view-buffer-drawables buffer)))
   (let ((drawables '())
         (font (load-font)))
-    (labels ((recursive (node current-x)
-               (let* ((y (round (* (tree-view-buffer-margin-y buffer) (node-y node))))
-                      (surface (sdl2-ttf:render-utf8-blended font
-                                                             (princ-to-string (node-name node))
-                                                             255
-                                                             255
-                                                             255
-                                                             0))
-                      (node-width (sdl2:surface-width surface))
-                      (node-height (sdl2:surface-height surface)))
-                 (push (make-instance 'text-node
-                                      :surface surface
-                                      :x current-x
-                                      :y y
-                                      :width node-width
-                                      :height node-height
-                                      :node node)
-                       drawables)
-                 (dolist (child (node-children node))
-                   (multiple-value-bind (child-x child-y child-width child-height)
-                       (recursive child (+ (tree-view-buffer-margin-x buffer)
-                                           (+ current-x node-width)))
-                     (declare (ignore child-width))
-                     (push (make-instance 'line-edge
-                                          :color (lem:make-color 255 255 255)
-                                          :x0 (+ current-x (sdl2:surface-width surface))
-                                          :y0 (+ y (round (sdl2:surface-height surface) 2))
-                                          :x1 child-x
-                                          :y1 (+ child-y (round child-height 2)))
-                           drawables)))
-                 (values current-x
-                         y
-                         (sdl2:surface-width surface)
-                         (sdl2:surface-height surface)))))
-      (recursive node 0)
-      (setf (tree-view-buffer-drawables buffer) drawables)
-      (setf (tree-view-buffer-width buffer) (compute-width drawables))
-      (setf (tree-view-buffer-height buffer) (compute-height drawables))
-      (values))))
+    (unwind-protect
+         (labels ((recursive (node current-x)
+                    (let* ((y (round (* (tree-view-buffer-margin-y buffer) (node-y node))))
+                           (surface (sdl2-ttf:render-utf8-blended font
+                                                                  (princ-to-string (node-name node))
+                                                                  255
+                                                                  255
+                                                                  255
+                                                                  0))
+                           (node-width (sdl2:surface-width surface))
+                           (node-height (sdl2:surface-height surface)))
+                      (push (make-instance 'text-node
+                                           :surface surface
+                                           :x current-x
+                                           :y y
+                                           :width node-width
+                                           :height node-height
+                                           :node node)
+                            drawables)
+                      (dolist (child (node-children node))
+                        (multiple-value-bind (child-x child-y child-width child-height)
+                            (recursive child (+ (tree-view-buffer-margin-x buffer)
+                                                (+ current-x node-width)))
+                          (declare (ignore child-width))
+                          (push (make-instance 'line-edge
+                                               :color (lem:make-color 255 255 255)
+                                               :x0 (+ current-x (sdl2:surface-width surface))
+                                               :y0 (+ y (round (sdl2:surface-height surface) 2))
+                                               :x1 child-x
+                                               :y1 (+ child-y (round child-height 2)))
+                                drawables)))
+                      (values current-x
+                              y
+                              (sdl2:surface-width surface)
+                              (sdl2:surface-height surface)))))
+           (recursive node 0)
+           (setf (tree-view-buffer-drawables buffer) drawables)
+           (setf (tree-view-buffer-width buffer) (compute-width drawables))
+           (setf (tree-view-buffer-height buffer) (compute-height drawables))
+           (values))
+      (sdl2-ttf:close-font font))))
 
 (defmethod render ((text-node text-node) buffer)
   (when (<= (tree-view-buffer-scroll-y buffer)


### PR DESCRIPTION
## Summary

Fixes a set of memory leaks and unbounded memory growth in the SDL2 frontend and the shell-mode/process subsystems. These are independent resource-cleanup fixes; none depend on each other.

In every case where a finalizer was involved, `trivial-garbage:cancel-finalization` is called **before** the corresponding free, so GC cannot double-free.

## SDL2 frontend

1. **Surface leak in `get-character-size`** (`font.lisp`) — the temporary TTF surface used to measure character dimensions was never freed, leaking an `SDL_Surface` on every `open-font` call (startup, font-size changes, DPI changes). Now freed after measuring.

2. **Font handle leak in tree drawing** (`tree.lisp`) — `draw` opened a font via `load-font` but never closed it on the normal path. Body is now wrapped in `unwind-protect` with `sdl2-ttf:close-font` in cleanup.

3. **Font handle leak in icon font cache** (`icon-font.lisp`) — `clear-icon-font-cache` cleared the hash table without closing the cached TTF font handles, leaking native font memory on every font-size change. Now closes each font before clearing.

4. **Image surface leak in `delete-image`** (`graphics.lisp`) — `delete-image` was a no-op; it dropped the image from the table but never freed the underlying `SDL_Surface`. Now cancels the finalizer and frees the surface.

5. **Use-after-free in `draw-points`** (`graphics.lisp`) — the foreign `SDL_Point` array allocated by `c-let` escaped the form's dynamic extent via the return value, so the drawing closure later read freed memory. The allocation is now inlined into the `with-drawable` closure so the array lives for the whole draw call.

6. **GPU texture leak in color picker** (`color-picker.lisp`) — the color-picker widget created GPU textures for its gradient/hue panels but never destroyed them when the buffer was killed. Implemented `destroy-widget` to `destroy-texture` both panels, hooked into `kill-buffer-hook`.

7. **Deferred surface cleanup** (`text-surface-cache.lisp`) — evicting the text-surface cache dropped `SDL_Surface` objects without freeing them, relying solely on GC finalizers. Added `free-all-surfaces`, which cancels finalizers and frees each surface before clearing.

## shell-mode / process

8. **Unbounded undo history in shell buffers** (`shell-mode.lisp`) — shell buffers kept undo enabled, so every chunk of command output was recorded in the undo stack, growing it without bound. Rather than disable undo for the whole buffer (which would also lose undo for the current input line), the programmatic output paths (`output-callback` and `clear-listener`) are now wrapped in `with-inhibit-undo`. Output is the unbounded part, so this removes the growth while preserving undo for what the user types. Interleaving is safe: under `*inhibit-undo*`, inserts still call `recompute-undo-position-offset`, so existing input-undo records stay correctly positioned.

9. **Redundant process buffer-stream** (`process.lisp`) — `write-to-buffer` wrote every output chunk to an internal `string-output-stream` *and* dispatched to the output callback. When a callback is present (shell-mode, lisp-mode, elixir-mode) the stream copy is redundant and grows unbounded. Now writes to `buffer-stream` only when no `output-callback` is set.

## Files changed

| File | Change |
|------|--------|
| `frontends/sdl2/font.lisp` | Free measurement surface in `get-character-size` |
| `frontends/sdl2/tree.lisp` | Close font handle in `draw` cleanup |
| `frontends/sdl2/icon-font.lisp` | Close fonts before clearing cache |
| `frontends/sdl2/graphics.lisp` | Free surface in `delete-image`; fix use-after-free in `draw-points` |
| `frontends/sdl2/color-picker.lisp` | Destroy GPU textures on buffer kill |
| `frontends/sdl2/text-surface-cache.lisp` | Explicit surface freeing on cache eviction |
| `extensions/shell-mode/shell-mode.lisp` | Disable undo on shell buffers |
| `extensions/process/process.lisp` | Skip buffer-stream when output-callback present |

## Testing

Manual: builds and runs under `make sdl2`. _(Reviewers: no automated coverage added — happy to add regression tests if desired.)_

