### PR TITLE
fix(terminal): correct VTermRect FFI field order to fix ghosting

### DIFF
--- a/extensions/terminal/ffi.lisp
+++ b/extensions/terminal/ffi.lisp
@@ -248,10 +248,15 @@
   (rows :int)
   (cols :int))
 
+;; Field order must match libvterm's VTermRect exactly: start_row, end_row,
+;; start_col, end_col.  A previous definition swapped end-row and start-col,
+;; so cb-damage/cb-moverect read a column value as the end row and marked an
+;; empty/garbage row range -- erases and scrolls the cursor didn't visit
+;; (clear, completion listings) were never re-rendered, leaving ghosting.
 (cffi:defcstruct vterm-rect
   (start-row :int)
-  (start-col :int)
   (end-row :int)
+  (start-col :int)
   (end-col :int))
 
 (cffi:defcstruct vterm-pos


### PR DESCRIPTION
## Problem

The `lem-terminal` extension left stale glyphs on screen (ghosting) after operations that erase or scroll regions the cursor doesn't visit:

- `clear` after a screen full of output (e.g. `tree`) leaves the old output below the new prompt
- `ls` + <kbd>Tab</kbd> completion listings remain rendered beneath the command line after the list narrows/closes

In every case, **resizing the window cleared it** — the tell that the screen content was correct in libvterm but the dirty-row bitmap was wrong.

## Root cause

libvterm's `VTermRect` is laid out:

```c
typedef struct {
  int start_row;
  int end_row;
  int start_col;
  int end_col;
} VTermRect;
```

but the CFFI `defcstruct` in `extensions/terminal/ffi.lisp` swapped `end-row` and `start-col`:

```lisp
(cffi:defcstruct vterm-rect
  (start-row :int)
  (start-col :int)   ; overlaps end_row
  (end-row :int)     ; overlaps start_col
  (end-col :int))
```

`cb-damage` and `cb-moverect` read `start-row`/`end-row` — but `end-row` actually read the bytes of libvterm's `start_col`, so `mark-rows-dirty` was handed a column value as the end row and marked an empty/garbage row range.

Only rows the cursor physically visited got marked dirty, via `cb-movecursor` (whose `VTermPos` `{row, col}` layout *is* correct). That's why streaming output rendered fine — the cursor advances line by line — while bulk erases/scrolls the cursor skipped over were never re-rendered. Resize masked the bug because `cb-resize` calls `mark-all-rows-dirty`, ignoring the rect.

## Fix

Reorder the struct fields to match libvterm exactly. Pure FFI change; no native (`terminal.so`) rebuild required, though the `lem-terminal` Lisp system must be recompiled so `with-foreign-slots` in the callbacks picks up the corrected offsets.

## Testing

Verified on the SDL2 frontend (macOS, arm64): after the fix, `tree`→`clear` and `ls`+<kbd>Tab</kbd> completion both repaint correctly with no leftover glyphs.