### PR TITLE
fix(sdl2): content-hash attributes in line fingerprint to fix text ghosting

### DIFF
--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -461,12 +461,55 @@ frontends such as SDL2."
   (alexandria:when-let ((cache (window-parameter window 'line-fingerprint-cache)))
     (evict-line-fingerprints-from cache y)))
 
+(defun item-content-hash (item)
+  "Return a content-based hash for ITEM.
+
+SXHASH on STANDARD-OBJECTs and STRUCTURE-OBJECTs is identity-based in
+SBCL, so an attribute mutated in place (e.g. recoloring the shared CURSOR
+attribute via SET-ATTRIBUTE) keeps the same SXHASH even though its visible
+content changed.  Hashing attribute/color content keeps the line
+fingerprint consistent with ATTRIBUTE-EQUAL and avoids stale glyphs
+(ghosting) when an attribute is mutated rather than replaced."
+  (typecase item
+    (attribute
+     (let ((hash 5381))
+       (declare (type fixnum hash))
+       (flet ((mix (x)
+                (setf hash (logand most-positive-fixnum
+                                   (+ (* hash 33) (item-content-hash x))))))
+         (mix (attribute-foreground item))
+         (mix (attribute-background item))
+         (mix (attribute-reverse item))
+         (mix (attribute-bold item))
+         (mix (attribute-underline item)))
+       hash))
+    (lem/common/color:color
+     (logand most-positive-fixnum
+             (+ (* 33 (+ (* 33 (lem/common/color:color-red item))
+                         (lem/common/color:color-green item)))
+                (lem/common/color:color-blue item))))
+    (cons
+     ;; Descend so attributes nested inside sublists (the (start end
+     ;; attribute) entries of LOGICAL-LINE-ATTRIBUTES) are content-hashed
+     ;; rather than caught by the identity-based SXHASH of the sublist.
+     (let ((hash 5381))
+       (declare (type fixnum hash))
+       (loop :for x := item :then (cdr x)
+             :while (consp x)
+             :do (setf hash (logand most-positive-fixnum
+                                    (+ (* hash 33) (item-content-hash (car x)))))
+             :finally (when x
+                        (setf hash (logand most-positive-fixnum
+                                           (+ (* hash 33) (item-content-hash x))))))
+       hash))
+    (t (sxhash item))))
+
 (defun djb2 (hash item)
   "Hash with seed and item using djb2 hash algorithm"
   (declare (type fixnum hash))
   (logand most-positive-fixnum
           (+ (* hash 33)
-             (sxhash item))))
+             (item-content-hash item))))
 
 (defun mix-hashes (&rest items)
   "Fold ITEMS into one fixnum hash, descending into nested lists. Iterative

--- a/tests/display-cache.lisp
+++ b/tests/display-cache.lisp
@@ -90,3 +90,35 @@
     (ok (= 3 (length (lem-core::remove-drawing-cache-entries-from entries 30))))
     ;; A y of 0 removes everything.
     (ok (null (lem-core::remove-drawing-cache-entries-from entries 0)))))
+
+(deftest test-fingerprint-detects-attribute-mutation
+  ;; An attribute mutated in place (e.g. recoloring the shared `cursor`
+  ;; attribute via SET-ATTRIBUTE, as vi-mode/skk-mode do) keeps the same
+  ;; object identity while its content changes.  Because SXHASH on a
+  ;; standard-object is identity-based in SBCL, the fingerprint would not
+  ;; change and the line would be skipped on redraw, leaving stale pixels on
+  ;; persistent textures (SDL2 ghosting).  The fingerprint must change.
+
+  ;; Mutation referenced through the attributes list.
+  (let* ((attribute (lem-core::make-attribute :foreground "#FF0000"))
+         (line (lem-core::make-logical-line
+                :string "foo"
+                :attributes (list (list 0 3 attribute))
+                :end-of-line-cursor-attribute nil
+                :extend-to-end nil
+                :line-end-overlay nil))
+         (before (lem-core::compute-line-fingerprint line 0 0)))
+    (lem-core::set-attribute attribute :background "#00FF00")
+    (ok (not (= before (lem-core::compute-line-fingerprint line 0 0)))))
+
+  ;; Mutation referenced through the end-of-line cursor attribute.
+  (let* ((cursor (lem-core::make-attribute :background "#FFFFFF"))
+         (line (lem-core::make-logical-line
+                :string "foo"
+                :attributes nil
+                :end-of-line-cursor-attribute cursor
+                :extend-to-end nil
+                :line-end-overlay nil))
+         (before (lem-core::compute-line-fingerprint line 0 0)))
+    (lem-core::set-attribute cursor :background "#000000")
+    (ok (not (= before (lem-core::compute-line-fingerprint line 0 0))))))

--- a/tests/display-cache.lisp
+++ b/tests/display-cache.lisp
@@ -99,8 +99,14 @@
   ;; change and the line would be skipped on redraw, leaving stale pixels on
   ;; persistent textures (SDL2 ghosting).  The fingerprint must change.
 
+  ;; `make-logical-line` and `compute-line-fingerprint` are unexported
+  ;; lem-core internals: this is a white-box unit test of the display
+  ;; layer's fingerprint cache, so internal access is necessary to build a
+  ;; logical-line and hash it directly.  `make-attribute`/`set-attribute`
+  ;; are exported and used through the package's :use of :lem-core.
+
   ;; Mutation referenced through the attributes list.
-  (let* ((attribute (lem-core::make-attribute :foreground "#FF0000"))
+  (let* ((attribute (make-attribute :foreground "#FF0000"))
          (line (lem-core::make-logical-line
                 :string "foo"
                 :attributes (list (list 0 3 attribute))
@@ -108,11 +114,11 @@
                 :extend-to-end nil
                 :line-end-overlay nil))
          (before (lem-core::compute-line-fingerprint line 0 0)))
-    (lem-core::set-attribute attribute :background "#00FF00")
+    (set-attribute attribute :background "#00FF00")
     (ok (not (= before (lem-core::compute-line-fingerprint line 0 0)))))
 
   ;; Mutation referenced through the end-of-line cursor attribute.
-  (let* ((cursor (lem-core::make-attribute :background "#FFFFFF"))
+  (let* ((cursor (make-attribute :background "#FFFFFF"))
          (line (lem-core::make-logical-line
                 :string "foo"
                 :attributes nil
@@ -120,5 +126,5 @@
                 :extend-to-end nil
                 :line-end-overlay nil))
          (before (lem-core::compute-line-fingerprint line 0 0)))
-    (lem-core::set-attribute cursor :background "#000000")
+    (set-attribute cursor :background "#000000")
     (ok (not (= before (lem-core::compute-line-fingerprint line 0 0))))))


### PR DESCRIPTION
## Summary

The SDL2 frontend composites persistent per-view GPU textures and only re-renders lines the core display layer marks as changed. That decision is made by a per-window **line-fingerprint cache** in `src/display/physical-line.lisp`: each frame every screen line is hashed, and if the hash matches the cached one the line is skipped.

The fingerprint folded each item through `sxhash`. In SBCL, `sxhash` on a `standard-object` (the `attribute` class) and on a `structure-object` (the `color` struct) is **identity-based**, not content-based. Attributes can be **mutated in place** — e.g. vi-mode and skk-mode recolor the shared `cursor` attribute via `set-attribute`. After such a mutation the object identity is unchanged, so `sxhash` is unchanged, so the fingerprint is unchanged, so the line is skipped on redraw — leaving the previous frame's glyphs on the persistent texture. **That is the ghosting.**

`M-x redraw-display` cleared the fingerprint cache and repainted every line, which is why a forced redraw made the ghost disappear.

This makes the fingerprint hash attribute/color **content**, consistent with how the rest of the pipeline compares attributes (`attribute-equal`, `drawing-object-equal`, the SDL2 `text-surface-cache`).

## Changes

### `src/display/physical-line.lisp`
- Added `item-content-hash`, a content-based hash used by `djb2`:
  - `attribute` → folds `foreground`, `background`, `reverse`, `bold`, `underline`.
  - `color` → folds the `red`/`green`/`blue` components.
  - `cons` → recurses through the spine (tolerant of dotted tails) so attributes nested inside the `(start end attribute)` entries of `logical-line-attributes` are content-hashed, not caught by the identity-based `sxhash` of the surrounding sublist.
  - everything else → `sxhash` (unchanged behavior).
- `djb2` now calls `item-content-hash` instead of `sxhash`.

The performance optimization is preserved: genuinely unchanged lines still hash identically and are still skipped; only in-place attribute mutation now correctly invalidates the line.

### `tests/display-cache.lisp`
- Added `test-fingerprint-detects-attribute-mutation`, asserting the line fingerprint changes after an in-place `set-attribute` mutation, covering both an attribute referenced through `logical-line-attributes` and one referenced through `end-of-line-cursor-attribute` (the literal cursor case).

## Notes
- Scope is limited to the two files above; no API signatures changed.
- Complies with `contract.yml` style rules (colon-prefixed `loop` keywords, kebab-case naming, docstring on the new function).