### PR TITLE
fix markdown-preview

### DIFF
--- a/extensions/markdown-mode/preview/external-browser.lisp
+++ b/extensions/markdown-mode/preview/external-browser.lisp
@@ -71,7 +71,7 @@ The WS connection is closed when the markdown file is closed."))
 (defun generate-html-and-preview (buffer)
   (let* ((port (setup-server buffer))
          (html-file (generate-html buffer port)))
-    (uiop:run-program
+    (uiop:launch-program
       (list #+(or win32 mswindows windows) "explorer"
             #+(or macos darwin) "open"
             #-(or win32 mswindows macos darwin windows) "xdg-open"

--- a/extensions/markdown-mode/preview/external-browser.lisp
+++ b/extensions/markdown-mode/preview/external-browser.lisp
@@ -71,7 +71,11 @@ The WS connection is closed when the markdown file is closed."))
 (defun generate-html-and-preview (buffer)
   (let* ((port (setup-server buffer))
          (html-file (generate-html buffer port)))
-    (trivial-open-browser:open-browser (namestring html-file))))
+    (uiop:run-program
+      (list #+(or win32 mswindows windows) "explorer"
+            #+(or macos darwin) "open"
+            #-(or win32 mswindows macos darwin windows) "xdg-open"
+            (namestring html-file)))))
 
 (defun refresh (buffer)
   (alexandria:when-let ((server (get-buffer-server-or-make buffer)))

--- a/extensions/markdown-mode/preview/external-browser.lisp
+++ b/extensions/markdown-mode/preview/external-browser.lisp
@@ -94,7 +94,7 @@ The WS connection is closed when the markdown file is closed."))
     (trivial-ws:stop handler)))
 
 (defmethod lem-markdown-mode/internal:on-change (buffer (view-type (eql :external-browser)))
-  )
+  (refresh buffer))
 
 (defmethod lem-markdown-mode/internal:preview (buffer (view-type (eql :external-browser)))
   "Render the markdown of the current buffer to a browser window. The preview is refreshed when the file is saved.

--- a/extensions/markdown-mode/preview/preview.lisp
+++ b/extensions/markdown-mode/preview/preview.lisp
@@ -5,6 +5,9 @@
 (define-command markdown-preview () ()
   (lem-markdown-mode/internal:preview (current-buffer) :html-buffer))
 
+(define-command markdown-preview-external-browser () ()
+  (lem-markdown-mode/internal:preview (current-buffer) :external-browser))
+
 (defun render (string)
   (let ((3bmd-code-blocks:*code-blocks* t))
     (with-output-to-string (stream)

--- a/extensions/markdown-mode/preview/preview.lisp
+++ b/extensions/markdown-mode/preview/preview.lisp
@@ -3,9 +3,11 @@
 (in-package :lem-markdown-mode/preview/preview)
 
 (define-command markdown-preview () ()
+  "Preview the current Markdown buffer as rendered HTML in an internal buffer."
   (lem-markdown-mode/internal:preview (current-buffer) :html-buffer))
 
 (define-command markdown-preview-external-browser () ()
+  "Preview the current Markdown buffer as rendered HTML in an external web browser."
   (lem-markdown-mode/internal:preview (current-buffer) :external-browser))
 
 (defun render (string)


### PR DESCRIPTION
the markdown-preview not open a external browser on ncurses. 
add a new command markdown-preview-external-browser to do it.
the trivial-open-browser use format to compose the path-name, that's why it reported error.
use `M-x markdown-preview-external-browser` to open the previewed markdown on browser.