### PR TITLE
chore(terminal): remove duplicate build-failed defun

### DIFF
--- a/scripts/build-terminal.lisp
+++ b/scripts/build-terminal.lisp
@@ -96,20 +96,6 @@ user gets that the terminal extension is unavailable."
   (finish-output *error-output*)
   (uiop:quit 1))
 
-(defun build-failed (format-control &rest format-arguments)
-  "Report a build failure on stderr and exit non-zero so callers (make,
-CI) can detect it. lem-terminal silently disables itself at runtime when
-the shared library is missing, so the hint below is the only feedback a
-user gets that the terminal extension is unavailable."
-  (format *error-output* "~&Failed to build terminal.so: ")
-  (apply #'format *error-output* format-control format-arguments)
-  (format *error-output*
-          "~&The lem-terminal extension will silently disable itself at~%~
-           runtime when the shared library is missing. Install libvterm~%~
-           (and a C toolchain) to enable it.~%")
-  (finish-output *error-output*)
-  (uiop:quit 1))
-
 (defun build-terminal ()
   (let* ((source (terminal-source))
          (lib (terminal-lib))


### PR DESCRIPTION
## Summary

`scripts/build-terminal.lisp` on `main` has two identical `build-failed`
definitions. Removing the duplicate.

## Cause

#2204 and #2205 were a stack but merged in **reverse order**: #2205 (which
contained #2204's commits) squash-merged first, then #2204 squash-merged on
top. Because #2205 had inserted `static-p`/`vterm-flags` just above
`build-failed`, git's 3-way merge for #2204 re-applied the `build-failed`
block rather than detecting it as already present — producing the duplicate.

## Impact

Functionally harmless (both copies are byte-identical), but SBCL emits a
redefinition warning when loading the script. This restores a single
definition.

Verified: `make terminal-lib` still builds; `grep -c 'defun build-failed'`
is now 1.