### PR TITLE
fix(lisp-syntax): don't apply macro indentation to keyword symbols

### DIFF
--- a/extensions/lisp-syntax/indent.lisp
+++ b/extensions/lisp-syntax/indent.lisp
@@ -433,7 +433,9 @@
            (when method
              (return-from find-indent-method method))))
     (f (get-indentation name))
-    (let ((name1 (ppcre:scan-to-strings "(?<=:)[^:]+" name)))
+    (let ((name1 (let ((registers (nth-value 1 (ppcre:scan-to-strings "^[^:]+:{1,2}([^:].*)$" name))))
+                   (when (and registers (plusp (length registers)))
+                     (aref registers 0)))))
       (when name1
         (f (get-indentation name1)))
       (f (and *get-method-function*

--- a/tests/lisp-syntax/indent-test.lisp
+++ b/tests/lisp-syntax/indent-test.lisp
@@ -48,6 +48,27 @@
             y))
 ")
 
+(deftest defpackage-use-clause-not-affected-by-use-macro
+  ;; A user-defined macro named USE must not influence the indentation of
+  ;; the :USE clause keyword in DEFPACKAGE. The package prefix of a
+  ;; package-qualified symbol may be stripped to look up its indentation,
+  ;; but a keyword such as :USE has no package prefix and must be left alone.
+  (let ((lem-lisp-mode/test-api:*disable-self-connect* t))
+    (lem-lisp-syntax.indent:set-indentation "use" '(&body))
+    (unwind-protect
+         (run-indent-test "defpackage-use-clause-not-affected-by-use-macro"
+"
+(defpackage :foo
+  (:use :cl
+        :bar))
+"
+"
+(defpackage :foo
+  (:use :cl
+        :bar))
+")
+      (lem-lisp-syntax.indent:set-indentation "use" nil))))
+
 (defun get-location-from-buffer-point (point pathname)
   (format nil "~A:~D:~A" pathname (lem:line-number-at-point point) (lem:line-string point)))
 


### PR DESCRIPTION
## Summary

When computing indentation, `find-indent-method` strips the package prefix of a package-qualified symbol (e.g. `alexandria:with-gensyms` → `with-gensyms`) so it can look up an indentation rule by the bare symbol name.

The previous regex `(?<=:)[^:]+` had no start anchor, so it also matched the part after the leading colon of a **keyword** symbol. For `:use` it returned `"use"`. If the user (or a loaded system) had defined a macro named `use` with a `&body`-style indentation rule, that rule was incorrectly applied to the `:use` clause of `defpackage`, breaking its indentation.

```lisp
(defpackage :foo
  (:use :cl
     :bar))
(in-package :foo)

(defmacro use (&body body)
  ... )
```

This replaces the lookbehind with an anchored, capturing regex `^[^:]+:{1,2}([^:].*)$` that requires a **non-empty package prefix** before the `:`/`::` separator. Keywords (which start with `:` and thus have no prefix) and unqualified symbols are now left untouched, while genuine package-qualified symbols still resolve correctly.

## Test

Adds `defpackage-use-clause-not-affected-by-use-macro` to `tests/lisp-syntax/indent-test.lisp`. It temporarily registers a `&body` indentation rule for the name `use`, then asserts that re-indenting a `defpackage` form with a `:use` clause leaves it unchanged. The registration is restored via `unwind-protect` to avoid leaking global indent-table state into other tests.

Verified the new test fails against the old regex (`:use` → `"use"`) and passes with the fix; the full `lem-tests/lisp-syntax/indent-test` suite is green.