### PR TITLE
Add print object method for prefix class

### DIFF
--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -34,6 +34,10 @@ NIL to append it to the key sequence normally.")
     :initform nil
     :documentation "extra metadata that a prefix may hold.")))
 
+(defmethod print-object ((object prefix) stream)
+  (print-unreadable-object (object stream :type t)
+    (format stream ":KEY \"~a\"" (slot-value object 'key))))
+
 (defgeneric prefix-key (prefix)
   (:method ((prefix prefix))
    (slot-value prefix 'key)))

--- a/src/keymap.lisp
+++ b/src/keymap.lisp
@@ -36,7 +36,8 @@ NIL to append it to the key sequence normally.")
 
 (defmethod print-object ((object prefix) stream)
   (print-unreadable-object (object stream :type t)
-    (format stream ":KEY \"~a\"" (slot-value object 'key))))
+    (when (slot-boundp object 'key)
+      (format stream ":KEY \"~a\"" (slot-value object 'key)))))
 
 (defgeneric prefix-key (prefix)
   (:method ((prefix prefix))


### PR DESCRIPTION
I was trying to inspect how the keybindings were implemented, and I noticed it was quite difficult to look through the different keymaps because the list of the prefixes didn't give any information about what key corresponded to those prefixes. 

I added a print object method that will now show what key the prefix uses in its printed representation
<img width="727" height="1095" alt="Screenshot_20260619_201805" src="https://github.com/user-attachments/assets/70bc937f-a55a-4697-b54f-a4a19c183cc7" />
