### PR TITLE
fix incorrectly displayed file names in directory mode

### DIFF
--- a/src/ext/directory-mode/commands.lisp
+++ b/src/ext/directory-mode/commands.lisp
@@ -315,7 +315,7 @@ With prefix argument ARG, unmark all those files."
 
     ;; Follow file name.
     (when (and path (str:non-blank-string-p (file-namestring path)))
-      (search-filename-and-recenter (file-namestring path)))))
+      (search-filename-and-recenter (display-name path)))))
 
 (define-command make-directory (filename) ((:new-file "Make directory: "))
   (setf filename (uiop:ensure-directory-pathname filename))
@@ -333,8 +333,7 @@ With prefix argument ARG, unmark all those files."
       (t
        (switch-to-buffer
         (find-file-buffer (lem-core/commands/file::directory-for-file-or-lose (buffer-directory))))
-       (let ((filename (file-namestring fullpath)))
-         (search-filename-and-recenter (file-namestring filename)))))))
+       (search-filename-and-recenter (display-name fullpath))))))
 
 (define-command directory-mode-kill-lines () ()
   "Delete the marked lines from the directory-mode buffer.

--- a/src/ext/directory-mode/internal.lisp
+++ b/src/ext/directory-mode/internal.lisp
@@ -25,6 +25,7 @@
            :get-mark
            :filter-marks
            :get-name
+           :display-name
            :marked-lines
            :marked-files
            :get-pathname
@@ -129,10 +130,13 @@
   pathname
   content)
 
+(defun display-name (pathname &optional (directory (uiop:pathname-directory-pathname pathname)))
+  "PATHNAME as a directory buffer lists it, relative to DIRECTORY."
+  (uiop:native-namestring (uiop:enough-pathname pathname directory)))
+
 (defun item-name (item)
   (or (item-content item)
-      (uiop:native-namestring (uiop:enough-pathname (item-pathname item)
-                                                    (item-directory item)))))
+      (display-name (item-pathname item) (item-directory item))))
 
 (defun human-readable-file-size (size)
   (loop :for sign :in '(#\Y #\Z #\E #\P #\T #\G #\M #\k)

--- a/src/ext/directory-mode/internal.lisp
+++ b/src/ext/directory-mode/internal.lisp
@@ -131,8 +131,8 @@
 
 (defun item-name (item)
   (or (item-content item)
-      (namestring (enough-namestring (item-pathname item)
-                                     (item-directory item)))))
+      (uiop:native-namestring (uiop:enough-pathname (item-pathname item)
+                                                    (item-directory item)))))
 
 (defun human-readable-file-size (size)
   (loop :for sign :in '(#\Y #\Z #\E #\P #\T #\G #\M #\k)

--- a/src/ext/directory-mode/internal.lisp
+++ b/src/ext/directory-mode/internal.lisp
@@ -191,7 +191,8 @@
   (let ((name (item-name item))
         (pathname (item-pathname item)))
     (unless (string= name "..")
-      (insert-icon point name))
+      ;; the pathname, not the name: insert-icon parses its argument as one
+      (insert-icon point pathname))
     (insert-string point
                    name
                    :attribute (get-file-attribute pathname)

--- a/src/system.lisp
+++ b/src/system.lisp
@@ -28,12 +28,15 @@
     (= status 0)))
 
 (defun open-external-file (pathname)
-  #+linux
-  (uiop:launch-program (list "xdg-open" (namestring pathname)))
-  #+darwin
-  (uiop:launch-program (list "open" (namestring pathname)))
-  #+windows
-  (uiop:launch-program (list "explorer" (namestring pathname)) :ignore-error-status t))
+  (let ((argument (if (pathnamep pathname)
+                      (uiop:native-namestring pathname)
+                      pathname)))
+    #+linux
+    (uiop:launch-program (list "xdg-open" argument))
+    #+darwin
+    (uiop:launch-program (list "open" argument))
+    #+windows
+    (uiop:launch-program (list "explorer" argument) :ignore-error-status t)))
 
 ;;;; PATH
 


### PR DESCRIPTION
in a directory buffer, a file named "12 Day of Rain [t0Tph__v070].webm"
was listed as "12 Day of Rain \[t0Tph__v070].webm"

this is fixed by making use of `uiop:native-namestring' instead of the builtin `namestring'.

fixing this revealed other issues because it made things error out, which is what the 2 other commits are for