### PR TITLE
Add C-g and q as more quit keybindings for grep (peek) mode

### DIFF
--- a/src/ext/peek-source.lisp
+++ b/src/ext/peek-source.lisp
@@ -46,6 +46,8 @@
 (define-key *peek-source-keymap* 'next-line 'peek-source-next)
 (define-key *peek-source-keymap* 'previous-line 'peek-source-previous)
 (define-key *peek-source-keymap* "Escape" 'peek-source-quit)  ;; also C-x 0 by default.
+(define-key *peek-source-keymap* "C-g" 'peek-source-quit)
+(define-key *peek-source-keymap* "q" 'peek-source-quit)
 (define-key *peek-source-keymap* "C-c C-k" 'peek-source-quit)
 (define-key *peek-source-keymap* "M-q" 'peek-source-quit)
 


### PR DESCRIPTION
Now you can cancel a grep search window using `C-g` or `q`, the expected keybindings for cancelling something