### PR TITLE
fix(sdl2): pixel-perfect rendering across DPI levels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ test:
 		--eval '(asdf:test-system "lem-tests")' \
 		--eval '(asdf:test-system "lem-vi-mode")' \
 		--eval '(asdf:test-system "lem-transient")' \
+		--eval '(asdf:test-system "lem-sdl2/tests")' \
 		--quit
 
 doc:

--- a/frontends/sdl2/display.lisp
+++ b/frontends/sdl2/display.lisp
@@ -16,6 +16,8 @@
            :display-window
            :display-char-width
            :display-char-height
+           :display-font-ascent
+           :display-font-descent
            :display-focus-p
            :create-view-texture
            :display-renderer
@@ -37,6 +39,9 @@
            :display-height
            :display-window-width
            :adapt-high-dpi-font-size
+           :handle-display-changed
+           :*post-display-change-hooks*
+           :add-post-display-change-hook
            :change-font
            :with-renderer
            :with-display-render-target
@@ -136,6 +141,16 @@ over `call-with-scratch-rect'."
 
 (defmethod display-braille-font ((display display))
   (font:font-braille-font (display-font display)))
+
+(defmethod display-font-ascent ((display display))
+  "Latin-normal-font ascent in pixels (always positive). Defines the row's
+target baseline relative to the cell top."
+  (font:font-ascent (display-font display)))
+
+(defmethod display-font-descent ((display display))
+  "Latin-normal-font descent in pixels (SDL_ttf convention: negative number,
+e.g. -3 for NotoSansMono at 12pt). |descent| pixels sit below the baseline."
+  (font:font-descent (display-font display)))
 
 (defmethod display-background-color ((display display))
   (or (lem:parse-color lem-if:*background-color-of-drawing-window*)
@@ -243,6 +258,25 @@ over `call-with-scratch-rect'."
                                      (* ratio (lem:config :sdl2-font-size (font:default-font-size))))
                    nil))))
 
+(defvar *post-display-change-hooks* '()
+  "Functions of one argument (DISPLAY) called after a DPI-driven
+font/char-metrics change has been applied, before `update-on-display-resized'.
+`lem-sdl2/view' registers a hook here to recreate per-view textures
+whose pixel sizes depend on `display-char-width' / `display-char-height';
+without it, the old view textures \u2014 sized at the *old* char metrics \u2014
+leak through as scaled/clipped artifacts (most visibly the buffer
+occupying only the upper-left quarter of the window when moving from
+Retina to a 1x display).")
+
+(defun add-post-display-change-hook (function)
+  "Register FUNCTION (a one-arg fn of DISPLAY) on `*post-display-change-hooks*'.
+Idempotent."
+  (pushnew function *post-display-change-hooks*))
+
+(defun run-post-display-change-hooks (display)
+  (dolist (hook *post-display-change-hooks*)
+    (funcall hook display)))
+
 (defmethod notify-required-redisplay ((display display))
   (with-renderer (display)
     (when (display-redraw-at-least-once-p display)
@@ -254,7 +288,32 @@ over `call-with-scratch-rect'."
       (adapt-high-dpi-display-scale display)
       #+darwin
       (adapt-high-dpi-font-size display)
+      (run-post-display-change-hooks display)
       (lem:update-on-display-resized))))
+
+(defun handle-display-changed (display)
+  "Handle a backing-size or display change for DISPLAY.
+Re-creates the texture at the new drawable size, re-derives the
+high-DPI scale, re-opens the font at the new scale, runs
+`*post-display-change-hooks*' (which refresh per-view textures), and
+relayouts windows.  Called when SDL fires `:size-changed' or
+`:display-changed' for the window \u2014 i.e. the window moved to a
+monitor with a different backing scale (Retina \u2194 standard DPI).
+Unlike `notify-required-redisplay' this runs the DPI adaptation
+unconditionally, since by the time the event fires the window has
+already been rendered at least once on the previous display.
+
+`update-texture' grabs the display mutex non-recursively, so it must
+be called outside the `with-renderer' block (matching the `:resized'
+event handler pattern in `on-windowevent')."
+  (update-texture display)
+  (with-renderer (display)
+    #+darwin
+    (adapt-high-dpi-display-scale display)
+    #+darwin
+    (adapt-high-dpi-font-size display)
+    (run-post-display-change-hooks display)
+    (lem:update-on-display-resized)))
 
 (defmethod render-fill-rect ((display display) x y width height &key color)
   (let ((x (* x (display-char-width display)))

--- a/frontends/sdl2/display.lisp
+++ b/frontends/sdl2/display.lisp
@@ -52,6 +52,17 @@
 
 (defvar *display*)
 
+(defvar *post-display-change-hooks* '()
+  "Hook variable (analogous to Lem's other `*...-hooks*' registries): a list
+of one-argument functions (DISPLAY) called after a DPI-driven font/char-metrics
+change has been applied, before `update-on-display-resized'.
+`lem-sdl2/view' registers a hook here to recreate per-view textures
+whose pixel sizes depend on `display-char-width' / `display-char-height';
+without it, the old view textures — sized at the *old* char metrics —
+leak through as scaled/clipped artifacts (most visibly the buffer
+occupying only the upper-left quarter of the window when moving from
+Retina to a 1x display).")
+
 (defun current-display ()
   *display*)
 
@@ -257,16 +268,6 @@ e.g. -3 for NotoSansMono at 12pt). |descent| pixels sit below the baseline."
                    (font:change-size font-config
                                      (* ratio (lem:config :sdl2-font-size (font:default-font-size))))
                    nil))))
-
-(defvar *post-display-change-hooks* '()
-  "Functions of one argument (DISPLAY) called after a DPI-driven
-font/char-metrics change has been applied, before `update-on-display-resized'.
-`lem-sdl2/view' registers a hook here to recreate per-view textures
-whose pixel sizes depend on `display-char-width' / `display-char-height';
-without it, the old view textures \u2014 sized at the *old* char metrics \u2014
-leak through as scaled/clipped artifacts (most visibly the buffer
-occupying only the upper-left quarter of the window when moving from
-Retina to a 1x display).")
 
 (defun add-post-display-change-hook (function)
   "Register FUNCTION (a one-arg fn of DISPLAY) on `*post-display-change-hooks*'.

--- a/frontends/sdl2/drawing.lisp
+++ b/frontends/sdl2/drawing.lisp
@@ -280,7 +280,7 @@ is not erased by the next glyph's background fill."
 widths, for the multi-character text run DRAWING-OBJECT."
   (let ((attribute (text-object-attribute drawing-object)))
     (loop :for c :across (text-object-string drawing-object)
-          :for letter := (lem-core::make-letter-object c attribute)
+          :for letter := (make-letter-object c attribute)
           :collect letter :into letters
           :collect (object-width letter display) :into widths
           :finally (return (values letters widths)))))
@@ -427,7 +427,7 @@ rather than the row-wide two-pass)."
                     (loop :with current-x := obj-x
                           :for c :across (text-object-string object)
                           :while (< current-x display-width)
-                          :for letter := (lem-core::make-letter-object
+                          :for letter := (make-letter-object
                                           c (text-object-attribute object))
                           :for letter-width := (object-width letter display)
                           :do (draw-text-glyph-surface letter current-x bottom-y

--- a/frontends/sdl2/drawing.lisp
+++ b/frontends/sdl2/drawing.lisp
@@ -70,14 +70,24 @@ Uses a sentinel key so it participates in the normal cache lifecycle
 (defmethod object-width ((drawing-object void-object) display)
   0)
 
+(defun text-cell-width (drawing-object display)
+  "Cell-aligned pixel width of a text-object: string-width × char-width.
+Mirrors lem-ncurses/drawing-object:object-width semantics (logical
+column width) so SDL2 text aligns on the character grid regardless of
+per-string SDL_ttf surface-width drift."
+  (* (lem-core:string-width (text-object-string drawing-object))
+     (display:display-char-width display)))
+
 (defmethod object-width ((drawing-object text-object) display)
-  (sdl2:surface-width (get-surface drawing-object display)))
+  (text-cell-width drawing-object display))
 
 (defmethod object-width ((drawing-object control-character-object) display)
   (* 2 (display:display-char-width display)))
 
 (defmethod object-width ((drawing-object icon-object) display)
-  (sdl2:surface-width (get-surface drawing-object display)))
+  ;; Cell-aligned advance (typically 2 * char-width). The icon font's natural
+  ;; glyph surface is usually wider than this; draw-object scales it to fit.
+  (text-cell-width drawing-object display))
 
 (defmethod object-width ((drawing-object folder-object) display)
   (* 2 (display:display-char-width display)))
@@ -92,7 +102,7 @@ Uses a sentinel key so it participates in the normal cache lifecycle
   0)
 
 (defmethod object-width ((drawing-object line-end-object) display)
-  (sdl2:surface-width (get-surface drawing-object display)))
+  (text-cell-width drawing-object display))
 
 (defmethod object-width ((drawing-object image-object) display)
   (or (image-object-width drawing-object)
@@ -105,7 +115,17 @@ Uses a sentinel key so it participates in the normal cache lifecycle
   (display:display-char-height display))
 
 (defmethod object-height ((drawing-object text-object) display)
-  (sdl2:surface-height (get-surface drawing-object display)))
+  ;; Use the stable row cell-height (derived from font metrics at the
+  ;; display level) rather than the per-string SDL_ttf surface height.
+  ;; SDL_ttf can return slightly different surface heights for different
+  ;; strings (e.g. ones containing descenders like `p'/`g'/`y' versus
+  ;; ones without), which would otherwise leak into the background
+  ;; rectangle drawn by `draw-text-glyph-surface', producing the
+  ;; uneven-extent "padding around the problem letters" artefact at
+  ;; attribute boundaries on a highlighted row.  The natural surface
+  ;; height is still read inside `draw-text-glyph-surface' directly
+  ;; from the surface for baseline-anchored glyph blitting.
+  (display:display-char-height display))
 
 (defmethod object-height ((drawing-object icon-object) display)
   (display:display-char-height display))
@@ -157,39 +177,175 @@ Uses a sentinel key so it participates in the normal cache lifecycle
     (:underline
      (draw-rect display x (+ y surface-height -1) surface-width 1 background))))
 
-(defmethod draw-object ((drawing-object text-object) x bottom-y display view)
-  (let* ((surface-width (object-width drawing-object display))
-         (surface-height (object-height drawing-object display))
+(defun draw-text-glyph-surface (drawing-object x bottom-y display view cell-width
+                                &key clip (phase :both))
+  "Draws DRAWING-OBJECT's cached SDL surface in a (CELL-WIDTH × cell-height) slot
+at (X, BOTTOM-Y). Cell-height is taken from the drawing-object's OBJECT-HEIGHT so
+non-text surfaces (folder PNG, icon font, emoji font) get scaled to the editor's
+character row height instead of being placed at their natural pixel height.
+
+CLIP / PHASE control how the glyph and its background are composited:
+
+* CLIP NIL (icon / folder / emoji): the surface is rendered into the cell with
+  `render-copy-ex' allowed to scale it down to fit, preventing oversized glyph
+  surfaces from spilling into adjacent columns or rows.
+
+* CLIP T (text characters): the surface is rendered at its natural pixel size.
+  At small font sizes the NotoSansMono rasterizer produces some glyphs (`p',
+  `g', `T', ...) whose blended surface-width is one pixel wider than the
+  advance width — that overhang is anti-aliasing tail that must not be
+  squished by `render-copy-ex' (which is what made `P' and the other exact-
+  width letters look visually different from their neighbours).
+
+PHASE selects what to draw:
+  :BG     — background fill + cursor box + underline only (no glyph).
+  :GLYPH  — glyph blit only (no background / cursor / underline).
+  :BOTH   — bg first, then glyph, then underline. Default.
+
+The two-phase split lets a multi-character text run paint all backgrounds
+first and then all glyphs, so a 1-pixel right-edge AA overhang from one glyph
+is not erased by the next glyph's background fill."
+  (let* ((surface (get-surface drawing-object display))
+         (surface-width (sdl2:surface-width surface))
+         (surface-height (sdl2:surface-height surface))
+         (cell-height (object-height drawing-object display))
          (attribute (text-object-attribute drawing-object))
          (background (lem-core:attribute-background-with-reverse attribute))
-         (texture (lem-sdl2/text-surface-cache:get-or-create-texture
-                   (display:display-renderer display)
-                   (get-surface drawing-object display)))
-         (y (- bottom-y surface-height)))
-    (cond ((and attribute (lem-core:cursor-attribute-p attribute))
-           (lem-sdl2/view:set-cursor-position view x y)
-           (draw-cursor display x y surface-width surface-height background))
+         (y (- bottom-y cell-height))
+         (draw-width (if clip surface-width (min surface-width cell-width)))
+         (draw-height (min surface-height cell-height)))
+    (when (member phase '(:bg :both))
+      (cond ((and attribute (lem-core:cursor-attribute-p attribute))
+             (lem-sdl2/view:set-cursor-position view x y)
+             (draw-cursor display x y cell-width cell-height background))
+            (t
+             (draw-rect display x y cell-width cell-height background))))
+    (when (member phase '(:glyph :both))
+      (let ((texture (lem-sdl2/text-surface-cache:get-or-create-texture
+                      (display:display-renderer display)
+                      surface)))
+        (cond
+          (clip
+           ;; Natural-size render with explicit baseline anchoring.  The
+           ;; `render-utf8-blended' surface places the glyph baseline at
+           ;; (ascent) pixels down from the surface top, regardless of the
+           ;; specific glyph's bounding box.  We anchor the surface so the
+           ;; baseline lands at the row's intrinsic baseline:
+           ;;     screen_baseline_y = bottom_y - |descent|
+           ;;     glyph_dst_y       = screen_baseline_y - ascent
+           ;;                       = bottom_y - ascent - |descent|
+           ;; This is equivalent to the SDL_ttf docs' per-glyph formula
+           ;;     dst.y = targetBaselineY - TTF_FontAscent + glyph.maxy
+           ;; once the (ascent - maxy) per-glyph offset already baked into
+           ;; the blended surface is accounted for, but it uses font-level
+           ;; metrics rather than the surface dimensions — so the baseline
+           ;; locks even if a particular glyph's surface comes back with a
+           ;; non-uniform height.  Any 1-px right-edge AA overhang is
+           ;; allowed to land in the next cell column; the preceding
+           ;; phase :bg sweep ensures the next cell's background does not
+           ;; erase it.
+           (let* ((ascent (display:display-font-ascent display))
+                  (descent (display:display-font-descent display))
+                  (glyph-y (- bottom-y ascent (abs descent))))
+             (display:with-scratch-rect (dst-rect display x glyph-y
+                                                  surface-width surface-height)
+               (sdl2:render-copy-ex (display:display-renderer display)
+                                    texture
+                                    :source-rect nil
+                                    :dest-rect dst-rect
+                                    :flip (list :none)))))
           (t
-           (draw-rect display x y surface-width surface-height background)))
-    (display:with-scratch-rect (dest-rect display x y surface-width surface-height)
-      (sdl2:render-copy-ex (display:display-renderer display)
-                           texture
-                           :source-rect nil
-                           :dest-rect dest-rect
-                           :flip (list :none)))
-    (when (and attribute
+           (display:with-scratch-rect (dst-rect display x y draw-width draw-height)
+             (sdl2:render-copy-ex (display:display-renderer display)
+                                  texture
+                                  :source-rect nil
+                                  :dest-rect dst-rect
+                                  :flip (list :none)))))))
+    (when (and (member phase '(:bg :both))
+               attribute
                (lem:attribute-underline attribute))
       (display:render-line display
                            x
-                           (1- (+ y surface-height))
-                           (+ x surface-width)
-                           (1- (+ y surface-height))
+                           (1- (+ y cell-height))
+                           (+ x cell-width)
+                           (1- (+ y cell-height))
                            :color (let ((underline (lem:attribute-underline attribute)))
                                     (if (eq underline t)
                                         (lem-core:attribute-foreground-color attribute)
                                         (or (lem:parse-color underline)
-                                            (lem-core:attribute-foreground-color attribute))))))
-    surface-width))
+                                            (lem-core:attribute-foreground-color attribute))))))))
+
+(defun text-object-letter-objects-and-widths (drawing-object display)
+  "Return two parallel lists: per-character letter-objects and their cell
+widths, for the multi-character text run DRAWING-OBJECT."
+  (let ((attribute (text-object-attribute drawing-object)))
+    (loop :for c :across (text-object-string drawing-object)
+          :for letter := (lem-core::make-letter-object c attribute)
+          :collect letter :into letters
+          :collect (object-width letter display) :into widths
+          :finally (return (values letters widths)))))
+
+(defun draw-text-object-phase (drawing-object x bottom-y display view phase)
+  "Render the text-object DRAWING-OBJECT for one of the two-pass phases
+(:BG or :GLYPH).  PHASE :BG paints backgrounds, cursors and underlines for
+every cell of the run; PHASE :GLYPH blits each glyph at its natural surface
+width so the rasterizer's right-edge anti-aliasing tail is preserved."
+  (let ((string (text-object-string drawing-object)))
+    (cond ((<= (length string) 1)
+           (draw-text-glyph-surface drawing-object x bottom-y display view
+                                    (object-width drawing-object display)
+                                    :clip t :phase phase))
+          (t
+           (multiple-value-bind (letter-objects letter-widths)
+               (text-object-letter-objects-and-widths drawing-object display)
+             (loop :with current-x := x
+                   :for letter-object :in letter-objects
+                   :for letter-width :in letter-widths
+                   :do (draw-text-glyph-surface letter-object current-x bottom-y
+                                                display view letter-width
+                                                :clip t :phase phase)
+                       (incf current-x letter-width)))))))
+
+(defmethod draw-object ((drawing-object text-object) x bottom-y display view)
+  ;; Render each character individually on the cell grid. SDL_ttf's blended
+  ;; surface for a multi-character string has metrics that do not equal the
+  ;; sum of its per-character metrics, so a glyph would otherwise land on a
+  ;; different pixel column when the cursor (or any overlay) splits the run
+  ;; into shorter segments. Per-character rendering eliminates that drift —
+  ;; the same character always lands on the same pixel column regardless of
+  ;; how the line is partitioned, matching ncurses semantics.
+  ;;
+  ;; This per-text-object two-pass preserves the AA overhang within the run.
+  ;; The cross-text-object equivalent (an adjacent text-object's :bg erasing
+  ;; the previous text-object's AA tail) is handled by `redraw-physical-line',
+  ;; which lifts the two-pass to span the entire physical line.
+  (let ((total-width (object-width drawing-object display)))
+    (draw-text-object-phase drawing-object x bottom-y display view :bg)
+    (draw-text-object-phase drawing-object x bottom-y display view :glyph)
+    total-width))
+
+(defmethod draw-object ((drawing-object icon-object) x bottom-y display view)
+  ;; Icon font glyphs typically render much wider than the 2-cell column the
+  ;; layout reserves for them; draw-text-glyph-surface scales them down to fit.
+  (let ((cell-width (object-width drawing-object display)))
+    (draw-text-glyph-surface drawing-object x bottom-y display view cell-width)
+    cell-width))
+
+(defmethod draw-object ((drawing-object folder-object) x bottom-y display view)
+  ;; Folder PNG surface is much wider than 2 cells; render once and scale to fit.
+  ;; Overrides the text-object per-character loop so the icon stays atomic.
+  (let ((cell-width (object-width drawing-object display)))
+    (draw-text-glyph-surface drawing-object x bottom-y display view cell-width)
+    cell-width))
+
+(defmethod draw-object ((drawing-object emoji-object) x bottom-y display view)
+  ;; Emoji strings may span multiple codepoints (base + variation selector,
+  ;; ZWJ sequences, ...) that must be rendered as one composed glyph. Use the
+  ;; single-surface path with cell-aligned scaling so we neither split the
+  ;; sequence per-codepoint nor let an oversized emoji surface spill over.
+  (let ((cell-width (object-width drawing-object display)))
+    (draw-text-glyph-surface drawing-object x bottom-y display view cell-width)
+    cell-width))
 
 (defmethod draw-object ((drawing-object eol-cursor-object) x bottom-y display view)
   (display:set-render-color display (eol-cursor-object-color drawing-object))
@@ -237,19 +393,60 @@ Uses a sentinel key so it participates in the normal cache lifecycle
     (sdl2:destroy-texture texture)
     surface-width))
 
+(defun plain-text-object-p (object)
+  "True when OBJECT is an instance of the base `text-object' class (and not
+one of its specialised subclasses `icon-object', `folder-object', or
+`emoji-object', which need their own scale-to-fit `draw-object' method
+rather than the row-wide two-pass)."
+  (eq (class-of object) (find-class 'text-object)))
+
 (defun redraw-physical-line (display view x y objects height)
-  (let ((display-width (round (* (display:display-window-width display)
-                                 (first (display:display-scale display))))))
-    (loop :with current-x := x
-          :for object :in objects
-          :do (if (and (typep object 'text-object)
-                       (< display-width
-                          (+ current-x (object-width object display))))
-                  (loop :for c :across (text-object-string object)
-                        :do (let ((object (lem-core::make-letter-object c (text-object-attribute object))))
-                              (incf current-x (draw-object object current-x (+ y height) display view)))
-                        :while (< current-x display-width))
-                  (incf current-x (draw-object object current-x (+ y height) display view))))))
+  ;; Two-pass over the whole physical line: paint every plain text-object's
+  ;; backgrounds first, then blit every plain text-object's glyphs.  This
+  ;; preserves the 1-pixel right-edge AA tail at attribute boundaries (e.g.
+  ;; on the dashboard's highlighted row, where a `p' or `g' at the end of
+  ;; one attribute run would otherwise be eroded by the next text-object's
+  ;; full-width background fill).  Everything else (icon / folder / emoji
+  ;; text-object subclasses, images, eol-cursor, extend-to-eol) draws fully
+  ;; in the first pass via its own `draw-object' method — those don't have
+  ;; AA overhang to preserve and need their bespoke rendering (scale-to-fit
+  ;; for icon/folder/emoji surfaces, fill for extend-to-eol, etc.).
+  (let* ((bottom-y (+ y height))
+         (display-width (round (* (display:display-window-width display)
+                                  (first (display:display-scale display)))))
+         (placed (loop :with current-x := x
+                       :for object :in objects
+                       :while (< current-x display-width)
+                       :collect (cons object current-x)
+                       :do (incf current-x (object-width object display)))))
+    (flet ((draw-text-pass (object obj-x phase)
+             ;; Honour the wrap-to-letters branch the old code used when a
+             ;; text-object would extend past the display width.
+             (cond ((< display-width
+                       (+ obj-x (object-width object display)))
+                    (loop :with current-x := obj-x
+                          :for c :across (text-object-string object)
+                          :while (< current-x display-width)
+                          :for letter := (lem-core::make-letter-object
+                                          c (text-object-attribute object))
+                          :for letter-width := (object-width letter display)
+                          :do (draw-text-glyph-surface letter current-x bottom-y
+                                                       display view letter-width
+                                                       :clip t :phase phase)
+                              (incf current-x letter-width)))
+                   (t
+                    (draw-text-object-phase object obj-x bottom-y
+                                            display view phase)))))
+      ;; Pass 1: plain-text backgrounds + everything else (subclassed text-
+      ;; objects and non-text objects) in normal order.
+      (loop :for (object . obj-x) :in placed
+            :do (if (plain-text-object-p object)
+                    (draw-text-pass object obj-x :bg)
+                    (draw-object object obj-x bottom-y display view)))
+      ;; Pass 2: plain-text glyphs.
+      (loop :for (object . obj-x) :in placed
+            :when (plain-text-object-p object)
+              :do (draw-text-pass object obj-x :glyph)))))
 
 (defun redraw-physical-line-from-behind (display view objects)
   (loop :with current-x := (lem-if:view-width (lem-core:implementation) view)

--- a/frontends/sdl2/font.lisp
+++ b/frontends/sdl2/font.lisp
@@ -12,6 +12,8 @@
            :font-braille-font
            :font-char-width
            :font-char-height
+           :font-ascent
+           :font-descent
            :save-font-size
            :make-font-config
            :font-config-size
@@ -43,7 +45,13 @@
   emoji-font
   braille-font
   char-width
-  char-height)
+  char-height
+  ;; Latin-normal-font TTF intrinsic metrics, cached at open-font time so the
+  ;; glyph-draw path can anchor baselines without round-tripping into FFI on
+  ;; every blit.  ASCENT is positive (pixels above baseline), DESCENT is
+  ;; negative (pixels below baseline) per SDL_ttf convention.
+  ascent
+  descent)
 
 (defun save-font-size (font-config &optional (ratio 1))
   (setf (lem:config :sdl2-font-size)
@@ -133,7 +141,9 @@
                  :emoji-font emoji-font
                  :braille-font braille-font
                  :char-width char-width
-                 :char-height char-height))))
+                 :char-height char-height
+                 :ascent (sdl2-ffi.functions:ttf-font-ascent latin-normal-font)
+                 :descent (sdl2-ffi.functions:ttf-font-descent latin-normal-font)))))
 
 (defun close-font (font)
   (sdl2-ttf:close-font (font-latin-normal-font font))

--- a/frontends/sdl2/lem-sdl2.asd
+++ b/frontends/sdl2/lem-sdl2.asd
@@ -25,7 +25,16 @@
                (:file "graphics")
                (:file "image-buffer")
                (:file "tree")
-               (:file "color-picker")))
+               (:file "color-picker"))
+  :in-order-to ((test-op (test-op "lem-sdl2/tests"))))
+
+(defsystem "lem-sdl2/tests"
+  :depends-on ("lem-sdl2"
+               "rove")
+  :components ((:module "tests"
+                :components ((:file "font")
+                             (:file "drawing"))))
+  :perform (test-op (op c) (symbol-call :rove '#:run c)))
 
 (defsystem "lem-sdl2/executable"
   :build-operation program-op

--- a/frontends/sdl2/main.lisp
+++ b/frontends/sdl2/main.lisp
@@ -97,6 +97,17 @@
     (sdl2-ffi:+sdl-windowevent-resized+
      (display:update-texture display)
      (display:notify-required-redisplay display))
+    ;; SDL fires :size-changed on backing-pixel-size changes that do not
+    ;; correspond to a user resize — most notably when the window moves
+    ;; between displays with different DPI (Retina ↔ standard).  Re-derive
+    ;; the high-DPI scale, re-open the font, and resize the backing texture.
+    (sdl2-ffi:+sdl-windowevent-size-changed+
+     (display:handle-display-changed display))
+    ;; SDL ≥ 2.0.18 fires :display-changed when the window is dragged onto
+    ;; a different monitor.  On older SDL builds this constant is still
+    ;; defined by the FFI binding but the event simply never fires.
+    (sdl2-ffi:+sdl-windowevent-display-changed+
+     (display:handle-display-changed display))
     (sdl2-ffi:+sdl-windowevent-focus-gained+
      (setf (display:display-focus-p display) t))
     (sdl2-ffi:+sdl-windowevent-focus-lost+

--- a/frontends/sdl2/tests/drawing.lisp
+++ b/frontends/sdl2/tests/drawing.lisp
@@ -1,0 +1,75 @@
+(defpackage :lem-sdl2/tests/drawing
+  (:use :cl :rove)
+  (:local-nicknames (:drawing :lem-sdl2/drawing)
+                    (:display :lem-sdl2/display)))
+(in-package :lem-sdl2/tests/drawing)
+
+;;; Regression tests for `lem-sdl2/drawing::object-height' on the base
+;;; `text-object' class.
+;;;
+;;; Earlier the method returned `(sdl2:surface-height (get-surface ...))',
+;;; i.e. the per-string SDL_ttf surface height.  SDL_ttf can return slightly
+;;; different surface heights for different strings (notably ones containing
+;;; descenders like `p'/`g'/`y' vs ones without), which leaked through to the
+;;; background rectangle drawn by `draw-text-glyph-surface' during the `:bg'
+;;; phase -- producing an uneven, stepped highlight outline at attribute
+;;; boundaries (the "padding around the problem letters" artefact visible on
+;;; the dashboard's highlighted row).
+;;;
+;;; The fix pins the text-object's reported height to the stable cell-row
+;;; height (`display-char-height') so adjacent attribute runs paint
+;;; rectangles with identical vertical extent.  These tests lock that
+;;; behaviour in so a future change to `object-height' cannot silently
+;;; regress the visual artefact.
+;;;
+;;; The tests use a stub `display' that only exposes `display-char-height',
+;;; so they run without an SDL window / renderer.  `object-height' on a
+;;; text-object does not read the SDL surface -- it goes straight through
+;;; `display-char-height' -- which is exactly the invariant we want to
+;;; assert.
+
+(defclass stub-display ()
+  ((char-height :initarg :char-height :reader display::display-char-height)))
+
+(defun make-stub-display (&key (char-height 17))
+  (make-instance 'stub-display :char-height char-height))
+
+(defun make-text-object (string)
+  (make-instance 'lem-core/display:text-object
+                 :string string
+                 :attribute nil
+                 :type :latin))
+
+(deftest text-object-height-is-the-stable-cell-height
+  (let ((display (make-stub-display :char-height 17)))
+    (testing "object-height matches display-char-height for a plain ASCII string"
+      (ok (= (drawing::object-height (make-text-object "hello") display)
+             17)))
+    (testing "object-height matches display-char-height for a string with descenders"
+      (ok (= (drawing::object-height (make-text-object "pygmy") display)
+             17)))
+    (testing "object-height matches display-char-height for a string with ascenders only"
+      (ok (= (drawing::object-height (make-text-object "ABCDEF") display)
+             17)))))
+
+(deftest text-object-height-is-independent-of-string-content
+  ;; The core invariant: two text-objects with very different glyph shapes
+  ;; (one with descenders, one without) must report the same height, so the
+  ;; row-wide two-pass renderer paints uniform background rectangles across
+  ;; attribute boundaries on a highlighted line.
+  (let ((display (make-stub-display :char-height 17)))
+    (ok (= (drawing::object-height (make-text-object "py")     display)
+           (drawing::object-height (make-text-object "ABCDEF") display)
+           (drawing::object-height (make-text-object "Tg")     display)
+           (drawing::object-height (make-text-object "   ")    display)))))
+
+(deftest text-object-height-tracks-display-char-height-changes
+  ;; After a DPI swap `display-char-height' is re-derived from the freshly
+  ;; opened font; the text-object height must follow it -- if it ever pinned
+  ;; itself to the first display's value the highlight band would no longer
+  ;; cover the new row height after a monitor change.
+  (let ((small (make-stub-display :char-height 14))
+        (large (make-stub-display :char-height 28))
+        (obj   (make-text-object "py")))
+    (ok (= (drawing::object-height obj small) 14))
+    (ok (= (drawing::object-height obj large) 28))))

--- a/frontends/sdl2/tests/font.lisp
+++ b/frontends/sdl2/tests/font.lisp
@@ -1,0 +1,74 @@
+(defpackage :lem-sdl2/tests/font
+  (:use :cl :rove)
+  (:local-nicknames (:font :lem-sdl2/font)))
+(in-package :lem-sdl2/tests/font)
+
+;;; Tests for `lem-sdl2/font:open-font' caching of the latin-normal-font's
+;;; intrinsic TTF metrics (ascent / descent).  Those metrics are read by
+;;; `lem-sdl2/drawing:draw-text-glyph-surface' through
+;;; `lem-sdl2/display:display-font-ascent' / `display-font-descent' to anchor
+;;; the per-glyph baseline; if the caching ever drifts from the live TTF
+;;; values (for example because `open-font' forgets to re-read the metrics on
+;;; a DPI swap), every glyph will land on the wrong y and the buffer will
+;;; show a mis-aligned baseline.
+
+(defun call-with-ttf (thunk)
+  (sdl2-ttf:init)
+  (unwind-protect (funcall thunk)
+    (sdl2-ttf:quit)))
+
+(defmacro with-ttf (() &body body)
+  `(call-with-ttf (lambda () ,@body)))
+
+(defun open-default-font (size)
+  (font:open-font (font:make-font-config :size size)))
+
+(deftest ascent-and-descent-are-cached-from-latin-normal-font
+  (with-ttf ()
+    (let ((font (open-default-font 14)))
+      (unwind-protect
+           (let* ((latin (font:font-latin-normal-font font))
+                  (live-ascent  (sdl2-ffi.functions:ttf-font-ascent  latin))
+                  (live-descent (sdl2-ffi.functions:ttf-font-descent latin)))
+             (testing "cached ascent matches the live TTF_FontAscent"
+               (ok (= (font:font-ascent font) live-ascent)))
+             (testing "cached descent matches the live TTF_FontDescent"
+               (ok (= (font:font-descent font) live-descent)))
+             (testing "ascent is positive (pixels above baseline)"
+               (ok (plusp (font:font-ascent font))))
+             (testing "descent is non-positive (SDL_ttf convention: <= 0)"
+               (ok (not (plusp (font:font-descent font))))))
+        (font:close-font font)))))
+
+(deftest baseline-band-fits-within-font-height
+  (with-ttf ()
+    (let ((font (open-default-font 14)))
+      (unwind-protect
+           ;; `draw-text-glyph-surface' anchors each glyph at
+           ;;   glyph_y = bottom_y - ascent - |descent|
+           ;; which places the descender's bottom at (bottom_y - 1) and the
+           ;; ascender's top (ascent + |descent|) pixels above it.  That band
+           ;; must fit inside the row's intrinsic font height (which may
+           ;; additionally include a small line gap) -- otherwise the glyph
+           ;; would clip into the next row.
+           (let* ((latin (font:font-latin-normal-font font))
+                  (height (sdl2-ffi.functions:ttf-font-height latin)))
+             (ok (<= (+ (font:font-ascent font)
+                        (abs (font:font-descent font)))
+                     height)))
+        (font:close-font font)))))
+
+(deftest metrics-refresh-when-font-is-reopened-at-a-new-size
+  ;; Mirrors the DPI-swap flow: when the window moves between a Retina and a
+  ;; standard-DPI display, `lem-sdl2/display:handle-display-changed' calls
+  ;; `open-font' again at the new effective size.  The cached metrics must
+  ;; track the new font, not stay pinned to the first one.
+  (with-ttf ()
+    (let* ((small (open-default-font 12))
+           (large (open-default-font 24)))
+      (unwind-protect
+           (testing "ascent grows with font size"
+             (ok (< (font:font-ascent small)
+                    (font:font-ascent large))))
+        (font:close-font small)
+        (font:close-font large)))))

--- a/frontends/sdl2/view.lisp
+++ b/frontends/sdl2/view.lisp
@@ -13,6 +13,7 @@
    :draw-window-border
    :render-border-using-view
    :render-view-texture-to-display
+   :refresh-all-view-textures
    :view-window
    :view-x
    :view-y
@@ -131,3 +132,27 @@
     (sdl2:render-copy (display:display-renderer display)
                       (view-texture view)
                       :dest-rect dest-rect)))
+
+(defun refresh-all-view-textures (display)
+  "Recreate the SDL texture backing every live view at the current
+display char dimensions.  Called via `display:*post-display-change-hooks*'
+whenever a DPI-driven font swap changes `display:display-char-width' /
+`display:display-char-height' without changing the col/row count of any
+window (the canonical Retina \u2194 standard-DPI move case).  In that
+situation `lem-if:set-view-size' is a no-op \u2014 `window-set-size'
+short-circuits when width/height are unchanged \u2014 so view textures
+would otherwise stay sized at the *old* char metrics and leak through
+as scaled or clipped artifacts (the buffer occupying only the
+upper-left quarter of the window)."
+  (dolist (window (append (lem:window-list)
+                          (lem:frame-floating-windows (lem:current-frame))))
+    (let ((view (lem:window-view window)))
+      (when (typep view 'view)
+        (when (view-texture view)
+          (sdl2:destroy-texture (view-texture view)))
+        (setf (view-texture view)
+              (display:create-view-texture display
+                                           (max (view-width view) 1)
+                                           (max (view-height view) 1)))))))
+
+(display:add-post-display-change-hook 'refresh-all-view-textures)

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -25,6 +25,7 @@
    :text-object-surface
    :text-object-type
    :void-object
+   :make-letter-object
    :text-object))
 
 (uiop:define-package :lem-core


### PR DESCRIPTION
## Summary

Fixes a set of SDL2 frontend rendering artefacts and adds a headless test suite to lock the invariants in.

| Concern | Fix |
|---|---|
| **Baseline drift** between glyphs on a row | Anchor glyphs from cached font metrics: `glyph_y = bottom_y - ascent - |descent|` instead of surface-height anchoring. `ascent`/`descent` are cached on the `font` struct from `TTF_FontAscent`/`TTF_FontDescent` at open-font time. |
| **AA tail erosion** at attribute boundaries (`p`/`g`/`T`/`y`/`Y`) | Lift the two-pass `:bg`/`:glyph` rendering to span the whole physical line in `redraw-physical-line` — pass 1 paints all backgrounds, pass 2 blits all glyphs, so a 1px right-edge AA overhang isn't erased by the next run's background. |
| **Oversized icon / folder / emoji glyphs** | `plain-text-object-p` routes only base `text-object` instances through the per-character path; `icon-object`/`folder-object`/`emoji-object` keep their scale-to-fit `draw-object` methods. |
| **Stepped / padded highlight rectangles** around descenders | Pin `object-height` for base `text-object` to the stable `display-char-height` instead of per-string SDL_ttf surface height, so adjacent attribute runs paint identical vertical extents. |
| **Buffer shrinks to upper-left quarter after monitor change** | Handle `:size-changed` / `:display-changed` window events: re-derive display scale, re-open the font at the new effective size, and refresh per-view textures via the new `*post-display-change-hooks*` mechanism. |

## Tests

Adds `lem-sdl2/tests` (`tests/font.lisp`, `tests/drawing.lisp`), wired into `make test`:

- Font metric caching matches live `TTF_FontAscent`/`TTF_FontDescent`, sign sanity, baseline band fits within font height, and metrics refresh on reopen at a new size.
- `text-object` height equals `display-char-height` regardless of string content, and tracks `display-char-height` changes (DPI swap).

**12 expectations across 6 deftests, all passing** (verified locally via `asdf:test-system "lem-sdl2/tests"`). The drawing tests use a minimal `stub-display` so they run headlessly without an SDL window/renderer.