### PR TITLE
Add menu key support for webview

### DIFF
--- a/src/key.lisp
+++ b/src/key.lisp
@@ -2,7 +2,7 @@
 
 (defvar *named-key-syms*
   '("Backspace" "Insert" "Delete" "Down" "End" "Escape" "F0" "F1" "F10" "F11" "F12" "F13" "F14" "F15" "F16" "F17" "F18" "F19" "F2" "F20" "F21" "F22" "F23" "F24" "F3" "F4" "F5" "F6" "F7" "F8" "F9"
-    "Home" "Left" "NopKey" "PageDown" "PageUp" "Return" "Right" "Space" "Tab" "Up"))
+    "Home" "Left" "ContextMenu" "NopKey" "PageDown" "PageUp" "Return" "Right" "Space" "Tab" "Up"))
 
 (defun named-key-sym-p (key-sym)
   (find key-sym *named-key-syms* :test #'string=))


### PR DESCRIPTION
An easy support for webview.
Can be tested by these codes:
```
(defvar *menu-keymap*
  (make-keymap)
  "Keymap for menu key.")
(define-keys *menu-keymap*
  ("h" 'move-to-beginning-of-buffer)
  ("n" 'move-to-end-of-buffer)
  ("f" 'select-buffer)
  (";" 'save-current-buffer)
  ("k" 'kill-buffer)
  ("b" 'mark-set-whole-buffer)
  ("g" 'revert-buffer)
  ("w" 'next-window)
  ("e" 'find-file)
  ("r" 'find-recent-file)
  ("0" 'delete-active-window)
  ("1" 'delete-other-windows)
  ("2" 'split-active-window-vertically)
  ("3" 'split-active-window-horizontally)
  ("d" 'lem/filer:filer)
  ("Space" 'lem/legit:legit-status)
  ("ContextMenu" 'execute-command))

(define-key *global-keymap* "ContextMenu" *menu-keymap*)
```
I bind caps to menu, it is really useful for me to have menu key support.