### PR TITLE
Save cursor state when changing history in repl

### DIFF
--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -183,7 +183,7 @@
     (when win
       (replace-textarea buffer str))))
 
-(defun %search-history-startwith (direction)
+(defun %search-history-startswith-input (direction)
   "Internal helper for history next and previous history navigation."
   (multiple-value-bind (step-fn rewind-fn)
       (ecase direction
@@ -219,13 +219,13 @@
   "Find the previous prompt starting with the current input.
 
   See also `listener-previous-input`."
-  (%search-history-startwith :previous))
+  (%search-history-startswith-input :previous))
 
 (define-command listener-next-startswith-input () ()
   "Find the next prompt starting with the current input.
 
   See also `listener-next-input`."
-  (%search-history-startwith :next))
+  (%search-history-startswith-input :next))
 
 (define-command listener-previous-input () ()
   "Get and insert the previous REPL input."

--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -185,35 +185,34 @@
 
 (defun %search-history-startswith-input (direction)
   "Internal helper for history next and previous history navigation."
-  (multiple-value-bind (step-fn rewind-fn)
-      (ecase direction
-        (:previous (values #'lem/common/history:previous-history
-                           #'lem/common/history:next-history))
-        (:next (values #'lem/common/history:next-history
-                       #'lem/common/history:previous-history)))
-    (let* ((buffer (current-buffer))
-           (point (buffer-point buffer))
-           (start (input-start-point buffer))
-           (prefix (points-to-string (input-start-point buffer) point))
-           (prefix-len (length prefix)))
-      (backup-edit-string (current-buffer))
-      (loop :for steps :from 0
-            :do (multiple-value-bind (str win)
-                    (funcall step-fn (current-listener-history))
-                  (if win
-                      (when (eql 0 (search prefix str :test #'string=))
-                        (replace-textarea buffer str)
-                        (lem-core:move-point point start)
-                        (lem-core:character-offset point prefix-len)
-                        (return))
-                      (progn 
-                        (dotimes (i steps)
-                          (funcall rewind-fn (current-listener-history)))
-                        (when (eq direction :next)
-                          (restore-edit-string buffer)
-                          (lem-core:move-point point start)
-                          (lem-core:character-offset point prefix-len))
-                        (return))))))))
+  (let* ((buffer (current-buffer))
+         (point (buffer-point buffer))
+         (start (input-start-point buffer))
+         (prefix (points-to-string (input-start-point buffer) point))
+         (prefix-len (length prefix))
+         (step-fn (case direction 
+                    (:previous #'lem/common/history:previous-history)
+                    (:next #'lem/common/history:next-history))))
+    (backup-edit-string (current-buffer))
+    (loop :for steps :from 0
+          :do (multiple-value-bind (str found)
+                  (funcall step-fn (current-listener-history))
+                (cond
+                  ((and found (eql 0 (search prefix str :test #'string=)))
+                   (replace-textarea buffer str)
+                   (move-point point start)
+                   (character-offset point prefix-len)
+                   (return))
+                  ((not found)
+                   (ecase direction
+                     (:previous 
+                      (dotimes (i steps)
+                        (lem/common/history:next-history (current-listener-history))))
+                     (:next 
+                      (restore-edit-string buffer)
+                      (move-point point start)
+                      (character-offset point prefix-len)))
+                   (return)))))))
 
 (define-command listener-previous-startswith-input () ()
   "Find the previous prompt starting with the current input.

--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -191,15 +191,19 @@
     (let* ((buffer (current-buffer))
            (point (buffer-point buffer))
            (charpos (point-charpos point))
-           (prefix (points-to-string (input-start-point buffer) point)))
+           (prefix (points-to-string (input-start-point buffer) point))
+           (prefix-len (length prefix)))
       (backup-edit-string (current-buffer))
       (flet ((commit (str)
                ;; Move to safe position before changing the underlying buffer
                (lem-core:move-point point (input-start-point buffer))
                
                (replace-textarea buffer str)
-               (setf (point-charpos point) 
-                     (min charpos (length (line-string point))))
+               
+               ;; Restore the cursor to beginning of line + prefix offset.
+               (lem-core:move-point point (input-start-point buffer))
+               (lem-core:character-offset point prefix-len)
+               
                (return)))
              
         (loop
@@ -212,8 +216,6 @@
                   (when rollback-on-fail
                     (restore-edit-string buffer))
                   (return)))))))))
-
-
 
 
 (define-command listener-previous-startswith-input () ()

--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -194,9 +194,14 @@
            (prefix (points-to-string (input-start-point buffer) point)))
       (backup-edit-string (current-buffer))
       (flet ((commit (str)
+               (lem-core:move-point point (input-start-point buffer))
+               
                (replace-textarea buffer str)
-               (setf (point-charpos point) charpos)
+               (setf (point-charpos point) 
+                     (min charpos (length (line-string point))))
+                     
                (return)))
+             
         (loop
           (multiple-value-bind (str win)
               (lem/common/history:previous-history (current-listener-history))
@@ -217,7 +222,8 @@
       (backup-edit-string (current-buffer))
       (flet ((commit (str)
                (replace-textarea buffer str)
-               (setf (point-charpos point) charpos)
+               (setf (point-charpos point) 
+                     (min charpos (length (line-string point))))
                (return))
              (rollback ()
                (restore-edit-string buffer)

--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -185,50 +185,62 @@
 
 
 
-(defun %search-history-startwith (step-fn &key rollback-on-fail)
+(defun %search-history-startwith (direction)
   "Internal helper for history next and previous"
-  (block nil
-    (let* ((buffer (current-buffer))
-           (point (buffer-point buffer))
-           (charpos (point-charpos point))
-           (prefix (points-to-string (input-start-point buffer) point))
-           (prefix-len (length prefix)))
-      (backup-edit-string (current-buffer))
-      (flet ((commit (str)
-               ;; Move to safe position before changing the underlying buffer
-               (lem-core:move-point point (input-start-point buffer))
+  (multiple-value-bind (step-fn rewind-fn)
+      (ecase direction
+        (:previous (values #'lem/common/history:previous-history
+                           #'lem/common/history:next-history))
+        (:next (values #'lem/common/history:next-history
+                       #'lem/common/history:previous-history)))
+  
+    (block nil
+      (let* ((buffer (current-buffer))
+             (point (buffer-point buffer))
+             (prefix (points-to-string (input-start-point buffer) point))
+             (prefix-len (length prefix)))
+        (backup-edit-string (current-buffer))
+        (flet ((commit (str)
+                 ;; Move to safe position before changing the underlying buffer
+                 (lem-core:move-point point (input-start-point buffer))
                
-               (replace-textarea buffer str)
+                 (replace-textarea buffer str)
                
-               ;; Restore the cursor to beginning of line + prefix offset.
-               (lem-core:move-point point (input-start-point buffer))
-               (lem-core:character-offset point prefix-len)
+                 ;; Restore the cursor to beginning of line + prefix offset.
+                 (lem-core:move-point point (input-start-point buffer))
+                 (lem-core:character-offset point prefix-len)
                
-               (return)))
+                 (return)))
              
-        (loop
-          (multiple-value-bind (str win)
-              (funcall step-fn (current-listener-history))
-            (if win
-                (when (eql 0 (search prefix str :test #'string=))
-                  (commit str))
-                (progn 
-                  (when rollback-on-fail
-                    (restore-edit-string buffer))
-                  (return)))))))))
+        
+          (loop :for steps :from 0
+                :do (multiple-value-bind (str win)
+                        (funcall step-fn (current-listener-history))
+                      (if win
+                          (when (eql 0 (search prefix str :test #'string=))
+                            (commit str))
+                          (progn 
+                            (dotimes (i steps)
+                              (funcall rewind-fn (current-listener-history)))
+                      
+                            (when (eq direction :next)
+                              (restore-edit-string buffer)
+                              (lem-core:move-point point (input-start-point buffer))
+                              (lem-core:character-offset point prefix-len))
+                            (return))))))))))
 
 
 (define-command listener-previous-startswith-input () ()
   "Find the previous prompt starting with the current input.
 
   See also `listener-previous-input`."
-  (%search-history-startwith #'lem/common/history:previous-history))
+  (%search-history-startwith :previous))
 
 (define-command listener-next-startswith-input () ()
   "Find the next prompt starting with the current input.
 
   See also `listener-next-input`."
-  (%search-history-startwith #'lem/common/history:next-history :rollback-on-fail t))
+  (%search-history-startwith :next))
 
 (define-command listener-previous-input () ()
   "Get and insert the previous REPL input."

--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -183,52 +183,37 @@
     (when win
       (replace-textarea buffer str))))
 
-
-
 (defun %search-history-startwith (direction)
-  "Internal helper for history next and previous"
+  "Internal helper for history next and previous history navigation."
   (multiple-value-bind (step-fn rewind-fn)
       (ecase direction
         (:previous (values #'lem/common/history:previous-history
                            #'lem/common/history:next-history))
         (:next (values #'lem/common/history:next-history
                        #'lem/common/history:previous-history)))
-  
-    (block nil
-      (let* ((buffer (current-buffer))
-             (point (buffer-point buffer))
-             (prefix (points-to-string (input-start-point buffer) point))
-             (prefix-len (length prefix)))
-        (backup-edit-string (current-buffer))
-        (flet ((commit (str)
-                 ;; Move to safe position before changing the underlying buffer
-                 (lem-core:move-point point (input-start-point buffer))
-               
-                 (replace-textarea buffer str)
-               
-                 ;; Restore the cursor to beginning of line + prefix offset.
-                 (lem-core:move-point point (input-start-point buffer))
-                 (lem-core:character-offset point prefix-len)
-               
-                 (return)))
-             
-        
-          (loop :for steps :from 0
-                :do (multiple-value-bind (str win)
-                        (funcall step-fn (current-listener-history))
-                      (if win
-                          (when (eql 0 (search prefix str :test #'string=))
-                            (commit str))
-                          (progn 
-                            (dotimes (i steps)
-                              (funcall rewind-fn (current-listener-history)))
-                      
-                            (when (eq direction :next)
-                              (restore-edit-string buffer)
-                              (lem-core:move-point point (input-start-point buffer))
-                              (lem-core:character-offset point prefix-len))
-                            (return))))))))))
-
+    (let* ((buffer (current-buffer))
+           (point (buffer-point buffer))
+           (start (input-start-point buffer))
+           (prefix (points-to-string (input-start-point buffer) point))
+           (prefix-len (length prefix)))
+      (backup-edit-string (current-buffer))
+      (loop :for steps :from 0
+            :do (multiple-value-bind (str win)
+                    (funcall step-fn (current-listener-history))
+                  (if win
+                      (when (eql 0 (search prefix str :test #'string=))
+                        (replace-textarea buffer str)
+                        (lem-core:move-point point start)
+                        (lem-core:character-offset point prefix-len)
+                        (return))
+                      (progn 
+                        (dotimes (i steps)
+                          (funcall rewind-fn (current-listener-history)))
+                        (when (eq direction :next)
+                          (restore-edit-string buffer)
+                          (lem-core:move-point point start)
+                          (lem-core:character-offset point prefix-len))
+                        (return))))))))
 
 (define-command listener-previous-startswith-input () ()
   "Find the previous prompt starting with the current input.

--- a/src/ext/listener-mode.lisp
+++ b/src/ext/listener-mode.lisp
@@ -116,7 +116,7 @@
     (when (input-start-point buffer)
       (delete-point (input-start-point buffer)))
     (set-input-start-point buffer
-                          (copy-point point :right-inserting))))
+                           (copy-point point :right-inserting))))
 
 (defun write-prompt (point)
   (let ((buffer (point-buffer point)))
@@ -183,10 +183,10 @@
     (when win
       (replace-textarea buffer str))))
 
-(define-command listener-previous-startswith-input () ()
-  "Find the previous prompt starting with the current input.
 
-  See also `listener-previous-input`."
+
+(defun %search-history-startwith (step-fn &key rollback-on-fail)
+  "Internal helper for history next and previous"
   (block nil
     (let* ((buffer (current-buffer))
            (point (buffer-point buffer))
@@ -194,47 +194,39 @@
            (prefix (points-to-string (input-start-point buffer) point)))
       (backup-edit-string (current-buffer))
       (flet ((commit (str)
+               ;; Move to safe position before changing the underlying buffer
                (lem-core:move-point point (input-start-point buffer))
                
                (replace-textarea buffer str)
                (setf (point-charpos point) 
                      (min charpos (length (line-string point))))
-                     
                (return)))
              
         (loop
           (multiple-value-bind (str win)
-              (lem/common/history:previous-history (current-listener-history))
+              (funcall step-fn (current-listener-history))
             (if win
                 (when (eql 0 (search prefix str :test #'string=))
                   (commit str))
-                (return))))))))
+                (progn 
+                  (when rollback-on-fail
+                    (restore-edit-string buffer))
+                  (return)))))))))
+
+
+
+
+(define-command listener-previous-startswith-input () ()
+  "Find the previous prompt starting with the current input.
+
+  See also `listener-previous-input`."
+  (%search-history-startwith #'lem/common/history:previous-history))
 
 (define-command listener-next-startswith-input () ()
   "Find the next prompt starting with the current input.
 
   See also `listener-next-input`."
-  (block nil
-    (let* ((buffer (current-buffer))
-           (point (buffer-point buffer))
-           (charpos (point-charpos point))
-           (prefix (points-to-string (input-start-point buffer) point)))
-      (backup-edit-string (current-buffer))
-      (flet ((commit (str)
-               (replace-textarea buffer str)
-               (setf (point-charpos point) 
-                     (min charpos (length (line-string point))))
-               (return))
-             (rollback ()
-               (restore-edit-string buffer)
-               (return)))
-        (loop
-          (multiple-value-bind (str win)
-              (lem/common/history:next-history (current-listener-history))
-            (if win
-                (when (eql 0 (search prefix str :test #'string=))
-                  (commit str))
-                (rollback))))))))
+  (%search-history-startwith #'lem/common/history:next-history :rollback-on-fail t))
 
 (define-command listener-previous-input () ()
   "Get and insert the previous REPL input."

--- a/tests/listener-mode.lisp
+++ b/tests/listener-mode.lisp
@@ -12,7 +12,9 @@
                 :listener-execute-function
                 :start-listener-mode
                 :refresh-prompt
-                :clamp-cursor-to-input-area))
+                :clamp-cursor-to-input-area
+                :listener-previous-startswith-input
+                :listener-next-startswith-input))
 (in-package :lem-tests/listener-mode)
 
 (defun setup-listener-buffer ()
@@ -35,28 +37,93 @@
     (with-current-buffers ()
       (let ((buffer (setup-listener-buffer)))
         (testing "cursor at input-start-point is not moved"
-          (move-point (current-point) (input-start-point buffer))
-          (lem/listener-mode:clamp-cursor-to-input-area)
-          (ok (point= (current-point) (input-start-point buffer))))
+                 (move-point (current-point) (input-start-point buffer))
+                 (lem/listener-mode:clamp-cursor-to-input-area)
+                 (ok (point= (current-point) (input-start-point buffer))))
 
         (testing "cursor before input-start-point on same line is clamped"
-          (line-start (current-point))
-          (ok (point< (current-point) (input-start-point buffer)))
-          (lem/listener-mode:clamp-cursor-to-input-area)
-          (ok (point= (current-point) (input-start-point buffer))))
+                 (line-start (current-point))
+                 (ok (point< (current-point) (input-start-point buffer)))
+                 (lem/listener-mode:clamp-cursor-to-input-area)
+                 (ok (point= (current-point) (input-start-point buffer))))
 
         (testing "cursor after input-start-point is not moved"
-          (buffer-end (current-point))
-          (insert-string (current-point) "hello")
-          (let ((pos (copy-point (current-point) :temporary)))
-            (lem/listener-mode:clamp-cursor-to-input-area)
-            (ok (point= (current-point) pos))))
+                 (buffer-end (current-point))
+                 (insert-string (current-point) "hello")
+                 (let ((pos (copy-point (current-point) :temporary)))
+                   (lem/listener-mode:clamp-cursor-to-input-area)
+                   (ok (point= (current-point) pos))))
 
         (testing "cursor on previous line is not clamped"
-          ;; Add a newline in the input area so cursor can go to a previous line
-          (move-point (current-point) (input-start-point buffer))
-          (character-offset (current-point) -1)
-          ;; cursor is now on a line before input-start-point's line
-          (unless (same-line-p (current-point) (input-start-point buffer))
-            (lem/listener-mode:clamp-cursor-to-input-area)
-            (ok (not (point= (current-point) (input-start-point buffer))))))))))
+                 ;; Add a newline in the input area so cursor can go to a previous line
+                 (move-point (current-point) (input-start-point buffer))
+                 (character-offset (current-point) -1)
+                 ;; cursor is now on a line before input-start-point's line
+                 (unless (same-line-p (current-point) (input-start-point buffer))
+                   (lem/listener-mode:clamp-cursor-to-input-area)
+                   (ok (not (point= (current-point) (input-start-point buffer))))))))))
+
+;; make-history does not need pathname?
+
+(deftest listener-history-search-state-and-geometry
+  (with-fake-interface ()
+    (with-current-buffers ()
+      (let* ((buffer (setup-listener-buffer))
+             (test-history (lem/common/history:make-history)))
+        
+        (setf (buffer-value buffer 'lem/listener-mode::%listener-history)
+              test-history)
+               
+        (lem/common/history:add-history test-history "hello")
+        (lem/common/history:add-history test-history "world")
+        (lem/common/history:add-history test-history "hector")
+
+        (testing "Successful previous match perfectly preserves prefix cursor offset"
+                 ;; Type our unsubmitted prefix "'he"
+                 (move-point (current-point) (input-start-point buffer))
+                 (insert-string (current-point) "he")
+          
+                 ;; Trigger the search
+                 (listener-previous-startswith-input)
+          
+                 ;; Assert 1: The buffer text was completely replaced with the newest match
+                 (let ((full-input (points-to-string (input-start-point buffer) 
+                                                     (buffer-end-point buffer))))
+                   (ok (string= "hector" full-input)))
+          
+                 ;; Assert 2: The cursor is resting exactly at the end of the "he" prefix.
+                 ;; This proves our linear offset math is working and preventing the timer crash!
+                 (let ((cursor-prefix (points-to-string (input-start-point buffer) 
+                                                        (current-point))))
+                   (ok (string= "he" cursor-prefix))))
+
+        (testing "State drift is prevented on failed searches and rollback succeeds"
+                 ;; We are currently viewing "hector". 
+                 ;; Search previous again to hit the oldest match ("hello").
+                 (listener-previous-startswith-input)
+                 (ok (string= "hello" (points-to-string (input-start-point buffer) 
+                                                        (buffer-end-point buffer))))
+
+                 ;; Now we force the failure state. Searching previous again will find nothing.
+                 ;; Because of our fix, the internal loop should rewind its phantom steps.
+                 (listener-previous-startswith-input)
+                 (ok (string= "hello" (points-to-string (input-start-point buffer) 
+                                                        (buffer-end-point buffer))))
+
+                 ;; If the rewind worked, stepping 'Next' exactly twice should traverse 
+                 ;; perfectly back through "hector" and hit the Rollback state.
+                 (listener-next-startswith-input)
+                 (ok (string= "hector" (points-to-string (input-start-point buffer) 
+                                                         (buffer-end-point buffer))))
+          
+                 ;; The final step Next: Rollback triggers!
+                 (listener-next-startswith-input)
+          
+                 ;; Assert 3: The unsubmitted text was flawlessly restored
+                 (ok (string= "he" (points-to-string (input-start-point buffer) 
+                                                     (buffer-end-point buffer))))
+          
+                 ;; Assert 4: The rollback explicitly clamped the cursor safely
+                 (let ((cursor-prefix (points-to-string (input-start-point buffer) 
+                                                        (current-point))))
+                   (ok (string= "he" cursor-prefix))))))))


### PR DESCRIPTION
Fixes a few issues with history navigation. And are probably the root cause to #2214.
- You can now step through multi line history items
- Fix issue where starting repl line were lost when trying to search past end of history

I split out a helper to share the logic of previous and next. Might we worth moving the 
searching to the history package at a later date.

```
[ THE BUG: Forcing an old position ]
You start with a longer string, cursor at the end.
Buffer:  cl-user> 'hello
Cursor:                 ^ (Old position saved)

Code replaces the text, then forcefully shoves 
the cursor back to that saved position.
Buffer:  cl-user> 'he
Cursor:                 ^ 💥 CRASH: Timer wakes up
                             and sees cursor in the void!

------------------------------------------

[ THE FIX: Safe linear offset ]
Buffer starts the same.
Buffer:  cl-user> 'hello

Code safely anchors to the start, then steps 
forward exactly `prefix-len`.
Buffer:  cl-user> 'he
Cursor:             ^ (Perfectly safe!)
==========================================
```