### PR TITLE
Fixes to find-file-directory

### DIFF
--- a/src/ext/directory-mode/commands.lisp
+++ b/src/ext/directory-mode/commands.lisp
@@ -329,7 +329,7 @@ With prefix argument ARG, unmark all those files."
       ((mode-active-p (current-buffer) 'directory-mode)
        (directory-mode-up-directory))
       ((null fullpath)
-       (message "No file at point"))
+       (switch-to-buffer (find-file-buffer (uiop:getcwd))))
       (t
        (switch-to-buffer
         (find-file-buffer (lem-core/commands/file::directory-for-file-or-lose (buffer-directory))))


### PR DESCRIPTION
Before, if you tried to use `C-x C-j` in the `*dashboard*` buffer you would get an error about no file being open at the point. I changed this behavior so that `find-file-directory` will fall back to `(uiop:getcwd)` if no file is associated with the current buffer