### PR TITLE
perf: fix terminal wakeup lock contention and cache webview view-id hash

### DIFF
--- a/extensions/terminal/terminal.lisp
+++ b/extensions/terminal/terminal.lisp
@@ -199,30 +199,33 @@ Avoids an O(rows) scan in the hot update loop.")
           (make-array *scrollback-limit* :initial-element nil))
     (mark-all-rows-dirty terminal)
     ;; Alacritty-style WakeupGate: the I/O thread only sends a new event
-    ;; if one isn't already pending.  When pending, it sleeps briefly to
-    ;; avoid hot-spinning on select() (PTY data isn't consumed until the
-    ;; editor thread runs process-input).
+    ;; if one isn't already pending.  select() returns immediately while
+    ;; the PTY buffer holds unread data (it isn't drained until the editor
+    ;; thread runs process-input), so without gating the thread would
+    ;; hot-spin.  When an event is already pending we block on a condition
+    ;; variable until the editor thread consumes it and signals us — this
+    ;; avoids both the spin and holding the lock across a sleep, which used
+    ;; to serialize the I/O and editor threads on the lock.
     (let ((event-pending nil)
-          (lock (bt2:make-lock :name "terminal-wakeup")))
+          (lock (bt2:make-lock :name "terminal-wakeup"))
+          (cv (bt2:make-condition-variable :name "terminal-wakeup")))
       (setf (terminal-thread terminal)
             (bt2:make-thread
              (lambda ()
                (loop
                  (ffi::terminal-process-input-wait (terminal-viscus terminal))
+                 ;; Only the event-pending flag is guarded by the lock.  The
+                 ;; sleep is gone; send-event runs outside the lock.
                  (bt2:with-lock-held (lock)
-                   (cond
-                     (event-pending
-                      ;; Previous event not yet consumed — sleep to avoid
-                      ;; hot-spinning (select returns immediately since
-                      ;; data is still in the PTY buffer).
-                      (sleep 0.001))
-                     (t
-                      (setf event-pending t)
-                      (send-event
-                       (lambda ()
-                         (ignore-errors (update terminal))
-                         (bt2:with-lock-held (lock)
-                           (setf event-pending nil)))))))))
+                   (loop :while event-pending
+                         :do (bt2:condition-wait cv lock))
+                   (setf event-pending t))
+                 (send-event
+                  (lambda ()
+                    (ignore-errors (update terminal))
+                    (bt2:with-lock-held (lock)
+                      (setf event-pending nil)
+                      (bt2:condition-notify cv))))))
              :name (format nil "Terminal ~D" id))))
     (add-terminal terminal)
     terminal))

--- a/frontends/server/main.lisp
+++ b/frontends/server/main.lisp
@@ -115,8 +115,14 @@
 (defun view-id-hash (view)
   "Return a minimal hash table containing only the view ID.
 Used for hot-path messages (put, clear-eol, etc.) where the JS frontend
-only needs viewInfo.id. Avoids serializing the full VIEW object (14+ fields)."
-  (hash "id" (view-id view)))
+only needs viewInfo.id. Avoids serializing the full VIEW object (14+ fields).
+
+The hash is memoized on the view: it is called once per drawing object
+per frame, but its content is constant, so we allocate it once and reuse
+the same immutable instance for every subsequent message."
+  (or (view-cached-id-hash view)
+      (setf (view-cached-id-hash view)
+            (hash "id" (view-id view)))))
 
 (defun get-all-views ()
   (if (null (lem:current-frame))

--- a/frontends/server/view.lisp
+++ b/frontends/server/view.lisp
@@ -4,6 +4,7 @@
            :make-view
            :view-window
            :view-id
+           :view-cached-id-hash
            :view-x
            :view-y
            :view-width
@@ -25,6 +26,10 @@
 
 (defstruct (view (:constructor %make-view))
   (id (incf *view-id-counter*))
+  ;; Memoized {"id": id} hash for hot-path messages (put, clear-eol).
+  ;; Immutable once built — id never changes — so it is safe to reuse the
+  ;; same instance across every message in a frame.  See VIEW-ID-HASH.
+  (cached-id-hash nil)
   window
   x
   y


### PR DESCRIPTION
## Summary

Two performance fixes found while profiling terminal output on the webview frontend (Arch Linux). Verified working across all frontends.

### Terminal I/O thread — WakeupGate lock contention
`extensions/terminal/terminal.lisp`

The WakeupGate held its lock across `(sleep 0.001)`. Since `terminal_process_input_wait` only `select()`s (the PTY is drained later on the editor thread), `select` returns immediately while output streams, so the I/O thread spun — and worse, it slept *holding the lock*. The editor's event callback must take the same lock to clear `event-pending`, so it blocked behind that 1ms nap, serializing the two threads.

Profile (414 samples / 4.14s) showed ~60% of samples in that one `with-lock-held`: ~28% in `nanosleep`, ~22% blocked in `deadlock-aware-mutex-wait`.

Fix:
- Move `sleep`/`send-event` out of the lock — only the `event-pending` flag is guarded now.
- Replace the 1ms poll with a condition variable the editor callback signals after clearing the flag. Removes the spin and the per-frame latency floor.

### Webview frontend — memoize per-view id hash
`frontends/server/view.lisp`, `frontends/server/main.lisp`

`view-id-hash` allocated a fresh `{id: N}` hash for every drawing object every frame, even though the value is constant for a view's lifetime. Memoize it on the view (immutable once built), removing one hash-table allocation plus plist consing per object per frame. **JSON output is byte-identical** — no client change, no `dist/` rebuild.

## Testing
Ran the affected frontends streaming heavy terminal output; rendering is correct (including the final prompt frame) and noticeably smoother. Reporter confirms performance is good across all frontends.

## Follow-up (not in this PR)
A larger, protocol-changing optimization — coalescing per-object `put` messages into one per-line message — is tracked separately. It requires a coordinated `editor.js` + frontend bundle rebuild and is intentionally kept out of this perf pass.