### PR TITLE
Fix vi-yank error on detached points (e.g. REPL history motion)

### DIFF
--- a/extensions/vi-mode/registers.lisp
+++ b/extensions/vi-mode/registers.lisp
@@ -214,6 +214,10 @@
   (with-killring-context (:options (case type
                                      (:line :vi-line)
                                      (:block :vi-block)))
+    (unless (and (lem:point-buffer start)
+                 (lem:point-buffer end))
+      (return-from yank-region))
+    
     (copy-to-clipboard-with-killring
      (case type
        (:block


### PR DESCRIPTION
The Bug
Sometimes when you type an operator and a motion that alters history (like y k in the lisp REPL), Lem crashes with:
The value NIL is not of type VECTOR when binding #:N-ARRAY

The Cause
The k motion triggers listener-previous-input, which deletes the current prompt text to swap in the history item. This leaves the saved start point floating without a buffer. When vi-yank tries to grab the text, points-to-string hits the detached point, expects a vector, gets NIL, and blows up the thread.

The Fix
I added a quick guard to check if both start and end are still attached to a buffer (using lem:point-buffer) before attempting to yank. If either point is detached, it just aborts the yank operation gracefully instead of crashing the editor.