### PR TITLE
ci: migrate Nix cache from sunset magic-nix-cache to FlakeHub Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
     name: builds ${{ matrix.backend }} on ${{ matrix.os }}
     # The 'runs-on' key also uses the dynamic matrix
     runs-on: ${{ matrix.os }}
+    # FlakeHub Cache authenticates via GitHub OIDC, which needs id-token: write.
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -62,8 +66,11 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: Setup Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v8
+      # magic-nix-cache-action was sunset 2025-02-01 and now rate-limits /
+      # 418s, causing intermittent "no substituter" failures. FlakeHub Cache
+      # is its supported successor (auth via the OIDC token above).
+      - name: Setup FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@main
 
       - name: Check flake
         run: nix flake check --all-systems --no-build


### PR DESCRIPTION
## Summary

Migrates the **Nix CI** workflow off `DeterminateSystems/magic-nix-cache-action@v8`, which was **sunset on 2025-02-01**, to its supported successor `flakehub-cache-action`.

## Why

`magic-nix-cache-action` now rate-limits and returns HTTP 418, and logs `FlakeHub cache is not enabled` / `Shutting down`. When its local substituter (`127.0.0.1:37515`) is disabled mid-build, paths it was serving (the SBCL lisp closure — `sbcl-micros`, `sbcl-queues`, `sbcl-sha3`, …) become unfetchable, producing intermittent **`error: ... is required, but there is no substituter that can build it`** failures on the Linux jobs. It's flaky-but-usually-green today (falls back to `cache.nixos.org`), but it's a deprecated dependency and a recurring source of CI noise.

## Change

- Swap the cache step to `DeterminateSystems/flakehub-cache-action@main`.
- Add `permissions: { id-token: write, contents: read }` to the `build` job (FlakeHub Cache authenticates via GitHub OIDC).

## ⚠️ Maintainer prerequisite

FlakeHub Cache authenticates via OIDC and requires the **`lem-project` org to be enrolled in FlakeHub** (free for public/OSS repos) at https://flakehub.com. **This PR's own CI run is the test:** if the cache step authenticates, we're good; if it errors with "create an organization at FlakeHub.com", the org needs enrolling first (or, as a fallback, we can simply drop the cache step and rely on `cache.nixos.org`).

## Notes / out of scope

- The same workflow also triggers Node 20 deprecation warnings for `actions/checkout@v4`, `nix-installer-action@v16`, and the (now-removed) cache action. Bumping those is a separate cleanup.
- Unrelated to the terminal PRs (#2204/#2205/#2207); raised on its own because the deprecation surfaced while debugging #2207's Linux jobs.