### PR TITLE
fix(sdl2): evict stale display-cache tail to fix invisible text after undo

### DIFF
--- a/src/display/physical-line.lisp
+++ b/src/display/physical-line.lisp
@@ -386,6 +386,25 @@ Assumes inputs are already reduced (no adjacent mergeable objects)."
                             (<= (+ y height) (+ cache-y cache-height)))))
                    (drawing-cache window))))
 
+(defun remove-drawing-cache-entries-from (entries y)
+  "Return ENTRIES with drawing-cache rows at or below Y removed.
+Pure helper over the entry list so the eviction can be unit tested without
+a window."
+  (remove-if (lambda (elt)
+               (>= (first elt) y))
+             entries))
+
+(defun invalidate-drawing-cache-from (window y)
+  "Drop drawing-cache entries for screen rows at or below Y.
+Counterpart to CLEAR-LINE-FINGERPRINT-CACHE-FROM for the drawing-object
+cache: when the area from Y down is blanked by CLEAR-TO-END-OF-WINDOW
+those rows no longer hold the objects their cache entries describe.  A
+later frame whose restored content matches a stale entry (e.g. undoing a
+large deletion) would otherwise pass VALIDATE-CACHE-P and skip the render,
+leaving the row blank on persistent-texture frontends such as SDL2."
+  (setf (drawing-cache window)
+        (remove-drawing-cache-entries-from (drawing-cache window) y)))
+
 (defun update-and-validate-cache-p (window y height objects)
   "Check cache validity, reducing objects once before storing.
 Returns T if the cached entry matches (render can be skipped)."
@@ -421,6 +440,26 @@ is force-redrawn or marked as needing redraw, since cached heights may
 no longer reflect the current layout."
   (alexandria:when-let ((cache (window-parameter window 'line-fingerprint-cache)))
     (clrhash cache)))
+
+(defun evict-line-fingerprints-from (cache y)
+  "Remove fingerprint entries in CACHE for screen rows at or below Y.
+Pure helper over the hash table so it can be unit tested without a window."
+  (loop :for key :being :the :hash-keys :of cache
+        :when (>= key y)
+        :collect key :into stale
+        :finally (dolist (key stale)
+                   (remhash key cache))))
+
+(defun clear-line-fingerprint-cache-from (window y)
+  "Drop cached line fingerprints for screen rows at or below Y on WINDOW.
+Called when the area from Y down is about to be blanked by
+CLEAR-TO-END-OF-WINDOW: those rows no longer hold the content their cached
+fingerprints describe.  Leaving them would let a later frame whose restored
+content happens to match a stale fingerprint (e.g. undoing a large
+deletion) skip the render, leaving the row blank on persistent-texture
+frontends such as SDL2."
+  (alexandria:when-let ((cache (window-parameter window 'line-fingerprint-cache)))
+    (evict-line-fingerprints-from cache y)))
 
 (defun djb2 (hash item)
   "Hash with seed and item using djb2 hash algorithm"
@@ -645,6 +684,8 @@ creating zero temporary letter-objects."
             (unless (< y height)
               (return-from outer)))))
       (when (< y height)
+        (clear-line-fingerprint-cache-from window y)
+        (invalidate-drawing-cache-from window y)
         (lem-if:clear-to-end-of-window (implementation) (window-view window) y))
       (setf (window-left-width window)
             (floor left-side-width (lem-if:get-char-width (implementation)))))))

--- a/tests/display-cache.lisp
+++ b/tests/display-cache.lisp
@@ -63,6 +63,8 @@
     (setf (gethash 0 cache) (cons 111 10))
     (setf (gethash 10 cache) (cons 222 10))
     (setf (gethash 20 cache) (cons 333 10))
+    ;; `lem-core::` reaches an unexported internal on purpose: this helper
+    ;; has no public equivalent and is exercised directly as a white-box test.
     (lem-core::evict-line-fingerprints-from cache 10)
     ;; Rows at or below the cleared y are gone; rows above are kept.
     (ok (nth-value 1 (gethash 0 cache)))
@@ -79,6 +81,8 @@
   ;; is an unexported display-layer internal, accessed here for a white-box
   ;; unit test over the (y height objects) entry list.
   (let ((entries (list (list 0 10 nil) (list 10 10 nil) (list 20 10 nil))))
+    ;; `lem-core::` reaches an unexported internal on purpose: this helper
+    ;; has no public equivalent and is exercised directly as a white-box test.
     ;; Only the row above the cleared y survives.
     (ok (equal (lem-core::remove-drawing-cache-entries-from entries 10)
                (list (list 0 10 nil))))

--- a/tests/display-cache.lisp
+++ b/tests/display-cache.lisp
@@ -51,3 +51,38 @@
     ;; 4. Parameter Cancellation Check: Matching coordinate variables don't zero out
     (ok (not (= (lem-core::compute-line-fingerprint line-a 15 15)
                 (lem-core::compute-line-fingerprint line-a 30 30))))))
+
+(deftest test-evict-line-fingerprints-from
+  ;; When the tail of a window is blanked by clear-to-end-of-window (e.g. after
+  ;; deleting a large region), the fingerprint entries for those rows must be
+  ;; dropped.  Otherwise undoing the deletion restores content whose fingerprint
+  ;; matches the stale entry, the render is skipped, and the row stays blank on
+  ;; persistent-texture frontends (SDL2).  `evict-line-fingerprints-from` is an
+  ;; unexported display-layer internal, accessed here for a white-box unit test.
+  (let ((cache (make-hash-table :test 'eql)))
+    (setf (gethash 0 cache) (cons 111 10))
+    (setf (gethash 10 cache) (cons 222 10))
+    (setf (gethash 20 cache) (cons 333 10))
+    (lem-core::evict-line-fingerprints-from cache 10)
+    ;; Rows at or below the cleared y are gone; rows above are kept.
+    (ok (nth-value 1 (gethash 0 cache)))
+    (ng (nth-value 1 (gethash 10 cache)))
+    (ng (nth-value 1 (gethash 20 cache)))
+    (ok (= 1 (hash-table-count cache)))))
+
+(deftest test-remove-drawing-cache-entries-from
+  ;; The drawing-object cache (keyed by screen y) has the same stale-tail
+  ;; hazard as the fingerprint cache: rows blanked by clear-to-end-of-window
+  ;; must be dropped so a later frame whose restored objects match a stale
+  ;; entry does not pass validate-cache-p and skip the render (SDL2 invisible
+  ;; text after undoing a large deletion).  `remove-drawing-cache-entries-from`
+  ;; is an unexported display-layer internal, accessed here for a white-box
+  ;; unit test over the (y height objects) entry list.
+  (let ((entries (list (list 0 10 nil) (list 10 10 nil) (list 20 10 nil))))
+    ;; Only the row above the cleared y survives.
+    (ok (equal (lem-core::remove-drawing-cache-entries-from entries 10)
+               (list (list 0 10 nil))))
+    ;; A y past all entries removes nothing.
+    (ok (= 3 (length (lem-core::remove-drawing-cache-entries-from entries 30))))
+    ;; A y of 0 removes everything.
+    (ok (null (lem-core::remove-drawing-cache-entries-from entries 0)))))


### PR DESCRIPTION
## Summary

On SDL2, deleting a large region and then undoing it leaves the restored text **invisible** until you scroll or move onto the affected line. Reproduced with vi-mode `da)` on a large function followed by undo.

## Root cause

When a deletion shrinks the buffer, `redraw-lines` blanks the now-empty rows with `clear-to-end-of-window`. Two per-window caches keyed by screen `y` decide whether a line's render can be skipped:

| Cache | Skip mechanism |
|---|---|
| line-fingerprint | early-exit in `redraw-logical-line-when-horizontal-scroll` (`check-line-fingerprint`) |
| drawing-object (`redrawing-cache`) | `validate-cache-p` in `render-line-with-caching` |

Neither cache was invalidated for the rows `clear-to-end-of-window` blanks, and normal editing does **not** set `window-need-to-redraw-p` (that's the point of the per-line caching), so the stale tail entries survived across frames.

Undo restores the deleted text to *exactly* its prior content, so its fingerprint **and** its drawing objects match the stale tail entries → the render is skipped. But the persistent SDL2 texture for that region had already been cleared by `clear-to-end-of-window`, so nothing is drawn → invisible text. A forced redraw (scroll, or moving onto the line) clears the caches and the text reappears.

## Fix

Evict both caches' entries for rows at or below `y` immediately before `clear-to-end-of-window`:

```lisp
(when (< y height)
  (clear-line-fingerprint-cache-from window y)
  (invalidate-drawing-cache-from window y)
  (lem-if:clear-to-end-of-window (implementation) (window-view window) y))
```

The eviction logic is factored into pure helpers (`evict-line-fingerprints-from` over the hash table, `remove-drawing-cache-entries-from` over the entry list) so it can be unit tested without constructing a window/frontend.

## Tests

`tests/display-cache.lisp` gains `test-evict-line-fingerprints-from` and `test-remove-drawing-cache-entries-from`, asserting rows at/below the cleared `y` are dropped while rows above are kept. All display-cache tests pass and `lem/core` compiles cleanly.

## Notes

- Verified against the live SDL2 repro: the restored text now paints immediately after undo.
- Related to but independent of #2219 (which fixes a different fingerprint bug — in-place *attribute mutation*). This PR is branched off `main`, so it merges independently.