### PR TITLE
Fix `Invalid index 0` crash in `string-width` on empty or nil strings

### DIFF
--- a/src/common/character/string-width-utils.lisp
+++ b/src/common/character/string-width-utils.lisp
@@ -75,11 +75,14 @@
          (+ width 1))))
 
 (defun string-width (string &key (start 0) end (tab-size +default-tab-size+))
-  (loop :with width := 0
-        :for index :from start :below (or end (length string))
-        :for char := (aref string index)
-        :do (setq width (char-width char width :tab-size tab-size))
-        :finally (return width)))
+  (let* ((len (length string))
+        (safe-end (min (or end len)
+                       len)))
+    (loop :with width := 0
+          :for index :from start :below safe-end
+          :for char := (aref string index)
+          :do (setq width (char-width char width :tab-size tab-size))
+          :finally (return width))))
 
 (defun wide-index (string goal &key (start 0) (tab-size +default-tab-size+))
   (loop :with width := 0

--- a/src/common/character/string-width-utils.lisp
+++ b/src/common/character/string-width-utils.lisp
@@ -76,8 +76,8 @@
 
 (defun string-width (string &key (start 0) end (tab-size +default-tab-size+))
   (let* ((len (length string))
-        (safe-end (min (or end len)
-                       len)))
+         (safe-end (min (or end len)
+                        len)))
     (loop :with width := 0
           :for index :from start :below safe-end
           :for char := (aref string index)

--- a/tests/string-width-utils.lisp
+++ b/tests/string-width-utils.lisp
@@ -387,6 +387,8 @@
     (ok (eql 0 (char-width #\newline 0)))))
 
 (deftest string-width
+  (ok (eql 0 (string-width nil)))
+  (ok (eql 0 (string-width "")))
   (ok (eql 1 (string-width "a")))
   (ok (eql 2 (string-width "ab")))
   (ok (eql 3 (string-width "abc")))


### PR DESCRIPTION
### The Problem
When navigating backward in the REPL history the current prompt text is temporarily deleted before the new history item is inserted. This can leave the cursor hanging at an out-of-bounds `charpos` (e.g., column 8 on a now-empty string `""` or `NIL`). 

When the display logic (like `%calc-window-cursor-x`) updates during this split-second state, it passes the out-of-bounds index to `string-width` as the `:end` parameter. This triggers an `Invalid index 0` crash when the loop attempts to call `aref` on the empty string.

### The Solution
Updated `string-width` to defensively clamp the `end` parameter against the string's actual length using `(min (or end len) len)`. 

* If the string is empty (`""`) or deleted (`NIL`), the bounded index evaluates to `0`.

### Tests Added
* Added explicit unit tests to ensure `string-width` safely returns `0` for both `""` and `NIL` inputs to prevent future regressions.


### Note
I am still having problems navigating back in the repl history sometimes but this should at least fix some of the issues.