### PR TITLE
fix(vi-mode): guard yank-region on alive-point-p, not point-buffer (follow-up to #2214)

### DIFF
--- a/extensions/vi-mode/registers.lisp
+++ b/extensions/vi-mode/registers.lisp
@@ -211,13 +211,17 @@
                 (return (format nil "~{~A~^~%~}" results))))))))
 
 (defun yank-region (start end &key type append)
+  ;; A motion that mutates the buffer (e.g. `k` in the REPL, which swaps in a
+  ;; history item and deletes the old input) can leave START or END on a line
+  ;; that no longer exists. Such a point still reports a non-nil POINT-BUFFER,
+  ;; so check ALIVE-POINT-P instead before reading the region; otherwise
+  ;; POINTS-TO-STRING walks a dead line and crashes the editor.
+  (unless (and (lem:alive-point-p start)
+               (lem:alive-point-p end))
+    (return-from yank-region))
   (with-killring-context (:options (case type
                                      (:line :vi-line)
                                      (:block :vi-block)))
-    (unless (and (lem:point-buffer start)
-                 (lem:point-buffer end))
-      (return-from yank-region))
-    
     (copy-to-clipboard-with-killring
      (case type
        (:block

--- a/extensions/vi-mode/tests/registers.lisp
+++ b/extensions/vi-mode/tests/registers.lisp
@@ -11,6 +11,7 @@
                 :get-numbered-register
                 :set-numbered-register
                 :make-yank
+                :yank-region
                 :yank-text
                 :yank-type
                 :*small-deletion-register*
@@ -120,3 +121,34 @@
 
       (cmd "/def<Return>")
       (ok (equal (register #\/) "def")))))
+
+(deftest yank-region-aborts-on-dead-point
+  ;; Regression for #2214: a motion that rewrites the buffer under the operator
+  ;; (e.g. `k` in the REPL, which swaps in a history item and deletes the old
+  ;; input) can leave START or END on a line that no longer exists. Such a point
+  ;; still reports a non-nil POINT-BUFFER, so guarding on POINT-BUFFER does not
+  ;; catch it and POINTS-TO-STRING crashes the editor. The guard must use
+  ;; ALIVE-POINT-P instead.
+  (with-fake-interface ()
+    (with-vi-buffer (#?"[a]bc\ndef\nghi\n")
+      (let ((buffer (current-buffer))
+            ;; START sits in the middle of the second line as a :temporary point,
+            ;; which is not relocated when the surrounding text is deleted.
+            (start (copy-point (current-point) :temporary)))
+        (line-offset start 1)
+        (character-offset start 1)
+        (ok (lem:alive-point-p start))
+        ;; Delete from the end of the first line through the end of the buffer,
+        ;; collapsing everything onto the first line. The line object START
+        ;; pointed at is freed, leaving START stranded on a dead line.
+        (with-point ((from (buffer-start-point buffer) :temporary))
+          (line-end from)
+          (delete-between-points from (buffer-end-point buffer)))
+        ;; The stranded point looks dead to ALIVE-POINT-P but still has a buffer,
+        ;; which is exactly why guarding on POINT-BUFFER was insufficient.
+        (ok (not (lem:alive-point-p start)))
+        (ok (lem:point-buffer start))
+        ;; YANK-REGION must abort gracefully rather than crash the editor.
+        (let ((end (copy-point (buffer-end-point buffer) :temporary)))
+          (ok (progn (yank-region start end :type :char)
+                     t)))))))


### PR DESCRIPTION
## Summary

Follow-up to #2214. That PR added a guard to `yank-region` to prevent the `NIL is not of type VECTOR` crash when a vi operator's region points at text that a motion deleted (e.g. `y k` in the REPL, where `k` swaps in a history item and rewrites the input). The guard checked `point-buffer`:

```lisp
(unless (and (lem:point-buffer start)
             (lem:point-buffer end))
  (return-from yank-region))
```

But `point-buffer` is the wrong predicate. `delete-point` / `delete-between-points` never null a point's `buffer` slot, so a point stranded on a **deleted line** still reports a non-nil `point-buffer`. The guard therefore never fires in the crashing scenario, and `points-to-string` still walks the dead line and crashes the editor.

I verified this directly against `lem/core`:

| point state | `point-buffer` | `alive-point-p` | `points-to-string` |
|---|---|---|---|
| on a live line | non-nil | `T` | OK |
| stranded on a deleted line | **non-nil** | **`nil`** | **errors** |

The crash is a dead-*line* condition, which is exactly what `alive-point-p` (`line-alive-p`) tests.

## Changes

- Guard `yank-region` on `alive-point-p` for both `start` and `end`.
- Run the guard before entering `with-killring-context` (no need to set up the killring just to abort).
- Add a regression test (`yank-region-aborts-on-dead-point`) that strands a point on a deleted line and asserts `yank-region` aborts gracefully instead of signalling.

## Testing

`lem-vi-mode/tests` — all pass (11/11 in the registers suite, including the new test).
