### PR TITLE
fix(display): reset cached surface on destructive drawing-object merge

### DIFF
--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -154,8 +154,12 @@
   (setf (slot-value drawing-object-1 'string)
         (str:concat (text-object-string drawing-object-1)
                     (text-object-string drawing-object-2)))
-  ;; Reset cached width since string changed
+  ;; Reset cached width and surface since string changed.  The surface is the
+  ;; frontend-rendered glyph bitmap; leaving the pre-merge surface in place
+  ;; makes draw-time render only the original (shorter) string and drop the
+  ;; rest of the merged run.
   (setf (drawing-object-width drawing-object-1) nil)
+  (setf (text-object-surface drawing-object-1) nil)
   drawing-object-1)
 
 (defmethod drawing-object-merge ((drawing-object-1 eol-cursor-object) (drawing-object-2 eol-cursor-object))
@@ -170,6 +174,7 @@
         (str:concat (text-object-string drawing-object-1)
                     (text-object-string drawing-object-2)))
   (setf (drawing-object-width drawing-object-1) nil)
+  (setf (text-object-surface drawing-object-1) nil)
   drawing-object-1)
 
 (defmethod drawing-object-merge ((drawing-object-1 image-object) (drawing-object-2 image-object))


### PR DESCRIPTION
## Problem

In the SDL2 frontend, buffer text was invisible on some lines until a redraw was forced on that line (e.g. moving the cursor/highlight onto it).

## Root cause

Regression from `e302803c` ("perf(display): reduce structural allocations in redraw loop").

`drawing-object-merge` for `text-object`/`line-end-object` was changed from allocating a fresh object (with `surface` defaulting to `nil`) to mutating the existing object in place. It resets the cached `width` after concatenating strings, but left the cached `surface` slot stale.

The `surface` slot holds the SDL2-rendered glyph bitmap. `object-width` (→ `get-surface`) runs on every object during `find-cursor-object` / `clip-objects-to-display-range` **before** `reduce-objects` merges them, so the merged object carried the surface for its *pre-merge* (shorter) string. At draw time `get-surface` returned that stale surface, painting only the first object's text and leaving the rest of the merged run as background — invisible text. The cursor line rendered correctly because `find-cursor-object` returns early there, leaving trailing surfaces unpopulated at merge time so they got rebuilt.

## Fix

Reset `text-object-surface` to `nil` alongside the existing `width` reset in both destructive merge methods, so the glyph bitmap is regenerated from the concatenated string.