### PR TITLE
Add advice to mark-set command for multicursor selection 

### DIFF
--- a/src/commands/mark.lisp
+++ b/src/commands/mark.lisp
@@ -12,13 +12,13 @@
 (define-key *global-keymap* "C-x C-x" 'exchange-point-mark)
 (define-key *global-keymap* "C-x h" 'mark-set-whole-buffer)
 
-(define-command (mark-set (:advice-classes editable-advice)) (p) (:universal-nil)
+(define-command mark-set (p) (:universal-nil)
   "Sets a mark at the current cursor position."
   (if p
       (move-point (current-point) (pop-buffer-point))
       (progn
         (set-cursor-mark (current-point) (current-point))
-        (message "Mark set"))))
+        (when-real-cursor (message "Mark set")))))
 
 (define-command exchange-point-mark () ()
   "Exchange the current cursor position with the marked position."

--- a/src/commands/mark.lisp
+++ b/src/commands/mark.lisp
@@ -12,7 +12,7 @@
 (define-key *global-keymap* "C-x C-x" 'exchange-point-mark)
 (define-key *global-keymap* "C-x h" 'mark-set-whole-buffer)
 
-(define-command mark-set (p) (:universal-nil)
+(define-command (mark-set (:advice-classes editable-advice)) (p) (:universal-nil)
   "Sets a mark at the current cursor position."
   (if p
       (move-point (current-point) (pop-buffer-point))

--- a/src/cursors.lisp
+++ b/src/cursors.lisp
@@ -123,3 +123,7 @@
                     (if not-lastp
                         (write-line string out)
                         (write-string string out))))))))
+
+(defmacro when-real-cursor (&body body)
+  `(unless (typep (current-point) 'fake-cursor)
+     ,@body))

--- a/src/cursors.lisp
+++ b/src/cursors.lisp
@@ -125,5 +125,7 @@
                         (write-string string out))))))))
 
 (defmacro when-real-cursor (&body body)
+  "Execute BODY only if the current cursor is a real one (i.e. not a fake-cursor)."
   `(unless (typep (current-point) 'fake-cursor)
      ,@body))
+

--- a/src/internal-packages.lisp
+++ b/src/internal-packages.lisp
@@ -621,7 +621,8 @@
    :make-fake-cursor
    :delete-fake-cursor
    :merge-cursor-killrings
-   :clear-cursors)
+   :clear-cursors
+   :when-real-cursor)
   ;; typeout.lisp
   (:export
    :*typeout-mode-keymap*


### PR DESCRIPTION
Hello,
While using lem to learn common lisp, I noticed that marks doesn't seem to work with multicursor.
Adding this advice seems to fix the issue, but as I’m still exploring both the codebase and Common Lisp,  I might have overlooked something.
Is there are any implications or edge cases I should be aware of?