### PR TITLE
fix(server): don't busy-wait for the first client login

### DIFF
--- a/frontends/server/main.lisp
+++ b/frontends/server/main.lisp
@@ -213,16 +213,16 @@ the same immutable instance for every subsequent message."
              args)))
 
 (defmethod lem-if:invoke ((jsonrpc jsonrpc) function)
-  (let ((ready nil))
+  (let ((ready (bt2:make-semaphore :name "lem-server ready")))
     (setf (jsonrpc-editor-thread jsonrpc)
           (funcall function
                    (lambda ()
-                     (loop :until ready))))
+                     (bt2:wait-on-semaphore ready))))
     (jsonrpc:expose (jsonrpc-server jsonrpc)
                     "login"
                     (login jsonrpc
                            (lambda ()
-                             (setf ready t))))
+                             (bt2:signal-semaphore ready))))
     (jsonrpc:expose (jsonrpc-server jsonrpc)
                     "input"
                     (lambda (args)


### PR DESCRIPTION
## Problem

In the JSONRPC (lem-server) frontend, the editor thread's initialize callback spins in a bare `(loop :until ready)` until the first client calls `login`. This pins one CPU core at 100% from process startup. On a server deployment where lem-server runs continuously and no client is connected yet, the process burns a full core indefinitely — it shows up as a "hung" container at 100% CPU.

The busy-wait has been there since lem-server was introduced (2f45f2fe). Disassembly on SBCL 2.6.3 shows the loop compiles to a 3-instruction tight spin (value-cell read → `NIL` compare → jump).

## Fix

Replace the busy-wait flag with a `bt2:semaphore`, so the editor thread blocks in `wait-on-semaphore` instead of spinning. The `login` callback signals the semaphore. Signaling more than once (e.g. when another client logs in later) just increments the count and is harmless.

## Verification

Ran `lem-server:run-websocket-server` locally and measured per-thread CPU with `ps -eL`:

| state | editor thread CPU |
|---|---|
| before fix, idle (no client) | ~93% |
| after fix, idle (no client) | ~0% |
| after fix, after `login` | ~0% (editor loop running normally) |

Also verified over an actual WebSocket connection that the JSON-RPC `login` request still returns a normal response and unblocks the editor thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)